### PR TITLE
zephyr: Fix invalid handle

### DIFF
--- a/ptsprojects/zephyr/gatt.py
+++ b/ptsprojects/zephyr/gatt.py
@@ -150,7 +150,7 @@ def test_cases_server():
                    TestFunc(btp.gatts_start_server),
                    TestFunc(btp.gap_adv_ind_on)]),
         QTestCase("GATT", "TC_GAR_SR_BI_11_C",
-                  edit1_wids = {121 : "0002", 122 : "AA51"},
+                  edit1_wids = {121 : "0003", 122 : "AA51"},
                   cmds = [TestFunc(btp.core_reg_svc_gap),
                           TestFunc(btp.core_reg_svc_gatts),
                           TestFunc(btp.gatts_add_svc, 0, 'AA50'),


### PR DESCRIPTION
This patch fixes invalid handle that has been sent to the PTS.

> ACL Data RX: Handle 64 flags 0x02 dlen 11  [hci0] 360723.442250
>       ATT: Read By Type Request (0x08) len 6
>         Handle range: 0x0003-0x0003
>         Attribute type: Unknown (0xaa51)
> < ACL Data TX: Handle 64 flags 0x00 dlen 9   [hci0] 360723.454563
>       ATT: Error Response (0x01) len 4
>         Read By Type Request (0x08)
>         Handle: 0x0003
>         Error: Insufficient Encryption Key Size (0x0c)
