### PR TITLE
common: Add command line parameter to enable PTS debug logs

### DIFF
--- a/autoptsclient-zephyr.py
+++ b/autoptsclient-zephyr.py
@@ -31,6 +31,9 @@ def parse_args():
     arg_parser.add_argument("--bd-addr",
                             help = "Clients bluetooth address")
 
+    arg_parser.add_argument("--pts-debug", action='store_true', default=False,
+                            help = "Enable PTS debug logs")
+
     args = arg_parser.parse_args()
 
     return args
@@ -43,7 +46,7 @@ def main():
     args = parse_args()
 
     proxy = autoptsclient.init_core(args.server_address, args.workspace,
-                                    args.bd_addr)
+                                    args.bd_addr, args.pts_debug)
 
     autoprojects.iutctl.init(args.kernel_image)
 

--- a/autoptsclient_common.py
+++ b/autoptsclient_common.py
@@ -142,7 +142,7 @@ def start_callback():
     server.register_introspection_functions()
     server.serve_forever()
 
-def init_core(server_address, workspace_path, bd_addr):
+def init_core(server_address, workspace_path, bd_addr, pts_debug):
     "Initialization procedure"
 
     script_name = os.path.basename(sys.argv[0]) # in case it is full path
@@ -189,6 +189,8 @@ def init_core(server_address, workspace_path, bd_addr):
             project_name = proxy.get_project_name(index)
             log("Set bd_addr PIXIT: %s for project: %s", bd_addr, project_name)
             proxy.update_pixit_param(project_name, "TSPX_bd_addr_iut", bd_addr)
+
+    proxy.enable_maximum_logging(pts_debug)
 
     return proxy
 


### PR DESCRIPTION
Full PTS logs are needed while reporting PTS issue.
With this patch PTS debug logs can be easily enabled.
