### PR TITLE
Fix description verification

### DIFF
--- a/ptsprojects/zephyr/btp.py
+++ b/ptsprojects/zephyr/btp.py
@@ -6,6 +6,7 @@ import struct
 import re
 
 from iutctl import get_zephyr
+from ptsprojects.testcase import MmiParser
 import btpdef
 
 #  Global temporary objects
@@ -131,16 +132,20 @@ def verify_description(description):
     """
     logging.debug("description=%r", description)
 
+    #Parsing description
+    mmi_parser = MmiParser()
+    mmi_parser.parse_description(description)
+
     global VERIFY_VALUES
     logging.debug("Verifying values: %r", VERIFY_VALUES)
 
     if not VERIFY_VALUES:
         return True
 
-    for value in VERIFY_VALUES:
+    for value in mmi_parser.args:
         logging.debug("Verifying: %r", value)
 
-        if value not in description:
+        if value not in VERIFY_VALUES:
             logging.debug("Verification failed, value not in description")
             return False
 


### PR DESCRIPTION
Added parsing PTS MMI description
to get values to be verified.

Example:
description="Please confirm IUT receive primary services uuid = '1800'O ,
 Service start handle = '0001'O, end handle = '0007'O in database.
 Click Yes if IUT receive it, otherwise click No.\n\nDescription:
 Verify that the Implementation Under Test (IUT) can send Discover
 primary service by UUID in database."
Values to be verify with: ['0001', '0007', '1800']
Verfiy if values 0001,0007 and 1800 exist in PTS description
Verifying: '1800'
Verifying: '0001'
Verifying: '0007'
