### PR TITLE
Revert "nble: allowing to use /dev/pts socat devices for BTP communic…

### DIFF
--- a/ptsprojects/zephyr/iutctl.py
+++ b/ptsprojects/zephyr/iutctl.py
@@ -131,7 +131,7 @@ class ZephyrCtl:
             board_name)
 
         if tty_file:
-            if (not tty_file.startswith("/dev/tty") and not tty_file.startswith("/dev/pts")):
+            if not tty_file.startswith("/dev/tty"):
                 raise Exception("%s is not a TTY file!" % repr(tty_file))
             if not os.path.exists(tty_file):
                 raise Exception("%s TTY file does not exist!" % repr(tty_file))


### PR DESCRIPTION
…ation"

Patch has been merged without review

This reverts commit d5b8d9dc8122f0780eb04e0aba713f6537093c64.
