### PR TITLE
nble: allowing to use /dev/pts socat devices for BTP communication

### DIFF
--- a/ptsprojects/zephyr/iutctl.py
+++ b/ptsprojects/zephyr/iutctl.py
@@ -132,7 +132,8 @@ class ZephyrCtl:
             board_name)
 
         if tty_file:
-            if not tty_file.startswith("/dev/tty"):
+            if (not tty_file.startswith("/dev/tty") and
+                not tty_file.startswith("/dev/pts")):
                 raise Exception("%s is not a TTY file!" % repr(tty_file))
             if not os.path.exists(tty_file):
                 raise Exception("%s TTY file does not exist!" % repr(tty_file))


### PR DESCRIPTION
Signed-off-by: Jonathan Gelie jonathanx.gelie@intel.com
