### PR TITLE
nble: increasing BTP socket timeout

### DIFF
--- a/ptsprojects/zephyr/iutctl.py
+++ b/ptsprojects/zephyr/iutctl.py
@@ -58,7 +58,7 @@ class BTPSocket(object):
 
         # This will hang forever if Zephyr don't try to connect
         self.conn, self.addr = self.sock.accept()
-        self.conn.settimeout(10) # BTP socket timeout in seconds
+        self.conn.settimeout(20) # BTP socket timeout in seconds
 
     def read(self):
         """Read BTP data from socket"""


### PR DESCRIPTION
As crb board reboot is longer than 10s, socket timeout is increasing from 10 to 20seconds.

Signed-off-by: Jonathan Gelie jonathanx.gelie@intel.com
