### PR TITLE
common: Add option to repeat test case if failed

### DIFF
--- a/autoptsclient-zephyr.py
+++ b/autoptsclient-zephyr.py
@@ -107,6 +107,10 @@ def parse_args():
                             "test cases can be specified by profile names: "
                             "GATT, GATTS, GATTC, GAP, L2CAP, SM, MESH")
 
+    arg_parser.add_argument("-r", "--retry", type=int, default=0,
+                            help="Repeat test if failed. Parameter specifies "
+                                 "maximum repeat count per test")
+
     args = arg_parser.parse_args()
 
     check_args(args)
@@ -138,7 +142,7 @@ def main():
         test_cases = autoptsclient.get_test_cases_subset(
             test_cases, args.test_cases, args.excluded)
 
-    autoptsclient.run_test_cases(pts, test_cases)
+    autoptsclient.run_test_cases(pts, test_cases, args.retry)
 
     autoprojects.iutctl.cleanup()
 


### PR DESCRIPTION
With this patch, test case can be automatically repeated if failed.

Usage:
$ ./autoptsclient-zephyr.py <...> -c GATT/SR/GAC/BV-01-C L2CAP/LE/CFC/BV-01-C -r 2
Starting PTS ... OK
Serving on port 65001 ...

1/2   GATT    GATT/SR/GAC/BV-01-C    PASS
2/2   L2CAP   L2CAP/LE/CFC/BV-01-C   INCONC
2/2   L2CAP   L2CAP/LE/CFC/BV-01-C   PASS                     #1

Summary:

Status Count
============
PASS      2
============
Total     2

Bye!