### PR TITLE
zephyr: iutctl: Wait with board reset until BTP socket is open

### DIFF
--- a/ptsprojects/zephyr/iutctl.py
+++ b/ptsprojects/zephyr/iutctl.py
@@ -90,10 +90,6 @@ class ZephyrCtl:
                                                   shell=False,
                                                   stdout=IUT_LOG_FO,
                                                   stderr=IUT_LOG_FO)
-
-            if self.board:
-                self.board.reset()
-
         else:
             qemu_cmd = get_qemu_cmd(self.kernel_image)
 
@@ -109,6 +105,9 @@ class ZephyrCtl:
 
     def wait_iut_ready_event(self):
         """Wait until IUT sends ready event after power up"""
+        if self.board:
+            self.board.reset()
+
         tuple_hdr, tuple_data = self.btp_socket.read()
 
         try:


### PR DESCRIPTION
This fixes race condition when IUT was resetted when BTP Socket
was closed yet so that IUT Ready Event might not be received.