### PR TITLE
common: Add a parameter to specify the client ip address

### DIFF
--- a/autoptsclient-zephyr.py
+++ b/autoptsclient-zephyr.py
@@ -57,6 +57,9 @@ def parse_args():
     arg_parser.add_argument("-i", "--ip_addr", nargs="+",
                             help="IP address of the PTS automation servers")
 
+    arg_parser.add_argument("-l", "--local_addr", default=None,
+                            help="Local IP address of PTS automation client")
+
     arg_parser.add_argument("workspace",
                             help="Path to PTS workspace file to use for "
                             "testing. It should have pqw6 extension. "
@@ -139,7 +142,8 @@ def main():
     for ip in args.ip_addr:
         ptses.append(autoptsclient.init_pts(ip, args.workspace, args.bd_addr,
                                             args.enable_max_logs,
-                                            callback_thread, tc_db_table_name))
+                                            callback_thread, tc_db_table_name,
+                                            args.local_addr))
 
     btp.init(get_iut)
     autoprojects.iutctl.init(args.kernel_image, args.tty_file, args.board)

--- a/autoptsclient_common.py
+++ b/autoptsclient_common.py
@@ -376,8 +376,6 @@ def init_core():
     "Initialization procedure for core modules"
     init_logging()
 
-    log("my IP address is: %s", get_my_ip_address())
-
     callback_thread = CallbackThread()
     callback_thread.start()
 
@@ -385,7 +383,7 @@ def init_core():
 
 
 def init_pts(server_address, workspace_path, bd_addr, enable_max_logs,
-             callback_thread, tc_db_table_name=None):
+             callback_thread, tc_db_table_name=None, local_address=None):
     "Initialization procedure for PTS instances"
     if AUTO_PTS_LOCAL:
         proxy = FakeProxy()
@@ -410,7 +408,13 @@ def init_pts(server_address, workspace_path, bd_addr, enable_max_logs,
     proxy.q_bd_addr = proxy.bd_addr()
     log("PTS BD_ADDR: %s", proxy.q_bd_addr)
 
-    proxy.register_xmlrpc_ptscallback(get_my_ip_address(), CLIENT_PORT)
+    client_ip_address = local_address
+    if client_ip_address is None:
+        client_ip_address = get_my_ip_address()
+
+    log("Client IP Address: %s", client_ip_address)
+
+    proxy.register_xmlrpc_ptscallback(client_ip_address, CLIENT_PORT)
 
     log("Opening workspace: %s", workspace_path)
     proxy.open_workspace(workspace_path)


### PR DESCRIPTION
When the client has multiple interfaces and autopts server is running
on private address, it cannot get the correct address for client.

This patch allows a user to specify the client ip address.