### PR TITLE
bot: Fix typo in config.py.sample

### DIFF
--- a/bot/config.py.sample
+++ b/bot/config.py.sample
@@ -16,7 +16,7 @@
 # Sample user_config file
 # Apply your changes and rename it to config.py
 
-projects = []
+BotProjects = []
 
 z = zephyr_nrf52 = {
     'name': 'zephyr'
@@ -101,4 +101,4 @@ z['scheduler'] = {
     'friday': '20:00',
 }
 
-projects.append(zephyr_nrf52)
+BotProjects.append(zephyr_nrf52)


### PR DESCRIPTION
s/projects/BotProjects
Fixes following error while trying to use sample
config:

File “./autoptsclient_bot.py”, line 23, in <module>
From bot.config import BotProjects
ImportError: cannot import name Botprojects