### PR TITLE
ptscontrol: Fix exception due to invalid type

### DIFF
--- a/ptscontrol.py
+++ b/ptscontrol.py
@@ -191,7 +191,7 @@ class PTSSender(PTSControl.IPTSImplicitSendCallbackEx):
                     test_case_name,
                     description,
                     int(style),
-                    int(response),
+                    response,
                     int(response_size),
                     int(response_is_present))
 


### PR DESCRIPTION
This patch fixes the exception caused by invalid type for response.