### PR TITLE
Move BTP specification from Zephyr

### DIFF
--- a/doc/btp_spec.txt
+++ b/doc/btp_spec.txt
@@ -1,0 +1,1640 @@
+Tester protocol for Bluetooth stack
+***********************************
+
+Copyright (C) 2015  Intel Corporation
+
+
+Overview
+========
+
+This document describes the format of data used for communicating between tester
+and implementation under test (IUT).
+
+The protocol is SOCK_STREAM based and follows a strict PDU specification
+with a generic header and initial registration exchange. The communication is
+driven from tester with commands/response exchange. The protocol is single PDU
+exchanged based, meaning every command requires a response. IUT will use events
+to signal notifications.
+
+Commands and events use single socket. All services are multi-plexed over same
+socket.
+
+	.--  IUT  --.                             .--Tester--.
+	|           |                             |          |
+	|           |          Command            |          |
+	|           | <-------------------------- |          |
+	|           |                             |          |
+	|           |          Response           |          |
+	|           | --------------------------> |          |
+	|           |                             |          |
+	|           |           Event             |          |
+	|           | --------------------------> |          |
+	|           |                             |          |
+	'-----------'                             '----------'
+
+
+Packet Structures
+=================
+
+Every packet will follow the basic header to support simple multi-plexing
+over the same socket. It will also support a basic control channel with service
+id 0. Due to use of single socket for command/response and events it is
+possible that event(s) will be received before response to command.
+
+	0            8       16                  24            40
+	+------------+--------+------------------+-------------+
+	| Service ID | Opcode | Controller Index | Data Length |
+	+------------+--------+------------------+-------------+
+	|                                                      |
+
+The unique service ID is assigned by this specification for each service
+supported by tester.
+
+As general rule of thumb, the opcode for command matches the opcode for a
+response. Or the opcode 0x00 for an error is returned.
+
+Events opcodes start from 0x80.
+
+All fields are in little-endian byte order (least significant byte first).
+
+Controller Index can have a special value <non-controller> to indicate that
+command or event is not related to any controller. Possible values:
+
+	<controller id>		0x00 to 0xFE
+	<non-controller>	0xFF
+
+Error response is common for all services and has fixed structure:
+
+	Opcode 0x00 - Error response
+
+		Response parameters: Status (1 octet)
+
+		Valid status values:	0x01 = Fail
+					0x02 = Unknown Command
+					0x03 = Not ready
+					0x04 = Invalid Index
+
+Core Service (ID 0)
+===================
+
+Commands and responses:
+
+	Opcode 0x00 - Error response
+
+	Opcode 0x01 - Read Supported Commands command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	<none>
+		Response parameters:	<supported commands> (variable)
+
+		Each bit in response is a flag indicating if command with
+		opcode matching bit number is supported. Bit set to 1 means
+		that command is supported. Bit 0 is reserved and shall always
+		be set to 0. If specific bit is not present in response (less
+		than required bytes received) it shall be assumed that command
+		is not supported.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x02 - Read Supported Services command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	<none>
+		Response parameters:	<supported services> (variable)
+
+		Each bit in response is a flag indicating if service with ID
+		matching bit number is supported. Bit set to 1 means that
+		service is supported. If specific bit is not present in response
+		(less than required bytes received) it shall be assumed that
+		service is not supported.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x03 - Register Service command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	Service ID (1 octet)
+		Response parameters:	<none>
+
+		In case a command is sent for an undeclared service ID, it will
+		be rejected. Also there will be no events for undeclared
+		service ID.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x04 - Unregister Service command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	Service ID (1 octet)
+		Response parameters:	<none>
+
+		In case of an error, the error response will be returned.
+
+Events:
+	Opcode 0x80 - IUT ready event
+
+		Controller Index:	<non-controller>
+		Event parameters:	<none>
+
+		This event indicates that IUT has been initialized and is ready to
+		receive BTP commands.
+		Tester shall wait for this event before sending any command to the IUT.
+
+GAP Service (ID 1)
+==================
+
+Commands and responses:
+
+	Opcode 0x00 - Error response
+
+	Opcode 0x01 - Read Supported Commands command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	<none>
+		Response parameters:	<supported commands> (variable)
+
+		Each bit in response is a flag indicating if command with
+		opcode matching bit number is supported. Bit set to 1 means
+		that command is supported. Bit 0 is reserved and shall always
+		be set to 0. If specific bit is not present in response (less
+		than required bytes received) it shall be assumed that command
+		is not supported.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x02 - Read Controller Index List command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	<none>
+		Response parameters:	Number of Controllers (1 octet)
+					Controller Index[i] (1 octet)
+
+		This command returns the list of controllers.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x03 - Read Controller Information command/response
+
+	Controller Index:	<controller id>
+	Command parameters:	<none>
+	Response parameters:	Address (6 Octets)
+				Supported_Settings (4 Octets)
+				Current_Settings (4 Octets)
+				Class_Of_Device (3 Octets)
+				Name (249 Octets)
+				Short_Name (11 Octets)
+
+		This command is used to retrieve the current state and basic
+		information of a controller. It is typically used right after
+		getting the response to the Read Controller Index List command
+
+		Current_Settings and Supported_Settings is a bitmask with
+		currently the following available bits:
+
+			0	Powered
+			1	Connectable
+			2	Fast Connectable
+			3	Discoverable
+			4	Bondable
+			5	Link Level Security (Sec. mode 3)
+			6	Secure Simple Pairing
+			7	Basic Rate/Enhanced Data Rate
+			8	High Speed
+			9	Low Energy
+			10	Advertising
+			11	Secure Connections
+			12	Debug Keys
+			13	Privacy
+			14	Controller Configuration
+			15	Static Address
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x04 - Reset command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Response parameters:	Current_Settings (4 Octets)
+
+		This allows to clean up any state data (eg. keys) and restore
+		controller to its default system state.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x05 - Set Powered command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Powered (1 octet)
+		Response parameters:	Current_Settings (4 Octets)
+
+		Valid Powered values:	0x00 = Off
+					0x01 = On
+
+		This command is used to power on or off a controller.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x06 - Set Connectable command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Connectable (1 octet)
+		Response parameters:	Current_Settings (4 Octets)
+
+		Valid Connectable values:	0x00 = Off
+						0x01 = On
+
+		This command is used to set controller connectable.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x07 - Set Fast Connectable command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Fast Connectable (1 octet)
+		Response parameters:	Current_Settings (4 Octets)
+
+		Valid Fast Connectable values:	0x00 = Off
+						0x01 = On
+
+		This command is used to set controller fast connectable.
+		This command is only available for BR/EDR capable controllers.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x08 - Set Discoverable command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Discoverable (1 octet)
+		Response parameters:	Current_Settings (4 Octets)
+
+		Valid Discoverable values:	0x00 = Off
+						0x01 = General Discoverable
+						0x02 = Limited Discoverable
+
+		This command is used to set controller discoverable.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x09 - Set Bondable command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Bondable (1 octet)
+		Response parameters:	Current_Settings (4 Octets)
+
+		Valid Bondable values:	0x00 = Off
+					0x01 = On
+
+		This command is used to set controller bondable.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0a - Start Advertising command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Adv_Data_Len (1 octet)
+					Scan_Rsp_len (1 octet)
+					Adv_Data (0-255 octets)
+					Scan_Rsp (0-255 octets)
+		Return Parameters:	Current_Settings (4 Octets)
+
+		This command is used to start advertising.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0b - Stop Advertising command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Return Parameters:	Current_Settings (4 Octets)
+
+		This command is used to stop advertising.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0c - Start Discovery command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Flags (1 octet)
+		Return Parameters:	<none>
+
+		Possible values for the Flags parameter are a bit-wise or
+		of the following bits:
+					0 = LE scan
+					1 = BR/EDR scan
+					2 = Use limited discovery procedure
+					3 = Use active scan type
+					4 = Use observation procedure
+
+		This command is used to start discovery.
+
+		Observation Procedure allows to receive advertisements
+		(and scan responses) from broadcasters (that are not visible
+		during General or Limited discovery, because those are not
+		discoverable). This procedure can use either passive or active
+		scan type. If "Use observation procedure" (bit 4) is set,
+		"Use limited discovery procedure" (bit 2) is excluded.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0d - Stop Discovery command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Return Parameters:	<none>
+
+		This command is used to stop discovery.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0e - Connect command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+		Return Parameters:	<none>
+
+		Valid Address_Type parameter values:
+					0x00 = Public
+					0x01 = Random
+
+		This command is used to create a Link Layer connection with
+		remote device.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0f - Disconnect command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+		Return Parameters:	<none>
+
+		Valid Address_Type parameter values:
+					0x00 = Public
+					0x01 = Random
+
+		This command is used to terminate an existing connection or
+		to cancel pending connection attempt.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x10 - Set IO Capability command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	IO_Capability (1 octet)
+		Return Parameters:	<none>
+
+		Valid IO_Capabilities parameter values:
+					0x00 = Display Only
+					0x01 = Display Yes/No
+					0x02 = Keyboard Only
+					0x03 = No Input, No Output
+					0x04 = Keyboard Display
+
+		This command is used to set IO capability.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x11 - Pair command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+		Return Parameters:	<none>
+
+		This command is used to initiate pairing with remote.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x12 - Unpair command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+		Return Parameters:	<none>
+
+		This command is used to unpair with remote.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x13 - Passkey Entry Response command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Passkey (4 octets)
+		Return Parameters:	<none>
+
+		This command is used to response with passkey for pairing
+		request.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x14 - Passkey Confirmation Response command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Match (1 octet)
+		Return Parameters:	<none>
+
+		This command is used to response for pairing request with
+		confirmation in accordance with initiator and responder
+		passkey.
+
+		In case of an error, the error response will be returned.
+
+Events:
+	Opcode 0x80 - New Settings event
+
+		Controller Index:	<controller id>
+		Event parameters:	Current_Settings (4 octets)
+
+		This event indicates that one or more of the settings for a
+		controller has changed.
+
+	Opcode 0x81 - Device Found event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					RSSI (1 octet)
+					Flags (1 octet)
+					EIR_Data_Length (2 Octets)
+					EIR_Data (0-65535 Octets)
+
+		Possible values for the Flags parameter are a bit-wise or
+		of the following bits:
+					0 = RSSI valid
+					1 = Adv_Data included
+					2 = Scan_Rsp included
+
+		This event indicates that a device was found during device
+		discovery.
+
+	Opcode 0x82 - Device Connected event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+
+		This event indicates that a device was connected.
+
+	Opcode 0x83 - Device Disconnected event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+
+		This event indicates that a device was disconnected.
+
+	Opcode 0x84 - Passkey Display event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Passkey (4 octets)
+
+		This event indicates that passkey was received and it needs to
+		be confirmed on remote side.
+
+	Opcode 0x85 - Passkey Enter Request event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+
+		This event indicates that remote requests for passkey enter.
+
+	Opcode 0x86 - Passkey Confirm Request event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Passkey (4 octets)
+
+		This event indicates that passkey needs to be confirmed.
+
+	Opcode 0x87 - Identity Resolved event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Identity_Address_Type (1 octet)
+					Identity_Address (6 octets)
+
+		This event indicates that the remote Identity Address has been
+		resolved.
+
+GATT Service (ID 2)
+===================
+
+Commands and responses:
+
+	Opcode 0x00 - Error response
+
+	Opcode 0x01 - Read Supported Commands command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	<none>
+		Response parameters:	<supported commands> (variable)
+
+		Each bit in response is a flag indicating if command with
+		opcode matching bit number is supported. Bit set to 1 means
+		that command is supported. Bit 0 is reserved and shall always
+		be set to 0. If specific bit is not present in response (less
+		than required bytes received) it shall be assumed that command
+		is not supported.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x02 - Add Service
+
+		Controller Index:	<controller id>
+		Command parameters:	Type (1 octet)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+		Response parameters:	Service_ID (2 octets)
+
+		Valid Type parameter values:
+					0x00 = Primary
+					0x01 = Secondary
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This command is used to add new service to GATT Server.
+		Service ID of service declaration is returned in the response.
+		Attribute database shall be initiated sequentially.
+		After this issuing this command tester shall add characteristics
+		or included services this service contains.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x03 - Add Characteristic
+
+		Controller Index:	<controller id>
+		Command parameters:	Service_ID (2 octets)
+					Properties (1 octet)
+					Permissions (1 octet)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+		Response parameters:	Characteristic_ID (2 octets)
+
+		Possible values for Service_ID:
+					0x0000 = Add in sequence
+					0x0001-0xffff = Add to service
+
+		Possible response parameters:
+					0x0000 = Relative ID, will be set after
+					start_server
+					0x0001-0xffff = ID in db
+
+		Possible values for the Properties parameter are a bit-wise
+		of the following bits:
+
+			0	Broadcast
+			1	Read
+			2	Write Without Response
+			3	Write
+			4	Notify
+			5	Indicate
+			6	Authenticated Signed Writes
+			7	Extended Properties
+
+		Possible values for the Permissions parameter are a bit-wise
+		of the following bits:
+
+			0	Read
+			1	Write
+			2	Read with Encryption
+			3	Write with Encryption
+			4	Read with Authentication
+			5	Write with Authentication
+			6	Read with Authorization
+			7	Write with Authorization
+
+		This command is used to add new characteristic to GATT Server.
+		Characteristic ID of characteristic declaration is returned in
+		the response.
+		Attribute's database shall be initiated sequentially.
+		After issuing this command tester can add descriptors to this
+		characteristic.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x04 - Add Descriptor
+
+		Controller Index:	<controller id>
+		Command parameters:	Characteristic_ID (2 octets)
+					Permissions (1 octet)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+		Response parameters:	Descriptor_ID (2 octets)
+
+		Possible values for Characteristic_ID:
+					0x0000 = Add in sequence
+					0x0001-0xffff = Add to characteristic
+
+		Possible response parameters:
+					0x0000 = Relative ID, will be set after
+					start_server
+					0x0001-0xffff = ID in db
+
+		This command is used to add new characteristic descriptor
+		to GATT Server. The command shall be used right after
+		Add Characteristic or previous Add Descriptor command.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x05 - Add Included Service
+
+		Controller Index:	<controller id>
+		Command parameters:	Service_ID (2 octets)
+		Response parameters:	Included_Service_ID (2 octets)
+
+		This command is used to add new included service declaration
+		to GATT Server. Service that is going to be included has to be
+		already added to the server. Attribute_ID of include
+		declaration is returned in the response.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x06 - Set Characteristic/Descriptor Value
+
+		Controller Index:	<controller id>
+		Command parameters:	Attribute_ID (2 octets)
+					Value_Length (2 octet)
+					Value (1-512 octets)
+		Response parameters:	<none>
+
+		Possible values for Characteristic_ID:
+					0x0000 = Set last attribute in db value
+					0x0001-0xffff = Set value of attribute
+					under ID
+
+		This command is used to set the value of characteristic
+		or descriptor.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x07 - Start Server
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Response parameters:	Database_Attribute_Offset (2 octets)
+					Database_Attribute_Count (1 octet)
+
+		This command is used to start server with previously prepared
+		attributes database. Device database may contain predefined
+		attributes. Predefined attributes should be registered before
+		attempt to register sequential database.
+		Subsequent calls of this command shall return an error.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x08 - Reset Server
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Response parameters:	<none>
+
+		This command is used to clear the server from attributes.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x09 - Set Required Encryption Key Size
+
+		Controller Index:	<controller id>
+		Command parameters:	Attribute_ID (2 octets)
+					Encryption_Key_Size (1 octet)
+		Response parameters:	<none>
+
+		Possible values for Attribute_ID:
+					0x0000 = Set encryption key of last
+					added attribute
+					0x0001-0xffff = Set enctryption of
+					attribute under ID
+
+		This command is used to set required Encryption Key Size of an
+		attribute. It shall be used only if encryption or authentication
+		is needed to have access to this attribute. Otherwise an error
+		shall be returned.
+
+		Possible values for Encryption_Key_Size parameter are:
+								<0x07, 0x0f>
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0a - Exchange MTU
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+		Response parameters:	<none>
+
+		This command is used by GATT Client to configure ATT protocol.
+		IUT is expected to send Exchange MTU Request to negotiate
+		MTU size.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0b - Discover All Primary Services
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+		Response parameters:	Services_Count (1 octet)
+					[array] Service (variable)
+
+		Object Service is defined as:
+					Start_Handle (2 octets)
+					End_Group_Handle (2 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used by a client to discover all primary
+		services on a server.
+		Services found during discovery are returned in the response.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0c - Discover Primary Service by UUID
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+		Response parameters:	Services_Count (1 octet)
+					[array] Service (variable)
+
+		Object Service is defined as:
+					Start_Handle (2 octets)
+					End_Group_Handle (2 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used by a client to discover primary services
+		with specific UUID on a server.
+		Services found during discovery are returned in the response.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0d - Find Included Services
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Service_Start_Handle (2 octets)
+					Service_End_Handle (2 octets)
+		Response parameters:	Services_Count (1 octet)
+					[array] Included_Service (variable)
+
+		Object Included_Service is defined as:
+					Included_Handle (2 octets)
+					Type (1 octet)
+					Service (7 or 21 octets)
+
+		Valid Type parameter values:
+					0x00 = Primary
+					0x01 = Secondary
+
+		Object Service is defined as:
+					Start_Handle (2 octets)
+					End_Group_Handle (2 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used by a client to discover service
+		relationships to other services.
+		Services found during discovery are returned in the response.
+
+	Opcode 0x0e - Discover All Characteristics of a Service
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Service_Start_Handle (2 octets)
+					Service_End_Handle (2 octets)
+		Response parameters:	Characteristics_Count (1 octet)
+					[array] Characteristic (variable)
+
+		Object Characteristic is defined as:
+					Characteristic_Handle (2 octets)
+					Value_Handle (2 octets)
+					Properties (1 octet)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used by a client to discover all
+		characteristics within specified service range.
+		Characteristics found during discovery are returned in the
+		response.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0f - Discover Characteristics by UUID
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Start_Handle (2 octets)
+					End_Handle (2 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+		Response parameters:	Characteristics_Count (1 octet)
+					[array] Characteristic (variable)
+
+		Object Characteristic is defined as:
+					Characteristic_Handle (2 octets)
+					Value_Handle (2 octets)
+					Properties (1 octet)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used by a client to discover characteristic
+		declarations with given UUID on a server.
+		Characteristics found during discovery are returned in the
+		response.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x10 - Discover All Characteristic Descriptors
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Start_Handle (2 octets)
+					End_Handle (2 octets)
+		Response parameters:	Descriptors_Count (1 octet)
+					[array] Descriptor (variable)
+
+		Object Descriptor is defined as:
+					Descriptor_Handle (2 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used by a client to discover all the
+		characteristic descriptors contained within characteristic.
+		Descriptors found during discovery are returned in the
+		response.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x11 - Read Characteristic Value/Descriptor
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+		Response parameters:	ATT_Response (1 octet)
+					Data_Length (2 octets)
+					Data (variable)
+
+		This procedure is used to read a Characteristic Value or
+		Characteristic Descriptor from a server.
+		Read results are returned in the response to this command.
+		ATT_Response shall be set to 0x00, if Read has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x12 - Read Using Characteristic UUID
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Start_Handle (2 octets)
+					End_Handle (2 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+		Response parameters:	ATT_Response (1 octet)s
+					Data_Length (2 octets)
+					Data (variable)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used to read a Characteristic Value from a
+		server when characteristic UUID is known.
+		Read results are returned in the response to this command.
+		ATT_Response shall be set to 0x00, if Read has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x13 - Read Long Characteristic Value/Descriptor
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+					Offset (2 octets)
+		Response parameters:	ATT_Response (1 octet)
+					Data_Length (2 octets)
+					Data (variable)
+
+		This procedure is used to read Long Characteristic Value or
+		Long Characteristic Descriptor from a server.
+		Read results are returned in the response to this command.
+		ATT_Response shall be set to 0x00, if Read has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x14 - Read Multiple Characteristic Values
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handles_Count (1 octet)
+					Handles (variable)
+		Response parameters:	ATT_Response (1 octet)
+					Data_Length (2 octets)
+					Data (variable)
+
+		This procedure is used to read multiple Characteristic Values
+		from a server.
+		Read results are returned in the response to this command.
+		ATT_Response shall be set to 0x00, if Read has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x15 - Write Without Response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+					Data_Length (2 octets)
+					Data (variable)
+		Response parameters:	<none>
+
+		This procedure is used to write a Characteristic Value to a
+		server. There is no acknowledgment that the write was
+		successfully performed.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x16 - Signed Write Without Response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+					Data_Length (2 octets)
+					Data (variable)
+		Response parameters:	<none>
+
+		This procedure is used to write a Characteristic Value to a
+		server. There is no acknowledgment that the write was
+		successfully performed. This procedure is intended to be used
+		if client and server are bonded, and connected using
+		non-encrypted link.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x17 - Write Characteristic Value/Descriptor
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+					Data_Length (2 octets)
+					Data (variable)
+		Response parameters:	ATT_Response (1 octet)
+
+		This procedure is used to write a Characteristic Value or
+		Characteristic Descriptor to a server.
+		ATT_Response shall be set to 0x00, if Write has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x18 - Write Long Characteristic Value/Descriptor
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+					Offset (2 octets)
+					Data_Length (2 octets)
+					Data (variable)
+		Response parameters:	ATT_Response (1 octet)
+
+		This procedure is used to write a Long Characteristic Value or
+		Long Characteristic Descriptor to a server.
+		ATT_Response shall be set to 0x00, if Write has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x19 - Reliable Write
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+					Offset (2 octets)
+					Data_Length (2 octets)
+					Data (variable)
+		Response parameters:	ATT_Response (1 octet)
+
+		This procedure is used to write a Characteristic Value to
+		a server and assurance is required that the correct
+		Characteristic Value is going to be written.
+		ATT_Response shall be set to 0x00, if Write has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x1a - Configure Notifications
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Enable (1 octet)
+					CCC_Handle (2 octets)
+		Response parameters:	<none>
+
+		This procedure is used to configure server to notify
+		characteristic value to a client.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x1b - Configure Indications
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Enable (1 octet)
+					CCC_Handle (2 octets)
+		Response parameters:	<none>
+
+		This procedure is used to configure server to indicate
+		characteristic value to a client.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x1c - Get Attributes
+
+		Controller Index:	<controller id>
+		Command parameters:	Start Handle (2 octets)
+					End Handle (2 octets)
+					Type_Length (1 octet)
+					Type (2 or 16 octets)
+		Response parameters:	Attributes_Count (1 octet)
+					[array] Attribute (variable)
+
+		Object Attribute is defined as:
+					Handle (2 octets)
+					Permission (1 octet)
+					Type_Length (1 octet)
+					Type (2 or 16 octets)
+
+		Valid Type_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used to query GATT Server for attributes based
+		on given search pattern. Attributes can be searched using
+		Attribute Handle range and Attribute Type.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x1d - Get Attribute Value
+
+		Controller Index:	<controller id>
+		Command parameters:	Handle (2 octets)
+		Response parameters:	ATT_Response (1 octet)
+					Value_Length (2 octet)
+					Value (variable)
+
+		This procedure is used to query GATT Server for attribute value.
+		In case of long attribute value, multiple responses will be
+		sent. BTP_STATUS_SUCCESS response indicates the procedure is
+		finished.
+
+		In case of an error, the error response will be returned.
+
+Events:
+	Opcode 0x80 - Notification/Indication Received
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Type (1 octet)
+					Handle (2 octets)
+					Data_Length (2 octets)
+					Data (variable)
+
+		Valid Type parameter values:
+					0x01 = Notification
+					0x02 = Indication
+
+		This event indicates that IUT has received notification
+		or notification.
+
+	Opcode 0x81 - Attribute Value Changed
+
+		Controller Index:	<controller id>
+		Event parameters:	Attribute_ID (2 octets)
+					Data_Length (2 octet)
+					Data (1-512 octets)
+
+		This event command is used to indicate attribute
+		(characteristic or descriptor) value changed.
+		Event is triggered when ATT Write operation to Tester GATT
+		Server has been performed successfully.
+
+L2CAP Service (ID 3)
+==================
+
+Commands and responses:
+
+	Opcode 0x00 - Error response
+
+	Opcode 0x01 - Read Supported Commands command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Response parameters:	<supported commands> (variable)
+
+		Each bit in response is a flag indicating if command with
+		opcode matching bit number is supported. Bit set to 1 means
+		that command is supported. Bit 0 is reserved and shall always
+		be set to 0. If specific bit is not present in response (less
+		than required bytes received) it shall be assumed that command
+		is not supported.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x02 - Connect command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					PSM (2 octets)
+		Response parameters:	Chan_ID (1 octet)
+
+		This command is used to create an L2CAP channel.
+		Chan_ID is returned in the response to this command to allow
+		cancellation of this connection request using Disconnect
+		command.
+		Connected Event (or Disconnected Event in case of an error)
+		shall be expected after issuing this command.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x03 - Disconnect command
+
+		Controller Index:	<controller id>
+		Command parameters:	Chan_ID (1 octet)
+		Response parameters:	<none>
+
+		This command is used to close an L2CAP channel.
+		Chan_ID is the internal application number that identifies
+		L2CAP channel.
+		Disconnected Event shall be expected after issuing this command.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x04 - Send Data command
+
+		Controller Index:	<controller id>
+		Command parameters:	Chan_ID (1 octet)
+					Data_Length (2 octets)
+					Data (Data_Length octets)
+		Response parameters:	<none>
+
+		This command is used to send data over L2CAP channel.
+		Chan_ID is the internal application number that identifies
+		L2CAP channel.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x05 - Listen command
+
+		Controller Index:	<controller id>
+		Command parameters:	PSM (2 octets)
+					Transport (1 octet)
+		Response parameters:	<none>
+
+		Valid Transport parameter values:
+					0x00 = BR/EDR
+					0x01 = LE
+
+		This command is used to register L2CAP PSM and listen for
+		incoming data.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x06 - Accept Connection Request
+
+		Controller Index:	<controller id>
+		Command parameters:	Chan_ID (1 octet)
+					Result (2 octets)
+		Return Parameters:	<none>
+
+		This command is used to accept/reject incoming connection
+		request. Connection can be rejected with non-zero Result value
+		(refer to the L2CAP <LE Credit Based> Connection Result values).
+		Connected Event shall be expected after issuing this command.
+
+		In case of an error, the error response will be returned.
+
+Events:
+	Opcode 0x80 - Connection Request Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Chan_ID (1 octet)
+					PSM (2 octets)
+					Address_Type (1 octet)
+					Address (6 octets)
+
+		This event indicates incoming request for L2CAP connection.
+		Connection Request needs to be accepted/rejected with result
+		code using Accept Connection Request command.
+
+	Opcode 0x81 - Connected Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Chan_ID (1 octet)
+					PSM (2 octets)
+					Address_Type (1 octet)
+					Address (6 octets)
+
+		This event indicates new L2CAP connection.
+		Chan_ID is the internal application number that identifies
+		L2CAP channel.
+
+	Opcode 0x82 - Disconnected Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Result (2 octets)
+					Chan_ID (1 octet)
+					PSM (2 octets)
+					Address_Type (1 octet)
+					Address (6 octets)
+
+		This event indicates L2CAP disconnection.
+		Result value is returned in the response, if remote rejected
+		connection request only. Otherwise it shall be set to zero.
+		Please refer to the Core Specification for possible
+		L2CAP <LE Credit Based> Connection Result values.
+		Chan_ID is the internal application number that identifies
+		L2CAP channel.
+
+	Opcode 0x83 - Data Received Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Chan_ID (1 octet)
+					Data_Length (2 octets)
+					Data (Data_Length octets)
+
+		This event forwards data received over L2CAP channel.
+		Chan_ID is the internal application number that identifies
+		L2CAP channel.
+
+Mesh Node Service (ID 4)
+==================
+
+Commands and responses:
+
+	Opcode 0x00 - Error response
+
+	Opcode 0x01 - Read Supported Commands command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Response parameters:	<supported commands> (variable)
+
+		Each bit in response is a flag indicating if command with
+		opcode matching bit number is supported. Bit set to 1 means
+		that command is supported. Bit 0 is reserved and shall always
+		be set to 0. If specific bit is not present in response (less
+		than required bytes received) it shall be assumed that command
+		is not supported.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x02 - Configure Provisioning command/response
+		Controller Index:	<controller id>
+		Command parameters:	UUID (16 octets)
+					Static Auth (16 octets)
+					Output Size (1 octet)
+					Output Actions (2 octets)
+					Input Size (1 octet)
+					Input Actions (2 octets)
+
+		This command is used to configure provisioning options.
+
+		Output actions is a bitmask with following available bits:
+			0	Blink
+			1	Beep
+			2	Vibrate
+			3	Display number
+			4	Display string
+
+		Input actions is a bitmask with following available bits:
+			0	Push
+			1	Twist
+			2	Enter number
+			3	Enter string
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x03 - Provision Node command/response
+		Controller Index:	<controller id>
+		Command parameters:	Network Key (16 octets)
+					Network Key Index (2 octets)
+					Provisioning Flags (1 octet)
+					IV Index (4 octets)
+					Sequence Number (4 octets)
+					Primary Element Address (2 octets)
+					Device Key (16 octets)
+
+		This command is used to provide provisioning information. It can
+		be used whenever unprovisioned beacon is advertising or not.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x04 - Init command/response
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to start advertising either as
+		unprovisioned beacon or network node. Action depends on previous
+		configuration.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x05 - Reset command/response
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to reset state of a provisioned node making
+		it to start sending unprovisioned beacons.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x06 - Input number command/response
+		Controller Index:	<controller id>
+		Command parameters:	Number (4 octets)
+
+		This command is used to reply with input number as a response to
+		Input action event.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x07 - Input string command/response
+		Controller Index:	<controller id>
+		Command parameters:	String Length (1 octet)
+					String (variable)
+
+		This command is used to reply with input string as a response to
+		Input action event.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x08 - IV Update Test Mode
+		Controller Index:	<controller id>
+		Command parameters:	Toggle (1 octet)
+
+		Valid Toggle values:
+					0x00 = Disable
+					0x01 = Enable
+
+		This command is used to toggle the IV Update test mode.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x09 - IV Update toggle state
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to make a IV Update state transition
+		while in IV Update test mode, ignoring the 96 hour limit.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0a - Network Send
+		Controller Index:	<controller id>
+		Command parameters:	TTL (1 octet)
+					SRC (2 octets)
+					DST (2 octets)
+					Payload_Len (1 octet)
+					Payload (variable)
+
+		This command is used to send network layer packet.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0b - Health Generate Faults
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Response parameters:	Test_ID (1 octet)
+					Current_Faults_Count (1 octet)
+					Registered_Faults_Count (1 octet)
+					Current_Faults (variable)
+					Registered_Faults (variable)
+
+		This command is used to generate health faults on IUT.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0c - Health Clear Faults
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to clear fault arrays on IUT.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0d - Low Power Node
+		Controller Index:	<controller id>
+		Command parameters:	Toggle (1 octet)
+
+		Valid Toggle values:
+					0x00 = Disable
+					0x01 = Enable
+
+		This command is used to toggle the Low Power feature of the
+		local device.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0e - Low Power Node Poll
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to send out a Friend Poll message.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0f - Model Send
+		Controller Index:	<controller id>
+		Command parameters:	SRC (2 octets)
+					DST (2 octets)
+					Payload_Len (1 octet)
+					Payload (variable)
+
+		This command is used to send Mesh model message.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x10 - Low Power Node Subscribe
+		Controller Index:	<controller id>
+		Command parameters:	Address (2 octets)
+
+		This command is used to send out a Friend Subscription List
+		Add message message.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x11 - Low Power Node Unsubscribe
+		Controller Index:	<controller id>
+		Command parameters:	Address (2 octets)
+
+		This command is used to send out a Friend Subscription List
+		Remove message.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x12 - Clear Replay Protection List Cache
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to clear Replay Protection List Cache.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x13 - Enable advertising with Node Identity
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to start advertising on each subnet using
+		Node Identity for the next 60 seconds.
+
+		In case of an error, the error response will be returned.
+
+Events:
+	Opcode 0x80 - Output number action Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Action (2 octets)
+					Number (4 octets)
+
+	Opcode 0x81 - Output string action Event
+
+		Controller Index:	<controller id>
+		Event parameters:	String Length (1 octet)
+					String (variable)
+
+	Opcode 0x82 - Input action Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Action (2 octets)
+					Size (1 octet)
+
+		This event indicates that input action is required. Depending
+		on action it may require reply with 'Input number' or
+		'Input string' commands.
+
+		Depending on action either number or string fields are valid.
+
+	Opcode 0x83 - Provisioned Event
+
+		Controller Index:	<controller id>
+		Event parameters:	<none>
+
+		This event indicate that node was provisioned.
+
+	Opcode 0x84 - Link open Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Bearer (1 octet)
+
+		Valid Bearer parameter values:
+
+					0x00 = PB-ADV
+					0x01 = PB-GATT
+
+		This event indicates that provisioning link has been opened on
+		given bearer.
+
+	Opcode 0x85 - Link closed Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Bearer (1 octet)
+
+		Valid Bearer parameter values:
+
+					0x00 = PB-ADV
+					0x01 = PB-GATT
+
+		This event indicates that provisioning link has been closed on
+		given bearer.
+
+	Opcode 0x86 - Network receive Event
+
+		Controller Index:	<controller id>
+		Event parameters:	TTL (1 octet)
+					CTL (1 octet)
+					SRC (2 octets)
+					DST (2 octets)
+					Payload_Len (1 octet)
+					Payload (variable)
+
+		This event indicates reception of network packet.
+
+	Opcode 0x87 - Invalid BearerOpcode Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Opcode (1 octet)
+
+		This event indicates reception of provisioning message with
+		invalid RFU BearerOpcode.
+
+	Opcode 0x88 - Transport Incomplete Timer Expired Event
+
+		Controller Index:	<controller id>
+		Event parameters:	<none>
+
+		This event indicates that segmented message incomplete timer
+		expired.


### PR DESCRIPTION
This moves BTP specification from Zephyr so that it's accessible for
all projects.