### PR TITLE
bot/common: Improve updating sources

### DIFF
--- a/bot/config.py.sample
+++ b/bot/config.py.sample
@@ -30,12 +30,23 @@ z['auto_pts'] = {
     'client_port': 65001,
     'local_ip' : ['192.168.0.100'],
     'project_path': '/path/to/project',
-    'git_branch': 'origin',
     'workspace': 'zephyr-hci',
     'board': 'nrf52',
     'enable_max_logs': False,
     'retry': '2',
     'bd_addr': '',
+}
+
+# ****************************************************************************
+# Git repositories configuration
+# ****************************************************************************
+m['git'] = {
+    'repo1': {
+        'path': 'path/to/repo',
+        'remote': 'origin',
+        'branch': 'master',
+        'stash_changes': False,
+    },
 }
 
 # ****************************************************************************

--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -390,9 +390,8 @@ def main(cfg):
                                         'bluetooth', 'tester', 'outdir',
                                         'zephyr', 'zephyr.elf')
 
-    zephyr_hash = \
-        bot.common.update_sources(os.path.abspath(args['project_path']),
-                                  args['git_branch'])
+    zephyr_hash = bot.common.update_repos(args['project_path'],
+                                          cfg["git"])['zephyr']
 
     summary, results, descriptions, regressions = \
         run_tests(args, cfg.get('iut_config', {}))


### PR DESCRIPTION
Previously you could only specify a remote from which
you could update the sources and you could only use 'master'
branch. Moreover 'reset --hard' had been used to do an update
so there was a possibility of losing some changes.

This patch introduces an improvement to the mechanism of
updating source code repositories. There is a new section
in the bot configuration that specifies what repositories are to
be updated. This functionality supports multiple repositories.
You can specify a path to the repository, absolute
or relative, a remote and a branch. You can also specify
if you want to stash non-committed changes. If the value
is False and there are changes then the repository will not be updated.
