### PR TITLE
ptscontrol: Do not send response parameter on implicit send callback

### DIFF
--- a/autoptsclient_common.py
+++ b/autoptsclient_common.py
@@ -151,7 +151,7 @@ class ClientCallback(PTSCallback):
             sys.exit("Exception in Log")
 
     def on_implicit_send(self, project_name, wid, test_case_name, description,
-                         style, response, response_size, response_is_present):
+                         style):
         """Implements:
 
         interface IPTSImplicitSendCallbackEx : IUnknown {
@@ -179,11 +179,6 @@ class ClientCallback(PTSCallback):
         log("test_case_name: %s" % test_case_name)
         log("description: %s" % description)
         log("style: %s 0x%x", ptstypes.MMI_STYLE_STRING[style], style)
-        log("response: %s %s %s" % (repr(response), type(response),
-                                    id(response)))
-        log("response_size: %s" % response_size)
-        log("response_is_present: %s %s" % (response_is_present,
-                                            type(response_is_present)))
 
         try:
             # XXX: 361 WID MESH sends tc name with leading white spaces
@@ -198,10 +193,7 @@ class ClientCallback(PTSCallback):
                     wid,
                     test_case_name,
                     description,
-                    style,
-                    response,
-                    response_size,
-                    response_is_present)
+                    style)
 
             log("test case returned on_implicit_send, response: %s",
                 testcase_response)

--- a/ptscontrol.py
+++ b/ptscontrol.py
@@ -192,10 +192,7 @@ class PTSSender(PTSControl.IPTSImplicitSendCallbackEx):
                     int(wid),  # UInt16 cannot be marshalled
                     test_case_name,
                     description,
-                    int(style),
-                    response,
-                    int(response_size),
-                    int(response_is_present))
+                    int(style))
 
                 # Don't block xml-rpc
                 if callback_response == "WAIT":

--- a/ptsprojects/testcase.py
+++ b/ptsprojects/testcase.py
@@ -301,7 +301,7 @@ class PTSCallback(object):
         raise AbstractMethodException()
 
     def on_implicit_send(self, project_name, wid, test_case_name, description,
-                         style, response, response_size, response_is_present):
+                         style):
         """Implements:
 
         interface IPTSImplicitSendCallbackEx : IUnknown {
@@ -647,7 +647,7 @@ class TestCase(PTSCallback):
             return "Retry" if response else "Abort"
 
     def on_implicit_send(self, project_name, wid, test_case_name, description,
-                         style, response, response_size, response_is_present):
+                         style):
         """Overrides PTSCallback method. Handles
         PTSControl.IPTSImplicitSendCallbackEx.OnImplicitSend"""
         log("%s %s", self, self.on_implicit_send.__name__)


### PR DESCRIPTION
These parameters are only useful on server side. This fixes using latest
auto-pts with PTS 7.3.0. Autopts server cannot marshall response which
is of IntPtr type.

Relevant autoptsserver.log fragment:

```
BEGIN OnImplicitSend:
project_name: GAP <type 'str'>
wid: 47 <type 'UInt16'>
test_case_name: GAP/BROB/BCST/BV-01-C <type 'str'>
description: Please enter broadcasting mode using specified TSPX_advertising_data value and start advertising. <type 'str'>
style: MMI_Style_Ok_Cancel2 0x11141
response:  <System.IntPtr object at 0x000000000000009B [7318720]> <type 'IntPtr'> 155
response_size: 2048 <type 'UInt32'>
response_is_present:  0 <type 'StrongBox[int]'>
Calling callback.on_implicit_send
Caught exception
cannot marshal <type 'IntPtr'> objects
PTS_LOGTYPE_IMPLICIT_SEND PTS ControlServer  Server: SUCCESS but response is not present
