### PR TITLE
bot: Ignore the untracked files

### DIFF
--- a/bot/common.py
+++ b/bot/common.py
@@ -357,7 +357,7 @@ def update_sources(repo, remote, branch, stash_changes=False):
     print('Updating ' + repo)
 
     repo = git.Repo(repo)
-    dirty = repo.is_dirty(untracked_files=True)
+    dirty = repo.is_dirty()
 
     if dirty and (not stash_changes):
         print('Repo is dirty. Not updating')


### PR DESCRIPTION
Turning on the untracked_files option prevent the bot from reusing the
same repo again because the bot generates the .conf file depends on the
iut_config and it doesn't delete it after the execution.

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>