### PR TITLE
doc/btp_spec: Refactor GATT Server database initialization

### DIFF
--- a/doc/btp_spec.txt
+++ b/doc/btp_spec.txt
@@ -548,148 +548,21 @@ Commands and responses:
 
 		In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Add Service
+	Opcode 0x02 - Unused
+	Opcode 0x03 - Unused
+	Opcode 0x04 - Unused
+	Opcode 0x05 - Unused
+	Opcode 0x06 - Unused
 
-		Controller Index:	<controller id>
-		Command parameters:	Type (1 octet)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-		Response parameters:	Service_ID (2 octets)
-
-		Valid Type parameter values:
-					0x00 = Primary
-					0x01 = Secondary
-
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
-
-		This command is used to add new service to GATT Server.
-		Service ID of service declaration is returned in the response.
-		Attribute database shall be initiated sequentially.
-		After this issuing this command tester shall add characteristics
-		or included services this service contains.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x03 - Add Characteristic
-
-		Controller Index:	<controller id>
-		Command parameters:	Service_ID (2 octets)
-					Properties (1 octet)
-					Permissions (1 octet)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-		Response parameters:	Characteristic_ID (2 octets)
-
-		Possible values for Service_ID:
-					0x0000 = Add in sequence
-					0x0001-0xffff = Add to service
-
-		Possible response parameters:
-					0x0000 = Relative ID, will be set after
-					start_server
-					0x0001-0xffff = ID in db
-
-		Possible values for the Properties parameter are a bit-wise
-		of the following bits:
-
-			0	Broadcast
-			1	Read
-			2	Write Without Response
-			3	Write
-			4	Notify
-			5	Indicate
-			6	Authenticated Signed Writes
-			7	Extended Properties
-
-		Possible values for the Permissions parameter are a bit-wise
-		of the following bits:
-
-			0	Read
-			1	Write
-			2	Read with Encryption
-			3	Write with Encryption
-			4	Read with Authentication
-			5	Write with Authentication
-			6	Read with Authorization
-			7	Write with Authorization
-
-		This command is used to add new characteristic to GATT Server.
-		Characteristic ID of characteristic declaration is returned in
-		the response.
-		Attribute's database shall be initiated sequentially.
-		After issuing this command tester can add descriptors to this
-		characteristic.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x04 - Add Descriptor
-
-		Controller Index:	<controller id>
-		Command parameters:	Characteristic_ID (2 octets)
-					Permissions (1 octet)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-		Response parameters:	Descriptor_ID (2 octets)
-
-		Possible values for Characteristic_ID:
-					0x0000 = Add in sequence
-					0x0001-0xffff = Add to characteristic
-
-		Possible response parameters:
-					0x0000 = Relative ID, will be set after
-					start_server
-					0x0001-0xffff = ID in db
-
-		This command is used to add new characteristic descriptor
-		to GATT Server. The command shall be used right after
-		Add Characteristic or previous Add Descriptor command.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x05 - Add Included Service
-
-		Controller Index:	<controller id>
-		Command parameters:	Service_ID (2 octets)
-		Response parameters:	Included_Service_ID (2 octets)
-
-		This command is used to add new included service declaration
-		to GATT Server. Service that is going to be included has to be
-		already added to the server. Attribute_ID of include
-		declaration is returned in the response.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x06 - Set Characteristic/Descriptor Value
-
-		Controller Index:	<controller id>
-		Command parameters:	Attribute_ID (2 octets)
-					Value_Length (2 octet)
-					Value (1-512 octets)
-		Response parameters:	<none>
-
-		Possible values for Characteristic_ID:
-					0x0000 = Set last attribute in db value
-					0x0001-0xffff = Set value of attribute
-					under ID
-
-		This command is used to set the value of characteristic
-		or descriptor.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x07 - Start Server
+	Opcode 0x07 - Init Server
 
 		Controller Index:	<controller id>
 		Command parameters:	<none>
-		Response parameters:	Database_Attribute_Offset (2 octets)
-					Database_Attribute_Count (1 octet)
+		Response parameters:    <none>
 
-		This command is used to start server with previously prepared
-		attributes database. Device database may contain predefined
-		attributes. Predefined attributes should be registered before
-		attempt to register sequential database.
+		This command is used to init GATT server with static defined
+		attribute database. The database shall be composed of attributes
+		that allow to test all of the ATT/GATT features the IUT supports.
 		Subsequent calls of this command shall return an error.
 
 		In case of an error, the error response will be returned.
@@ -704,26 +577,13 @@ Commands and responses:
 
 		In case of an error, the error response will be returned.
 
-	Opcode 0x09 - Set Required Encryption Key Size
+	Opcode 0x09 - Service Changed
 
 		Controller Index:	<controller id>
-		Command parameters:	Attribute_ID (2 octets)
-					Encryption_Key_Size (1 octet)
+		Command parameters:	<none>
 		Response parameters:	<none>
 
-		Possible values for Attribute_ID:
-					0x0000 = Set encryption key of last
-					added attribute
-					0x0001-0xffff = Set enctryption of
-					attribute under ID
-
-		This command is used to set required Encryption Key Size of an
-		attribute. It shall be used only if encryption or authentication
-		is needed to have access to this attribute. Otherwise an error
-		shall be returned.
-
-		Possible values for Encryption_Key_Size parameter are:
-								<0x07, 0x0f>
+		This command is used to trigger service changed indication.
 
 		In case of an error, the error response will be returned.
 


### PR DESCRIPTION
The aim of this patch is to refactor the way the GATT Server
is initialized so that the API can be easily used by different
host implementations.
Instead of dynamically initialization, GATT attributes are
static defined in IUT tester application. It is up to
implementation to compose it's attribute database to allow
to test all of the features it supports.