### PR TITLE
btp: fix advertisement/scan response construction

### DIFF
--- a/pybtp/btp.py
+++ b/pybtp/btp.py
@@ -524,14 +524,14 @@ def gap_adv_ind_on(ad={}, sd={}):
 
     for ad_type, ad_data in ad.iteritems():
         data = binascii.unhexlify(bytearray(ad_data))
+        ad_ba.extend(chr(len(data)+1))
         ad_ba.extend(chr(ad_type))
-        ad_ba.extend(chr(len(data)))
         ad_ba.extend(data)
 
     for sd_type, sd_data in sd.iteritems():
         data = binascii.unhexlify(bytearray(sd_data))
+        sd_ba.extend(chr(len(data)+1))
         sd_ba.extend(chr(sd_type))
-        sd_ba.extend(chr(len(data)))
         sd_ba.extend(data)
 
     data_ba.extend(chr(len(ad_ba)))


### PR DESCRIPTION
btp.gap_adv_ind_on constructs advertisement data as a list of { ad_type, ad_len, ad_data} chunks: https://github.com/intel/auto-pts/blob/master/pybtp/btp.py#L527. 

However, it should be { ad_len, ad_type, ad_data } according to Core V5.1, [Vol 3] Part C, Section 1.) 

I didn't see any comments in the btp_spec.txt which would indicate a different format for the BTP message.