### PR TITLE
btp: use own_addr_type instead of use own address

### DIFF
--- a/doc/btp_spec.txt
+++ b/doc/btp_spec.txt
@@ -373,12 +373,13 @@ Commands and responses:
 		Controller Index:	<controller id>
 		Command parameters:	Address_Type (1 octet)
 					Address (6 octets)
-					Use own ID address (1 octet)
+					Own_Addr_Type (1 octet)
 		Return Parameters:	<none>
 
-		Valid Address_Type parameter values:
-					0x00 = Public
-					0x01 = Random
+		Valid Own_Addr_Type parameter values:
+					0x00 = Identity Address
+					0x01 = Resolvable Private Address
+					0x02 = Non-resolvabe Private Address
 
 		This command is used to create a Link Layer connection with
 		remote device.

--- a/doc/btp_spec.txt
+++ b/doc/btp_spec.txt
@@ -305,12 +305,17 @@ Commands and responses:
 					Adv_Data (0-255 octets)
 					Scan_Rsp (0-255 octets)
 					Duration (4 octets)
-					Use own ID address (1 octet)
+					Own_Addr_Type (1 octet)
 		Return Parameters:	Current_Settings (4 Octets)
+
+		Valid Own_Addr_Type parameter values:
+					0x00 = Identity Address
+					0x01 = Resolvable Private Address
+					0x02 = Non-resolvabe Private Address
 
 		This command is used to start advertising.
 
-                Adv_Data and Scan_Rsp are a list of { AD_Type, AD_Len, AD_DATA } structures.
+		Adv_Data and Scan_Rsp are a list of { AD_Type, AD_Len, AD_DATA } structures.
 
 		When Duration parameter value equals UINT32_MAX then the
 		advertising duration is disabled.

--- a/pybtp/btp.py
+++ b/pybtp/btp.py
@@ -669,7 +669,7 @@ def gap_direct_adv_on(addr, addr_type, high_duty=0):
     __gap_current_settings_update(tuple_data)
 
 
-def gap_conn(bd_addr=None, bd_addr_type=None):
+def gap_conn(bd_addr=None, bd_addr_type=None, own_addr_type=OwnAddrType.le_identity_address):
     logging.debug("%s %r %r", gap_conn.__name__, bd_addr, bd_addr_type)
     iutctl = get_iut()
 
@@ -678,13 +678,14 @@ def gap_conn(bd_addr=None, bd_addr_type=None):
 
     data_ba.extend(chr(pts_addr_type_get(bd_addr_type)))
     data_ba.extend(bd_addr_ba)
+    data_ba.extend(chr(own_addr_type))
 
     iutctl.btp_socket.send(*GAP['conn'], data=data_ba)
 
     gap_command_rsp_succ()
 
 
-def gap_rpa_conn(description):
+def gap_rpa_conn(description, own_addr_type=OwnAddrType.le_identity_address):
     """Initiate connection with PTS using RPA address provided
     in MMI description. Function returns True.
 
@@ -702,6 +703,7 @@ def gap_rpa_conn(description):
 
     data_ba.extend(chr(pts_addr_type_get(bd_addr_type)))
     data_ba.extend(bd_addr_ba)
+    data_ba.extend(chr(own_addr_type))
 
     iutctl.btp_socket.send(*GAP['conn'], data=data_ba)
 

--- a/pybtp/btp.py
+++ b/pybtp/btp.py
@@ -23,7 +23,7 @@ import socket
 from threading import Timer, Event
 
 import defs
-from types import BTPError, gap_settings_btp2txt, addr2btp_ba, Addr
+from types import BTPError, gap_settings_btp2txt, addr2btp_ba, Addr, OwnAddrType, AdDuration
 from pybtp.types import Perm
 from iutctl_common import set_event_handler
 from random import randint
@@ -589,7 +589,7 @@ def gap_wait_for_disconnection(timeout=30):
     stack.gap.wait_for_disconnection(timeout)
 
 
-def gap_adv_ind_on(ad={}, sd={}):
+def gap_adv_ind_on(ad={}, sd={}, duration=AdDuration.forever, own_addr_type=OwnAddrType.le_identity_address):
     logging.debug("%s %r %r", gap_adv_ind_on.__name__, ad, sd)
 
     stack = get_stack()
@@ -620,6 +620,8 @@ def gap_adv_ind_on(ad={}, sd={}):
     data_ba.extend(chr(len(sd_ba)))
     data_ba.extend(ad_ba)
     data_ba.extend(sd_ba)
+    data_ba.extend(struct.pack("<I", duration))
+    data_ba.extend(chr(own_addr_type))
 
     iutctl.btp_socket.send(*GAP['start_adv'], data=data_ba)
 

--- a/pybtp/types.py
+++ b/pybtp/types.py
@@ -86,6 +86,8 @@ class AdFlags:
     sim_le_br_edr_contr = 0x08
     sim_le_br_edr_host = 0x10
 
+class AdDuration:
+    forever = 0xFFFFFFFF
 
 class UriScheme:
     https = '17'
@@ -128,6 +130,10 @@ class Addr:
     le_public = 0
     le_random = 1
 
+class OwnAddrType:
+    le_identity_address = 0
+    le_resolvable_private_address = 1
+    le_non_resolvable_private_address = 2
 
 class MeshVals:
     subscription_addr_list1 = 'C302'


### PR DESCRIPTION
Specifying own addr type allows to configure IUT for GAP/BROB/BCST/BV-04