### PR TITLE
bot: Enable Zip64 option for large files

### DIFF
--- a/bot/common.py
+++ b/bot/common.py
@@ -377,7 +377,7 @@ def archive_recursive(dir_path):
     """
     zip_file_path = os.path.join(os.path.dirname(dir_path),
                                  os.path.basename(dir_path) + '.zip')
-    with zipfile.ZipFile(zip_file_path, 'w') as zf:
+    with zipfile.ZipFile(zip_file_path, 'w', allowZip64=True) as zf:
         for root, dirs, files in os.walk(dir_path):
             for file_or_dir in files + dirs:
                 zf.write(


### PR DESCRIPTION
This patch enabls allowZip64 option for large files. This was set to
False by default on Python 2.7.

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>