### PR TITLE
zephyr/iutctl: Flush serial before board reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Over 460 test cases have been automated for Zephyr OS and Mynewt OS which reduce
 
 # Linux Prerequisites
 
-Install required modules with:
+`sudo apt-get install python-setuptools socat`
+
+Additionally, install required Python modules with:
 
 `python2 -m pip install --user -r autoptsclient_requirements.txt`
 

--- a/autoptsclient_requirements.txt
+++ b/autoptsclient_requirements.txt
@@ -1,1 +1,2 @@
 termcolor
+pyserial

--- a/autoptsclient_requirements.txt
+++ b/autoptsclient_requirements.txt
@@ -1,2 +1,3 @@
 termcolor
 pyserial
+wheel


### PR DESCRIPTION
This is needed to clean up any data left before board reset.
Any data left may affect the BTP commands flow.