### PR TITLE
zephyr: Fix typo in workspaces

### DIFF
--- a/workspaces/autopts-zephyr-210/autopts-zephyr-210.pqw6
+++ b/workspaces/autopts-zephyr-210/autopts-zephyr-210.pqw6
@@ -1,4 +1,4 @@
-<WORKSPACE_INFORMATION NAME="autopts-zephyt-210" PATH="C:\msys64\home\michaln\auto-pts\workspaces\autopts-zephyt-210" CREATED_WITH="Profile Tuning Suite, 7.6.0, 15" BD_ADDR="000000000000" QDID="145446">
+<WORKSPACE_INFORMATION NAME="autopts-zephyr-210" PATH="C:\msys64\home\michaln\auto-pts\workspaces\autopts-zephyr-210" CREATED_WITH="Profile Tuning Suite, 7.6.0, 15" BD_ADDR="000000000000" QDID="145446">
   <PROJECTS_INFORMATION>
     <PROJECT_INFORMATION NAME="GAP" TC_LOG="tc_log.xml" TC_SCRIPT="tc_sqript.xml" USERDLL="" USE_USERDLL="False" RUNTIME_LOGGING="False">
       <PICS>

--- a/workspaces/autopts-zephyr-210/autopts-zephyr-210.pts
+++ b/workspaces/autopts-zephyr-210/autopts-zephyr-210.pts
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <project>
   <qdid>145446</qdid>
-  <name>autopts-zephyt-2.1.0</name>
+  <name>autopts-zephyr-2.1.0</name>
   <pics>
     <profile>
       <name>GAP</name>


### PR DESCRIPTION
Fix a typo in the workspace files.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>