### PR TITLE
zephyr: Fix workspace version

### DIFF
--- a/workspaces/autopts-zephyr-22/autopts-zephyr-22.pqw6
+++ b/workspaces/autopts-zephyr-22/autopts-zephyr-22.pqw6
@@ -1,4 +1,4 @@
-<WORKSPACE_INFORMATION NAME="autopts-zephyr-210" PATH="C:\msys64\home\michaln\auto-pts\workspaces\autopts-zephyr-210" CREATED_WITH="Profile Tuning Suite, 7.6.0, 15" BD_ADDR="000000000000" QDID="145446">
+<WORKSPACE_INFORMATION NAME="autopts-zephyr-22" PATH="C:\msys64\home\michaln\auto-pts\workspaces\autopts-zephyr-22" CREATED_WITH="Profile Tuning Suite, 7.6.0, 15" BD_ADDR="000000000000" QDID="145446">
   <PROJECTS_INFORMATION>
     <PROJECT_INFORMATION NAME="GAP" TC_LOG="tc_log.xml" TC_SCRIPT="tc_sqript.xml" USERDLL="" USE_USERDLL="False" RUNTIME_LOGGING="False">
       <PICS>

--- a/workspaces/autopts-zephyr-22/autopts-zephyr-22.pts
+++ b/workspaces/autopts-zephyr-22/autopts-zephyr-22.pts
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <project>
   <qdid>145446</qdid>
-  <name>autopts-zephyr-2.1.0</name>
+  <name>autopts-zephyr-2.2</name>
   <pics>
     <profile>
       <name>GAP</name>


### PR DESCRIPTION
Latest updates target Zephyr version 2.2.0, so we rename the workspace.
Also versions 2.2.x may be compatible with this workspace so lets
use version 2.2.