### PR TITLE
zephyr: Fix workspace ICS settings

### DIFF
--- a/workspaces/autopts-zephyr-22/autopts-zephyr-22.pqw6
+++ b/workspaces/autopts-zephyr-22/autopts-zephyr-22.pqw6
@@ -1,4 +1,4 @@
-<WORKSPACE_INFORMATION NAME="autopts-zephyr-22" PATH="C:\msys64\home\michaln\auto-pts\workspaces\autopts-zephyr-22" CREATED_WITH="Profile Tuning Suite, 7.6.0, 15" BD_ADDR="000000000000" QDID="145446">
+<WORKSPACE_INFORMATION NAME="autopts-zephyr-22" CREATED_WITH="Profile Tuning Suite, 7.6.0, 15" BD_ADDR="000000000000" QDID="146022">
   <PROJECTS_INFORMATION>
     <PROJECT_INFORMATION NAME="GAP" TC_LOG="tc_log.xml" TC_SCRIPT="tc_sqript.xml" USERDLL="" USE_USERDLL="False" RUNTIME_LOGGING="False">
       <PICS>
@@ -302,13 +302,13 @@
           <Row>
             <Name>TSPC_GAP_8_3</Name>
             <Description>Non-Connectable and Non-Scannable Directed Event (C.1)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_GAP_8_4</Name>
             <Description>Scannable Directed Event (C.1)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -656,19 +656,19 @@
           <Row>
             <Name>TSPC_GAP_20_5</Name>
             <Description>Connectable Undirected Event (C.3)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_GAP_20_6</Name>
             <Description>Non-Connectable and Non-Scannable Directed Event (C.3)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_GAP_20_7</Name>
             <Description>Scannable Directed Event (C.3)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -812,7 +812,7 @@
           <Row>
             <Name>TSPC_GAP_21_7</Name>
             <Description>LE Ping Procedure (C.3)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -878,7 +878,7 @@
           <Row>
             <Name>TSPC_GAP_23_2</Name>
             <Description>Directed Connectable Mode (O)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -956,7 +956,7 @@
           <Row>
             <Name>TSPC_GAP_25_4</Name>
             <Description>Authorization Procedure (O)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -1160,7 +1160,7 @@
           <Row>
             <Name>TSPC_GAP_31_7</Name>
             <Description>LE Ping Procedure (O)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -1226,7 +1226,7 @@
           <Row>
             <Name>TSPC_GAP_33_3</Name>
             <Description>Selective Connection Establishment Procedure (O)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -1298,7 +1298,7 @@
           <Row>
             <Name>TSPC_GAP_35_4</Name>
             <Description>Authorization Procedure (O)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -1514,7 +1514,7 @@
           <Row>
             <Name>TSPC_SM_2_4</Name>
             <Description>OOB supported (O)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -2050,7 +2050,7 @@
           <Row>
             <Name>TSPC_GATT_3_16</Name>
             <Description>Characteristic Value Reliable Writes (O)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -2278,13 +2278,13 @@
           <Row>
             <Name>TSPC_GATT_4_24</Name>
             <Description>Configured Broadcast (C.5)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_GATT_4_25</Name>
             <Description>Execute Write Request with empty queue (C.7)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -4160,7 +4160,7 @@
           <Row>
             <Name>TSPC_SM_2_4</Name>
             <Description>OOB supported (O)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -4190,7 +4190,7 @@
           <Row>
             <Name>TSPC_SM_4_3</Name>
             <Description>Out of Band (C.1)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>

--- a/workspaces/autopts-zephyr-22/autopts-zephyr-22.pts
+++ b/workspaces/autopts-zephyr-22/autopts-zephyr-22.pts
@@ -1,13 +1,89 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <project>
-  <qdid>145446</qdid>
-  <name>autopts-zephyr-2.2</name>
+  <qdid>146022</qdid>
+  <name>autopts-zephyr-22</name>
   <pics>
     <profile>
       <name>GAP</name>
       <item>
+        <table>23</table>
+        <row>1</row>
+      </item>
+      <item>
         <table>21</table>
         <row>9</row>
+      </item>
+      <item>
+        <table>21</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>25</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>20A</table>
+        <row>13</row>
+      </item>
+      <item>
+        <table>20A</table>
+        <row>8</row>
+      </item>
+      <item>
+        <table>26</table>
+        <row>4</row>
+      </item>
+      <item>
+        <table>6</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>8a</table>
+        <row>9</row>
+      </item>
+      <item>
+        <table>20A</table>
+        <row>5</row>
+      </item>
+      <item>
+        <table>31</table>
+        <row>9</row>
+      </item>
+      <item>
+        <table>17</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>20A</table>
+        <row>12</row>
+      </item>
+      <item>
+        <table>31</table>
+        <row>8</row>
+      </item>
+      <item>
+        <table>36</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>8</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>8a</table>
+        <row>10</row>
+      </item>
+      <item>
+        <table>27</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>5</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>8a</table>
+        <row>15</row>
       </item>
       <item>
         <table>20</table>
@@ -18,36 +94,16 @@
         <row>5</row>
       </item>
       <item>
-        <table>20A</table>
-        <row>13</row>
-      </item>
-      <item>
-        <table>8</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>20A</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>17</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>11</table>
+        <table>31</table>
         <row>1</row>
-      </item>
-      <item>
-        <table>27</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>21</table>
-        <row>2</row>
       </item>
       <item>
         <table>22</table>
         <row>4</row>
+      </item>
+      <item>
+        <table>21</table>
+        <row>3</row>
       </item>
       <item>
         <table>31</table>
@@ -58,87 +114,7 @@
         <row>6</row>
       </item>
       <item>
-        <table>20A</table>
-        <row>12</row>
-      </item>
-      <item>
-        <table>6</table>
-        <row>1</row>
-      </item>
-      <item>
         <table>20</table>
-        <row>7</row>
-      </item>
-      <item>
-        <table>24</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>8</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>8a</table>
-        <row>15</row>
-      </item>
-      <item>
-        <table>25</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>20A</table>
-        <row>8</row>
-      </item>
-      <item>
-        <table>6</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>8a</table>
-        <row>9</row>
-      </item>
-      <item>
-        <table>25</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>33</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>8a</table>
-        <row>10</row>
-      </item>
-      <item>
-        <table>5</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>23</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>26</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>31</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>21</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>20</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>31</table>
-        <row>9</row>
-      </item>
-      <item>
-        <table>33</table>
         <row>3</row>
       </item>
       <item>
@@ -146,20 +122,28 @@
         <row>3</row>
       </item>
       <item>
-        <table>31</table>
-        <row>8</row>
+        <table>6</table>
+        <row>1</row>
       </item>
       <item>
-        <table>20</table>
-        <row>5</row>
+        <table>11</table>
+        <row>1</row>
       </item>
       <item>
-        <table>36</table>
-        <row>2</row>
+        <table>33</table>
+        <row>4</row>
+      </item>
+      <item>
+        <table>24</table>
+        <row>4</row>
       </item>
       <item>
         <table>23</table>
         <row>3</row>
+      </item>
+      <item>
+        <table>35</table>
+        <row>7</row>
       </item>
       <item>
         <table>23</table>
@@ -170,52 +154,16 @@
         <row>3</row>
       </item>
       <item>
-        <table>21</table>
-        <row>7</row>
-      </item>
-      <item>
-        <table>25</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>8a</table>
-        <row>14</row>
-      </item>
-      <item>
-        <table>27</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>29</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>8a</table>
-        <row>7</row>
-      </item>
-      <item>
-        <table>21</table>
-        <row>8</row>
-      </item>
-      <item>
-        <table>18</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>28</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>35</table>
-        <row>7</row>
-      </item>
-      <item>
-        <table>7</table>
+        <table>13</table>
         <row>1</row>
       </item>
       <item>
         <table>7</table>
         <row>2</row>
+      </item>
+      <item>
+        <table>25</table>
+        <row>5</row>
       </item>
       <item>
         <table>27</table>
@@ -230,6 +178,14 @@
         <row>2</row>
       </item>
       <item>
+        <table>33</table>
+        <row>5</row>
+      </item>
+      <item>
+        <table>37</table>
+        <row>1</row>
+      </item>
+      <item>
         <table>34</table>
         <row>1</row>
       </item>
@@ -238,8 +194,20 @@
         <row>2</row>
       </item>
       <item>
-        <table>32</table>
-        <row>3</row>
+        <table>8a</table>
+        <row>14</row>
+      </item>
+      <item>
+        <table>27</table>
+        <row>5</row>
+      </item>
+      <item>
+        <table>29</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>14</table>
+        <row>1</row>
       </item>
       <item>
         <table>13</table>
@@ -250,48 +218,24 @@
         <row>11</row>
       </item>
       <item>
-        <table>8a</table>
-        <row>17</row>
-      </item>
-      <item>
-        <table>20A</table>
-        <row>9</row>
-      </item>
-      <item>
-        <table>13</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>8a</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>33</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>37</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>20A</table>
-        <row>17</row>
-      </item>
-      <item>
-        <table>35</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>33</table>
-        <row>1</row>
-      </item>
-      <item>
         <table>20</table>
         <row>4</row>
       </item>
       <item>
         <table>25</table>
         <row>10</row>
+      </item>
+      <item>
+        <table>18</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>8a</table>
+        <row>17</row>
+      </item>
+      <item>
+        <table>20A</table>
+        <row>9</row>
       </item>
       <item>
         <table>8a</table>
@@ -302,12 +246,20 @@
         <row>8</row>
       </item>
       <item>
-        <table>20</table>
-        <row>6</row>
+        <table>7</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>8a</table>
+        <row>4</row>
       </item>
       <item>
         <table>22</table>
         <row>3</row>
+      </item>
+      <item>
+        <table>20A</table>
+        <row>17</row>
       </item>
       <item>
         <table>20A</table>
@@ -318,7 +270,11 @@
         <row>14</row>
       </item>
       <item>
-        <table>14</table>
+        <table>32</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>33</table>
         <row>1</row>
       </item>
       <item>
@@ -326,27 +282,27 @@
         <row>6</row>
       </item>
       <item>
-        <table>23</table>
-        <row>2</row>
+        <table>8a</table>
+        <row>7</row>
+      </item>
+      <item>
+        <table>21</table>
+        <row>8</row>
       </item>
       <item>
         <table>28</table>
         <row>1</row>
       </item>
       <item>
+        <table>28</table>
+        <row>2</row>
+      </item>
+      <item>
         <table>19</table>
         <row>1</row>
       </item>
       <item>
-        <table>19</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>31</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>26</table>
+        <table>35</table>
         <row>1</row>
       </item>
       <item>
@@ -354,7 +310,83 @@
         <row>1</row>
       </item>
       <item>
+        <table>11</table>
+        <row>3</row>
+      </item>
+      <item>
         <table>17</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>25</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>25</table>
+        <row>6</row>
+      </item>
+      <item>
+        <table>25</table>
+        <row>9</row>
+      </item>
+      <item>
+        <table>20A</table>
+        <row>10</row>
+      </item>
+      <item>
+        <table>35</table>
+        <row>8</row>
+      </item>
+      <item>
+        <table>16</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>12</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>8a</table>
+        <row>11</row>
+      </item>
+      <item>
+        <table>31</table>
+        <row>5</row>
+      </item>
+      <item>
+        <table>33</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>29</table>
+        <row>4</row>
+      </item>
+      <item>
+        <table>24</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>8a</table>
+        <row>5</row>
+      </item>
+      <item>
+        <table>36</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>8a</table>
+        <row>13</row>
+      </item>
+      <item>
+        <table>35</table>
+        <row>5</row>
+      </item>
+      <item>
+        <table>36</table>
+        <row>5</row>
+      </item>
+      <item>
+        <table>14</table>
         <row>2</row>
       </item>
       <item>
@@ -366,99 +398,19 @@
         <row>15</row>
       </item>
       <item>
-        <table>8</table>
+        <table>19</table>
         <row>3</row>
-      </item>
-      <item>
-        <table>12</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>21</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>8a</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>36</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>14</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>20A</table>
-        <row>10</row>
-      </item>
-      <item>
-        <table>35</table>
-        <row>8</row>
-      </item>
-      <item>
-        <table>31</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>35</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>24</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>8a</table>
-        <row>13</row>
-      </item>
-      <item>
-        <table>35</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>5</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>36</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>35</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>11</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>25</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>25</table>
-        <row>9</row>
-      </item>
-      <item>
-        <table>25</table>
-        <row>6</row>
-      </item>
-      <item>
-        <table>16</table>
-        <row>1</row>
       </item>
       <item>
         <table>18</table>
         <row>1</row>
       </item>
       <item>
-        <table>8a</table>
-        <row>11</row>
+        <table>21</table>
+        <row>5</row>
       </item>
       <item>
-        <table>33</table>
+        <table>35</table>
         <row>2</row>
       </item>
       <item>
@@ -466,7 +418,7 @@
         <row>1</row>
       </item>
       <item>
-        <table>29</table>
+        <table>31</table>
         <row>4</row>
       </item>
       <item>
@@ -475,43 +427,15 @@
       </item>
       <item>
         <table>8a</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>31</table>
-        <row>10</row>
-      </item>
-      <item>
-        <table>21</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>35</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>22</table>
         <row>2</row>
       </item>
       <item>
         <table>26</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>27</table>
-        <row>6</row>
-      </item>
-      <item>
-        <table>30</table>
         <row>1</row>
       </item>
       <item>
-        <table>32</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>31</table>
-        <row>7</row>
+        <table>5</table>
+        <row>4</row>
       </item>
       <item>
         <table>27</table>
@@ -522,52 +446,40 @@
         <row>1</row>
       </item>
       <item>
+        <table>25</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>35</table>
+        <row>10</row>
+      </item>
+      <item>
+        <table>31</table>
+        <row>10</row>
+      </item>
+      <item>
+        <table>21</table>
+        <row>4</row>
+      </item>
+      <item>
         <table>21</table>
         <row>10</row>
       </item>
       <item>
-        <table>37</table>
-        <row>2</row>
+        <table>8a</table>
+        <row>12</row>
       </item>
       <item>
-        <table>5</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>36</table>
+        <table>20</table>
         <row>1</row>
-      </item>
-      <item>
-        <table>21</table>
-        <row>11</row>
       </item>
       <item>
         <table>34</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>21</table>
-        <row>6</row>
-      </item>
-      <item>
-        <table>29</table>
         <row>3</row>
-      </item>
-      <item>
-        <table>24</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>17</table>
-        <row>1</row>
       </item>
       <item>
         <table>20A</table>
         <row>16</row>
-      </item>
-      <item>
-        <table>20A</table>
-        <row>4</row>
       </item>
       <item>
         <table>20A</table>
@@ -582,68 +494,20 @@
         <row>2</row>
       </item>
       <item>
-        <table>26</table>
-        <row>2</row>
+        <table>36</table>
+        <row>1</row>
       </item>
       <item>
         <table>22</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>20A</table>
-        <row>11</row>
-      </item>
-      <item>
-        <table>25</table>
-        <row>7</row>
-      </item>
-      <item>
-        <table>25</table>
-        <row>8</row>
-      </item>
-      <item>
-        <table>17</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>25</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>35</table>
-        <row>10</row>
-      </item>
-      <item>
-        <table>8</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>8a</table>
-        <row>12</row>
-      </item>
-      <item>
-        <table>24</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>20</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>34</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>29</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>5</table>
-        <row>1</row>
+        <row>2</row>
       </item>
       <item>
         <table>31</table>
         <row>2</row>
+      </item>
+      <item>
+        <table>21</table>
+        <row>11</row>
       </item>
       <item>
         <table>21</table>
@@ -654,12 +518,104 @@
         <row>2</row>
       </item>
       <item>
-        <table>15</table>
+        <table>20A</table>
+        <row>11</row>
+      </item>
+      <item>
+        <table>26</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>30</table>
         <row>1</row>
+      </item>
+      <item>
+        <table>21</table>
+        <row>6</row>
       </item>
       <item>
         <table>35</table>
         <row>9</row>
+      </item>
+      <item>
+        <table>25</table>
+        <row>8</row>
+      </item>
+      <item>
+        <table>17</table>
+        <row>4</row>
+      </item>
+      <item>
+        <table>8</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>29</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>24</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>24</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>37</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>17</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>20A</table>
+        <row>4</row>
+      </item>
+      <item>
+        <table>29</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>5</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>26</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>35</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>5</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>22</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>15</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>34</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>27</table>
+        <row>6</row>
+      </item>
+      <item>
+        <table>32</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>25</table>
+        <row>7</row>
       </item>
       <item>
         <table>30</table>
@@ -673,6 +629,10 @@
         <row>1</row>
       </item>
       <item>
+        <table>2</table>
+        <row>47</row>
+      </item>
+      <item>
         <table>0</table>
         <row>2</row>
       </item>
@@ -682,19 +642,11 @@
       </item>
       <item>
         <table>2</table>
-        <row>47</row>
-      </item>
-      <item>
-        <table>2</table>
-        <row>45a</row>
-      </item>
-      <item>
-        <table>2</table>
         <row>43</row>
       </item>
       <item>
         <table>2</table>
-        <row>42</row>
+        <row>45a</row>
       </item>
       <item>
         <table>3</table>
@@ -702,7 +654,23 @@
       </item>
       <item>
         <table>2</table>
+        <row>42</row>
+      </item>
+      <item>
+        <table>2</table>
+        <row>46</row>
+      </item>
+      <item>
+        <table>1</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>2</table>
         <row>40</row>
+      </item>
+      <item>
+        <table>2</table>
+        <row>41</row>
       </item>
       <item>
         <table>1</table>
@@ -710,38 +678,11 @@
       </item>
       <item>
         <table>1</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>1</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>1</table>
         <row>4</row>
       </item>
       <item>
-        <table>2</table>
-        <row>41</row>
-      </item>
-      <item>
-        <table>2</table>
-        <row>46</row>
-      </item>
-    </profile>
-    <profile>
-      <name>SUM ICS</name>
-      <item>
-        <table>34</table>
-        <row>15</row>
-      </item>
-      <item>
-        <table>52</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>31</table>
-        <row>20</row>
+        <table>1</table>
+        <row>5</row>
       </item>
     </profile>
     <profile>
@@ -758,24 +699,8 @@
     <profile>
       <name>GATT</name>
       <item>
-        <table>4</table>
-        <row>7</row>
-      </item>
-      <item>
         <table>3</table>
-        <row>12</row>
-      </item>
-      <item>
-        <table>7</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>14</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>15</row>
+        <row>10</row>
       </item>
       <item>
         <table>3</table>
@@ -783,19 +708,19 @@
       </item>
       <item>
         <table>4</table>
-        <row>26</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>10</row>
-      </item>
-      <item>
-        <table>4</table>
         <row>18</row>
       </item>
       <item>
         <table>3</table>
-        <row>16</row>
+        <row>12</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>14</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>26</row>
       </item>
       <item>
         <table>4</table>
@@ -803,15 +728,23 @@
       </item>
       <item>
         <table>3</table>
-        <row>5</row>
+        <row>15</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>7</row>
+      </item>
+      <item>
+        <table>7</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>17</row>
       </item>
       <item>
         <table>4</table>
         <row>8</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>19</row>
       </item>
       <item>
         <table>4</table>
@@ -827,7 +760,11 @@
       </item>
       <item>
         <table>4</table>
-        <row>17</row>
+        <row>19</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>5</row>
       </item>
       <item>
         <table>3</table>
@@ -838,40 +775,12 @@
         <row>6</row>
       </item>
       <item>
-        <table>4</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>20</row>
+        <table>7</table>
+        <row>3</row>
       </item>
       <item>
         <table>4</table>
         <row>5</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>21</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>13</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>19</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>18</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>23</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>3</row>
       </item>
       <item>
         <table>4</table>
@@ -879,111 +788,83 @@
       </item>
       <item>
         <table>3</table>
-        <row>8</row>
+        <row>21</row>
       </item>
       <item>
-        <table>4</table>
-        <row>9</row>
+        <table>3</table>
+        <row>19</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>7</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>18</row>
       </item>
       <item>
         <table>3</table>
         <row>14</row>
       </item>
       <item>
-        <table>7</table>
-        <row>3</row>
-      </item>
-      <item>
         <table>4</table>
-        <row>11</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>7</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>22</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>24</row>
-      </item>
-      <item>
-        <table>1a</table>
         <row>1</row>
       </item>
       <item>
+        <table>4</table>
+        <row>23</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>3</row>
+      </item>
+      <item>
         <table>3</table>
+        <row>20</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>8</row>
+      </item>
+      <item>
+        <table>4</table>
         <row>11</row>
       </item>
       <item>
-        <table>7</table>
-        <row>7</row>
-      </item>
-      <item>
         <table>4</table>
-        <row>25</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>13</row>
+        <row>9</row>
       </item>
       <item>
         <table>3</table>
-        <row>17</row>
+        <row>13</row>
       </item>
       <item>
         <table>2</table>
         <row>2</row>
       </item>
       <item>
-        <table>3</table>
-        <row>23</row>
-      </item>
-      <item>
-        <table>1</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>1</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>4</row>
-      </item>
-      <item>
         <table>4</table>
         <row>12</row>
       </item>
       <item>
-        <table>4</table>
-        <row>16</row>
+        <table>3</table>
+        <row>23</row>
       </item>
       <item>
         <table>1a</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>9</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>6</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>20</row>
+        <row>1</row>
       </item>
       <item>
         <table>7</table>
         <row>4</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>11</row>
+      </item>
+      <item>
+        <table>7</table>
+        <row>7</row>
       </item>
       <item>
         <table>4</table>
@@ -991,13 +872,65 @@
       </item>
       <item>
         <table>4</table>
+        <row>13</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>6</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>4</row>
+      </item>
+      <item>
+        <table>3</table>
         <row>2</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>22</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>16</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>20</row>
+      </item>
+      <item>
+        <table>1</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>1a</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>1</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>17</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>9</row>
       </item>
     </profile>
     <profile>
       <name>SM</name>
       <item>
         <table>2</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>2</table>
         <row>5</row>
       </item>
       <item>
@@ -1005,20 +938,12 @@
         <row>2</row>
       </item>
       <item>
-        <table>4</table>
-        <row>3</row>
+        <table>5</table>
+        <row>2</row>
       </item>
       <item>
         <table>2</table>
         <row>1</row>
-      </item>
-      <item>
-        <table>2</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>5</table>
-        <row>2</row>
       </item>
       <item>
         <table>7</table>
@@ -1029,20 +954,24 @@
         <row>1</row>
       </item>
       <item>
-        <table>5</table>
-        <row>3</row>
-      </item>
-      <item>
         <table>4</table>
         <row>1</row>
       </item>
       <item>
+        <table>5</table>
+        <row>3</row>
+      </item>
+      <item>
         <table>2</table>
-        <row>4</row>
+        <row>2</row>
       </item>
       <item>
         <table>7</table>
         <row>1</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>2</row>
       </item>
       <item>
         <table>7</table>
@@ -1053,10 +982,6 @@
         <row>1</row>
       </item>
       <item>
-        <table>2</table>
-        <row>2</row>
-      </item>
-      <item>
         <table>5</table>
         <row>1</row>
       </item>
@@ -1065,51 +990,31 @@
         <row>2</row>
       </item>
       <item>
-        <table>4</table>
-        <row>2</row>
+        <table>5</table>
+        <row>4</row>
       </item>
       <item>
         <table>6</table>
         <row>1</row>
-      </item>
-      <item>
-        <table>5</table>
-        <row>4</row>
       </item>
     </profile>
     <profile>
       <name>ATT</name>
       <item>
-        <table>5</table>
-        <row>4</row>
+        <table>3</table>
+        <row>29</row>
       </item>
       <item>
         <table>3</table>
         <row>19</row>
       </item>
       <item>
-        <table>4</table>
-        <row>22</row>
+        <table>1</table>
+        <row>1</row>
       </item>
       <item>
         <table>4</table>
         <row>25</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>26</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>15</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>1</table>
-        <row>1</row>
       </item>
       <item>
         <table>4</table>
@@ -1120,24 +1025,36 @@
         <row>2</row>
       </item>
       <item>
-        <table>4</table>
-        <row>10</row>
-      </item>
-      <item>
         <table>3</table>
         <row>4</row>
       </item>
       <item>
-        <table>3</table>
-        <row>29</row>
+        <table>5</table>
+        <row>4</row>
       </item>
       <item>
         <table>4</table>
         <row>15</row>
       </item>
       <item>
+        <table>3</table>
+        <row>26</row>
+      </item>
+      <item>
         <table>4</table>
         <row>20</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>22</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>15</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>10</row>
       </item>
       <item>
         <table>3</table>
@@ -1145,15 +1062,43 @@
       </item>
       <item>
         <table>3</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>6</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>11</row>
+      </item>
+      <item>
+        <table>3</table>
         <row>7</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>17</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>6</row>
       </item>
       <item>
         <table>3</table>
         <row>11</row>
       </item>
       <item>
+        <table>4</table>
+        <row>18</row>
+      </item>
+      <item>
         <table>3</table>
         <row>23</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>1</row>
       </item>
       <item>
         <table>4</table>
@@ -1161,23 +1106,23 @@
       </item>
       <item>
         <table>3</table>
-        <row>6</row>
+        <row>17</row>
       </item>
       <item>
-        <table>5</table>
-        <row>7</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>8</row>
+        <table>4</table>
+        <row>1</row>
       </item>
       <item>
         <table>3</table>
-        <row>2</row>
+        <row>21</row>
       </item>
       <item>
         <table>4</table>
         <row>8</row>
+      </item>
+      <item>
+        <table>5</table>
+        <row>7</row>
       </item>
       <item>
         <table>3</table>
@@ -1193,51 +1138,47 @@
       </item>
       <item>
         <table>3</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>30</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>11</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>17</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>6</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>18</row>
+        <row>8</row>
       </item>
       <item>
         <table>3</table>
-        <row>17</row>
+        <row>2</row>
       </item>
       <item>
         <table>4</table>
-        <row>1</row>
+        <row>3</row>
       </item>
       <item>
-        <table>3</table>
+        <table>4</table>
+        <row>4</row>
+      </item>
+      <item>
+        <table>4</table>
         <row>21</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>25</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>9</row>
       </item>
       <item>
         <table>2</table>
         <row>2</row>
       </item>
       <item>
-        <table>4</table>
-        <row>14</row>
+        <table>3</table>
+        <row>16</row>
       </item>
       <item>
         <table>4</table>
         <row>26</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>13</row>
       </item>
       <item>
         <table>3</table>
@@ -1245,31 +1186,27 @@
       </item>
       <item>
         <table>4</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>21</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>25</row>
-      </item>
-      <item>
-        <table>3</table>
-        <row>27</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>3</row>
+        <row>23</row>
       </item>
       <item>
         <table>3</table>
         <row>24</row>
       </item>
       <item>
+        <table>4</table>
+        <row>5</row>
+      </item>
+      <item>
         <table>3</table>
-        <row>16</row>
+        <row>27</row>
+      </item>
+      <item>
+        <table>3</table>
+        <row>20</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>14</row>
       </item>
       <item>
         <table>1</table>
@@ -1284,24 +1221,8 @@
         <row>29</row>
       </item>
       <item>
-        <table>4</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>9</row>
-      </item>
-      <item>
         <table>3</table>
-        <row>20</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>13</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>23</row>
+        <row>14</row>
       </item>
       <item>
         <table>4</table>
@@ -1313,11 +1234,11 @@
       </item>
       <item>
         <table>4</table>
-        <row>27</row>
+        <row>24</row>
       </item>
       <item>
-        <table>4</table>
-        <row>24</row>
+        <table>3</table>
+        <row>28</row>
       </item>
       <item>
         <table>3</table>
@@ -1332,20 +1253,44 @@
         <row>7</row>
       </item>
       <item>
-        <table>3</table>
-        <row>14</row>
-      </item>
-      <item>
         <table>4</table>
         <row>16</row>
       </item>
       <item>
-        <table>3</table>
-        <row>28</row>
+        <table>4</table>
+        <row>27</row>
       </item>
     </profile>
     <profile>
       <name>MESH</name>
+      <item>
+        <table>4</table>
+        <row>9</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>5</row>
+      </item>
+      <item>
+        <table>7</table>
+        <row>4</row>
+      </item>
+      <item>
+        <table>14</table>
+        <row>5</row>
+      </item>
+      <item>
+        <table>5</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>1</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>7</table>
+        <row>5</row>
+      </item>
       <item>
         <table>7</table>
         <row>1</row>
@@ -1359,75 +1304,39 @@
         <row>3</row>
       </item>
       <item>
-        <table>6</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>6</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>14</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>1</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>7</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>2</row>
-      </item>
-      <item>
         <table>2</table>
         <row>1</row>
       </item>
       <item>
-        <table>7</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>5</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>5</row>
-      </item>
-      <item>
-        <table>0a</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>9</row>
-      </item>
-      <item>
-        <table>16</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>14</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>16</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>16</table>
+        <table>6</table>
         <row>3</row>
       </item>
       <item>
+        <table>16</table>
+        <row>4</row>
+      </item>
+      <item>
         <table>0a</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>4</row>
+      </item>
+      <item>
+        <table>6</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>11</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>14</table>
         <row>2</row>
       </item>
       <item>
@@ -1435,16 +1344,24 @@
         <row>2</row>
       </item>
       <item>
+        <table>5</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>16</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>0a</table>
+        <row>2</row>
+      </item>
+      <item>
         <table>7</table>
         <row>3</row>
       </item>
       <item>
-        <table>11</table>
+        <table>16</table>
         <row>2</row>
-      </item>
-      <item>
-        <table>5</table>
-        <row>3</row>
       </item>
       <item>
         <table>0</table>
@@ -1455,8 +1372,24 @@
         <row>3</row>
       </item>
       <item>
+        <table>4</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>4</table>
+        <row>8</row>
+      </item>
+      <item>
+        <table>14</table>
+        <row>1</row>
+      </item>
+      <item>
         <table>3</table>
         <row>2</row>
+      </item>
+      <item>
+        <table>16</table>
+        <row>1</row>
       </item>
       <item>
         <table>3</table>
@@ -1467,71 +1400,19 @@
         <row>1</row>
       </item>
       <item>
-        <table>14</table>
-        <row>1</row>
-      </item>
-      <item>
         <table>4</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>16</table>
         <row>1</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>8</row>
       </item>
       <item>
         <table>4</table>
         <row>12</row>
       </item>
       <item>
-        <table>12</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>8</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>6</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>10</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>12</table>
-        <row>2</row>
-      </item>
-      <item>
-        <table>4</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>10</table>
-        <row>1</row>
-      </item>
-      <item>
-        <table>10</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>14</table>
-        <row>3</row>
-      </item>
-      <item>
-        <table>12</table>
-        <row>4</row>
-      </item>
-      <item>
-        <table>13</table>
-        <row>1</row>
-      </item>
-      <item>
         <table>11</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>10</table>
         <row>1</row>
       </item>
       <item>
@@ -1541,6 +1422,42 @@
       <item>
         <table>14</table>
         <row>4</row>
+      </item>
+      <item>
+        <table>10</table>
+        <row>4</row>
+      </item>
+      <item>
+        <table>14</table>
+        <row>3</row>
+      </item>
+      <item>
+        <table>12</table>
+        <row>4</row>
+      </item>
+      <item>
+        <table>6</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>12</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>10</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>12</table>
+        <row>2</row>
+      </item>
+      <item>
+        <table>8</table>
+        <row>1</row>
+      </item>
+      <item>
+        <table>13</table>
+        <row>1</row>
       </item>
       <item>
         <table>4</table>


### PR DESCRIPTION
There were some wrong ICS settings selected int .pts file
e.g. SM OOB was enabled.

This file was generated in Launch Studio by importing
autopts-zephyr-1.14.pts file and resolving consistency issues.