### PR TITLE
Fix missing Python coloredlogs module requirement

### DIFF
--- a/autoptsclient_requirements.txt
+++ b/autoptsclient_requirements.txt
@@ -1,3 +1,4 @@
 termcolor
 pyserial
 wheel
+coloredlogs


### PR DESCRIPTION
missing module used in ptsprojects/mynewt/gatt.py