### PR TITLE
WID69 - parsing correction

### DIFF
--- a/ptsprojects/mynewt/gatt_wid.py
+++ b/ptsprojects/mynewt/gatt_wid.py
@@ -662,7 +662,7 @@ def hdl_wid_69(desc):
         return False
 
     handle = int(MMI.args[0], 16)
-    size = int(MMI.args[1], 16)
+    size = int(MMI.args[1], 10)
 
     btp.gattc_write_long(btp.pts_addr_type_get(), btp.pts_addr_get(),
                          handle, 0, '12', size)


### PR DESCRIPTION
Size value was cast to hexadecimal, corrected to decimal.