### PR TITLE
mynewt: Clean up IutCtl and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Then start the AutoPTS Client using e.g. own workspace file:
 
 **Testing Mynewt build on nRF52**:
 
-    ./autoptsclient-mynewt.py Mynewt\ Nimble\ Host -i SERVER_IP -l LOCAL_IP -t /dev/ttyACM0 -b nordic_pca10056
+    ./autoptsclient-mynewt.py "Mynewt Nimble Host" -i SERVER_IP -l LOCAL_IP -t /dev/ttyACM0 -b nordic_pca10056
 
 # Running AutoPTSClientBot
 

--- a/autoptsclient-mynewt.py
+++ b/autoptsclient-mynewt.py
@@ -15,7 +15,7 @@
 # more details.
 #
 
-"""Zephyr auto PTS client"""
+"""Mynewt auto PTS client"""
 
 import os
 import sys
@@ -31,9 +31,7 @@ from ptsprojects.mynewt.iutctl import get_iut
 def check_args(args):
     """Sanity check command line arguments"""
 
-    qemu_bin = autoprojects.iutctl.QEMU_BIN
     tty_file = args.tty_file
-    kernel_image = args.kernel_image
     ip_addr = args.ip_addr
 
     if not ip_addr:
@@ -46,23 +44,15 @@ def check_args(args):
         if not os.path.exists(tty_file):
             sys.exit("%s TTY file does not exist!" % repr(tty_file))
 
-    if not os.path.isfile(kernel_image):
-        sys.exit("kernel_image %s is not a file!" % repr(kernel_image))
-
 
 def parse_args():
     """Parses command line arguments and options"""
 
     arg_parser = autoptsclient.CliParser("PTS automation client")
 
-    # IUT specific arguments below
-    arg_parser.add_argument("kernel_image",
-                            help="Zephyr OS kernel image to be used for "
-                            "testing. Normally a mynewt.elf file.")
-
     arg_parser.add_argument("-t", "--tty-file",
                             help="If TTY is specified, BTP communication "
-                            "with Zephyr OS running on hardware will "
+                            "with Mynewt OS running on hardware will "
                             "be done over this TTY. Hence, QEMU will "
                             "not be used.")
 
@@ -102,7 +92,7 @@ def main():
     ptses = autoptsclient.init_pts(args, callback_thread, tc_db_table_name)
 
     btp.init(get_iut)
-    autoprojects.iutctl.init(args.kernel_image, args.tty_file, args.board)
+    autoprojects.iutctl.init(args.tty_file, args.board)
 
     stack.init_stack()
     stack_inst = stack.get_stack()

--- a/ptsprojects/mynewt/iutctl.py
+++ b/ptsprojects/mynewt/iutctl.py
@@ -25,34 +25,24 @@ from pybtp.iutctl_common import BTPWorker, BTP_ADDRESS
 
 log = logging.debug
 MYNEWT = None
-
-# qemu binary should be installed in shell PATH
-QEMU_BIN = "qemu-system-arm"
-
-# qemu log file object
 IUT_LOG_FO = None
-
 SERIAL_BAUDRATE = 115200
 
 
 class MynewtCtl:
     '''Mynewt OS Control Class'''
 
-    def __init__(self, kernel_image, tty_file, board_name=None):
+    def __init__(self, tty_file, board_name):
         """Constructor."""
-        log("%s.%s kernel_image=%s tty_file=%s board_name=%s",
-            self.__class__, self.__init__.__name__, kernel_image, tty_file,
+        log("%s.%s tty_file=%s board_name=%s",
+            self.__class__, self.__init__.__name__, tty_file,
             board_name)
 
-        self.kernel_image = kernel_image
+        assert tty_file and board_name
+
         self.tty_file = tty_file
+        self.board = Board(board_name, tty_file)
 
-        if self.tty_file and board_name:  # DUT is a hardware board, not QEMU
-            self.board = Board(board_name, kernel_image, tty_file)
-        else:  # DUT is QEMU or a board that won't be reset
-            self.board = None
-
-        self.qemu_process = None
         self.socat_process = None
         self.btp_socket = None
 
@@ -94,10 +84,6 @@ class MynewtCtl:
         self.stop()
         self.start()
         self.flush_serial()
-
-        if not self.board:
-            return
-
         self.board.reset()
 
     def wait_iut_ready_event(self):
@@ -153,22 +139,17 @@ class Board:
         'nordic_pca10056'
     ]
 
-    def __init__(self, board_name, kernel_image, tty_file):
+    def __init__(self, board_name, tty_file):
         """Constructor of board"""
         if board_name not in self.names:
             raise Exception("Board name %s is not supported!" % board_name)
 
         self.name = board_name
-        self.kernel_image = kernel_image
         self.tty_file = tty_file
         self.reset_cmd = self.get_reset_cmd()
 
     def reset(self):
-        """Reset HW DUT board with openocd
-
-        With introduction of persistent storage in DUT flashing kernel image in
-        addition to reset will become necessary
-
+        """Reset HW DUT board with
         """
         log("About to reset DUT: %r", self.reset_cmd)
 
@@ -179,22 +160,6 @@ class Board:
 
         if reset_process.wait():
             logging.error("reset failed")
-
-        # success = False
-        # retry_max = 1
-        # retry_count = 0
-        #
-        # while (not success) and (retry_count < retry_max):
-        #     reset_process = subprocess.Popen(shlex.split(self.reset_cmd),
-        #                                      shell=False,
-        #                                      stdout=IUT_LOG_FO,
-        #                                      stderr=IUT_LOG_FO)
-        #     if reset_process.wait() != 0:
-        #         logging.error("reset failed")
-        #         retry_count += 1
-        #         time.sleep(5)
-        #     else:
-        #         success = True
 
     def get_reset_cmd(self):
         """Return reset command for a board"""
@@ -212,21 +177,19 @@ def init_stub():
     MYNEWT = MynewtCtlStub()
 
 
-def init(kernel_image, tty_file, board=None):
+def init(tty_file, board):
     """IUT init routine
 
-    kernel_image -- Path to Mynewt kernel image
-    tty_file -- Path to TTY file, if specified QEMU will not be used and
-                BTP communication with HW DUT will be done over this TTY.
-    board -- HW DUT board to use for testing. This parameter is used only
-             if tty_file is specified
+    tty_file -- Path to TTY file. BTP communication with HW DUT will be done
+    over this TTY.
+    board -- HW DUT board to use for testing.
     """
     global IUT_LOG_FO
     global MYNEWT
 
     IUT_LOG_FO = open("iut-mynewt.log", "w")
 
-    MYNEWT = MynewtCtl(kernel_image, tty_file, board)
+    MYNEWT = MynewtCtl(tty_file, board)
 
 
 def cleanup():


### PR DESCRIPTION
Remove mention of Zephyr, redundant argument and mention of QEMU.