### PR TITLE
Multiple WID corrections

### DIFF
--- a/ptsprojects/mynewt/gap.py
+++ b/ptsprojects/mynewt/gap.py
@@ -73,7 +73,7 @@ init_gatt_db = [TestFunc(btp.core_reg_svc_gatt),
 
 iut_device_name = 'Tester'
 iut_manufacturer_data = 'ABCD'
-iut_ad_uri = '162F'
+iut_ad_uri = '000168747470733A2F2F7777772E626C7565746F'
 iut_appearance = '1111'
 iut_svc_data = '1111'
 iut_flags = '11'
@@ -174,7 +174,7 @@ def set_pixits(pts):
     pts.set_pixit("GAP",
                   "TSPX_iut_device_name_in_adv_packet_for_random_address", iut_device_name)
     pts.set_pixit("GAP", "TSPX_Tgap_104", "60000")
-    pts.set_pixit("GAP", "TSPX_URI", "162F2F7777772E626C7565746F6F74682E636F6D")
+    pts.set_pixit("GAP", "TSPX_URI", "000168747470733A2F2F7777772E626C7565746F")
 
 
 def test_cases(pts):

--- a/ptsprojects/mynewt/gatt_wid.py
+++ b/ptsprojects/mynewt/gatt_wid.py
@@ -662,7 +662,7 @@ def hdl_wid_69(desc):
         return False
 
     handle = int(MMI.args[0], 16)
-    size = int(MMI.args[1], 16)
+    size = int(MMI.args[1], 10)
 
     btp.gattc_write_long(btp.pts_addr_type_get(), btp.pts_addr_get(),
                          handle, 0, '12', size)
@@ -809,15 +809,15 @@ def hdl_wid_81(desc):
     MMI.reset()
     MMI.parse_description(desc)
 
-    hdl = MMI.args[0]
-    val_mtp = int(MMI.args[1], 16)
+    hdl = int(MMI.args[0], 16)
+    val_mtp = int(MMI.args[1], 10)+1
 
     if not hdl or not val_mtp:
         logging.error("parsing error")
         return False
 
     btp.gattc_write_long(btp.pts_addr_type_get(), btp.pts_addr_get(),
-                         hdl, 0, '1234', val_mtp)
+                         hdl, 0, '1', val_mtp)
 
     btp.gattc_write_long_rsp(True)
 


### PR DESCRIPTION
- WID 69 - size value was cast to hexadecimal, corrected to decimal.
- WID 81 - added casting of hdl and val_mtp to int, val_mtp should be larger than in WID message, so 1 was added, changed value from 4 octets to 1