### PR TITLE
Mynewt: WID 81 correction

### DIFF
--- a/ptsprojects/mynewt/gatt_wid.py
+++ b/ptsprojects/mynewt/gatt_wid.py
@@ -817,7 +817,7 @@ def hdl_wid_81(desc):
         return False
 
     btp.gattc_write_long(btp.pts_addr_type_get(), btp.pts_addr_get(),
-                         hdl, 0, '1', val_mtp)
+                         hdl, 0, '11', val_mtp)
 
     btp.gattc_write_long_rsp(True)
 


### PR DESCRIPTION
Test was failing for odd values of val_mtp, because multiplied string was of length 1, and should be even. Switched to value '11' of length 2.