### PR TITLE
btp: changed VERIFY_VALUES saving for gattc_read_uuid_rsp

### DIFF
--- a/pybtp/btp.py
+++ b/pybtp/btp.py
@@ -2633,7 +2633,11 @@ def gattc_read_uuid_rsp(store_rsp=False, store_val=False):
             VERIFY_VALUES.append(att_rsp_str[rsp])
 
         if store_val:
-            VERIFY_VALUES.append((binascii.hexlify(value[0])).upper())
+            n = len(value[0])
+            value = (binascii.hexlify(value[0])).upper()
+            if value != '':
+                chunks = [value[i:i+len(value)/n] for i in range(0, len(value), len(value)/n)]
+                VERIFY_VALUES.extend(chunks)
 
 
 def gattc_read_long_rsp(store_rsp=False, store_val=False):


### PR DESCRIPTION
In wid 50 data was required to mach against PTS querry. Previously, that data was countinous string wich caused failed checks. Now, this data is split into characters (modified gattc_read_uuid_rsp).