### PR TITLE
Mynewt: gatt_wid_76 patched (GATT/CL/GAW/BV-05-C) - mtp_value

### DIFF
--- a/ptsprojects/mynewt/gatt_wid.py
+++ b/ptsprojects/mynewt/gatt_wid.py
@@ -760,7 +760,7 @@ def hdl_wid_76(desc):
 
     btp.gattc_write_reliable(btp.pts_addr_type_get(),
                              btp.pts_addr_get(),
-                             MMI.args[0], 0, '12', MMI.args[1])
+                             MMI.args[0], 0, '12', 1)
 
     btp.gattc_write_reliable_rsp(True)
 


### PR DESCRIPTION
PTS asks for prepare write request with data length less or equal than some random value. This value can be larger than 512, which may cause problems with current configuration. Because used value can be smaller than requested, value of 1 always works.