### PR TITLE
Mynewt: gap_wid_77 correction

### DIFF
--- a/ptsprojects/mynewt/gap_wid.py
+++ b/ptsprojects/mynewt/gap_wid.py
@@ -371,7 +371,6 @@ def hdl_wid_76(desc):
 
 
 def hdl_wid_77(desc):
-    time.sleep(2)
     btp.gap_disconn()
     return True
 


### PR DESCRIPTION
In test In test GAP/BOND/BON/BV-04-C sleep(2) causes inconclusive result.
Removing it fixes the issue.