### PR TITLE
[RFC] doc: Add MTU parameter to the Get Attribute Value response

### DIFF
--- a/doc/btp_spec.txt
+++ b/doc/btp_spec.txt
@@ -1290,6 +1290,7 @@ Commands and responses:
 					Address (6 octets)
 					Handle (2 octets)
 		Response parameters:	ATT_Response (1 octet)
+					MTU (2 octets)
 					Value_Length (2 octet)
 					Value (variable)
 


### PR DESCRIPTION
In test cases like GATT/SR/GAR/BV-01-C and GATT/SR/GAR/BV-06-C
the PTS will randomly choose a handle on which it will perform
ATT_Read_Request. If the value is longer than ATT_MTU then
only the first ATT_MTU-1 octets will be included in the response.
PTS then asks the Upper Tester to verify if IUT's database
contains such value under that handle. In that situation
the Upper tester will compare the actual value (which is long)
with the short one returned by PTS. This will cause the test
to fail randomly.

A proposed solution is to include a return parameter to the
Get Attribute Value Response so that we can compare up to
(ATT_MTU-1) bytes of value if the length of both values does
not match.