### PR TITLE
btp: use try/except around close socket to iut

### DIFF
--- a/pybtp/iutctl_common.py
+++ b/pybtp/iutctl_common.py
@@ -122,13 +122,14 @@ class BTPSocket(object):
         self.conn.send(bin)
 
     def close(self):
-        self.sock.shutdown(socket.SHUT_RDWR)
-        self.sock.close()
-
+        try:
+            self.sock.shutdown(socket.SHUT_RDWR)
+            self.sock.close()
+        except:
+            pass
         self.sock = None
         self.conn = None
         self.addr = None
-
 
 class BTPWorker(BTPSocket):
     def __init__(self):


### PR DESCRIPTION
If the socket to btpclient is down and we try to close it, it will cause an exception. This minor patch wraps the call in try/except to ignore it.