### PR TITLE
btp: fix core_log_message

### DIFF
--- a/pybtp/btp.py
+++ b/pybtp/btp.py
@@ -545,9 +545,7 @@ def core_unreg_svc_rsp_succ():
 def core_log_message(message):
     logging.debug("%s", core_log_message.__name__)
 
-    message_data = bytearray(message)
-    data = struct.pack('H', len(message_data))
-    data.extend(message_data)
+    data = bytearray( struct.pack('H', len(message)) + message)
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*CORE['log_message'], data=data)


### PR DESCRIPTION
Existing code causes a run time error with Python 2.7, where the result from struct.pack(..) is a string, which does not have an extend method. The new code does not work with Python 3.x. Any suggestion for a clean Python 2+3 compatible implementation? 