### PR TITLE
Zephyr: gap wid51 synced with spec

### DIFF
--- a/ptsprojects/zephyr/gap_wid.py
+++ b/ptsprojects/zephyr/gap_wid.py
@@ -208,8 +208,8 @@ def hdl_wid_50(desc):
 def hdl_wid_51(desc):
     stack = get_stack()
 
+    btp.gap_set_nonconn()
     btp.gap_set_gendiscov()
-
     btp.gap_adv_ind_on(ad=stack.gap.ad)
 
     return True


### PR DESCRIPTION
Tests performed with Python 3 port of auto-pts revealed inconsistency
with spec in this wid. GAP/DISC/GENM/BV-03-C is passing in current
version, but not in  port. Although it's currently not affecting tests,
wid should call btp.gap_set_nonconn(), as instructed in TS.