### PR TITLE
Zephyr: correct deprecated board name

### DIFF
--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -155,7 +155,7 @@ def apply_overlay(zephyr_wd, base_conf, cfg_name, overlay):
 
 autopts2board = {
     None: None,
-    'nrf52': 'nrf52840_pca10056',
+    'nrf52': 'nrf52840dk_nrf52840',
     'reel_board' : 'reel_board'
 }
 


### PR DESCRIPTION
name "nrf52840_pca10056" is deprecated and "nrf52840dk_nrf52840"
should be used