### PR TITLE
common: Fix retry in test cases

### DIFF
--- a/autoptsclient_common.py
+++ b/autoptsclient_common.py
@@ -800,6 +800,7 @@ def run_test_case(ptses, test_case_instances, test_case_name, stats, session_log
         # FIXME
         return 'NOT_IMPLEMENTED'
 
+    test_case_lt1.reset()
     test_case_lt1.initialize_logging(session_log_dir)
     file_handler = logging.FileHandler(test_case_lt1.log_filename)
     file_handler.setFormatter(formatter)

--- a/ptsprojects/testcase.py
+++ b/ptsprojects/testcase.py
@@ -408,6 +408,10 @@ class TestCase(PTSCallback):
         self.log_filename = log_filename
         self.log_dir = log_dir
 
+    def reset(self):
+        self.status = "init"
+        self.state = None
+
     def __str__(self):
         """Returns string representation"""
         return "%s %s" % (self.project_name, self.name)


### PR DESCRIPTION
Test cases were already past the init state and the test runner would
get stuck in an infinite loop. Previously the test cases were copied
so this was not a problem.