### PR TITLE
fix for Bluez documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Then start the AutoPTS Client using e.g. own workspace file:
 
     ./autoptsclient-mynewt.py "Mynewt Nimble Host" -i SERVER_IP -l LOCAL_IP -t /dev/ttyACM0 -b nordic_pca10056
 
-**Testing BlueZ on Linux
+**Testing BlueZ on Linux**:
 
 See [ptsprojects/bluez/README.md](./ptsprojects/bluez/README.md)
 


### PR DESCRIPTION
this is just minor fix on documentation page to format correctly.