### PR TITLE
wid: Fix L2CAP WID_43 and WID_38 for PTS 8.0.0

### DIFF
--- a/wid/l2cap.py
+++ b/wid/l2cap.py
@@ -109,6 +109,20 @@ def hdl_wid_37(desc):
 
     return data[0] == tx_data[0]
 
+def hdl_wid_38(desc):
+    """
+    Implements: TSC_MMI_upper_tester_send_LE_data_packet1
+    :param desc: Upper Tester command IUT to send a nonsegmented LE data packet to the PTS with any values.
+    :return:
+    """
+    stack = get_stack()
+    channel = stack.l2cap._chan_lookup_id(0)
+    if not channel:
+        return False
+
+    btp.l2cap_send_data(0, 'FF')
+    return True
+
 
 def hdl_wid_39(desc):
     """

--- a/wid/l2cap.py
+++ b/wid/l2cap.py
@@ -181,8 +181,12 @@ def hdl_wid_43(desc):
     :return:
     """
     stack = get_stack()
+    l2cap = stack.l2cap
+    channel = l2cap._chan_lookup_id(0)
+    if not channel:
+        return False
 
-    btp.l2cap_send_data(0, "FF", 21)
+    btp.l2cap_send_data(0, 'FF' * channel.peer_mps)
 
     return True
 


### PR DESCRIPTION
They are used by L2CAP/COS/CFC/BV-01-C and L2CAP/COS/CFC/BV-02-C.