### PR TITLE
zephyr: multi dut support with nrf5340

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This may contain few sections:
     - `project_path` - path to project source directory
     - `workspace` - PTS workspace path to be used
     - `board` - IUT used. Currently nrf52 is supported only
-    - `board_id` - Segger ID of the IUT used.
+    - `board_id` - Serial number of the IUT used.
     - `enable_max_logs` - enable debug logs
     - `retry` - maximum repeat count per test
     - `bd_addr` - IUT Bluetooth Address (optional)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ This may contain few sections:
     - `project_path` - path to project source directory
     - `workspace` - PTS workspace path to be used
     - `board` - IUT used. Currently nrf52 is supported only
+    - `board_id` - Segger ID of the IUT used.
     - `enable_max_logs` - enable debug logs
     - `retry` - maximum repeat count per test
     - `bd_addr` - IUT Bluetooth Address (optional)

--- a/bot/config.py.zephyr.sample
+++ b/bot/config.py.zephyr.sample
@@ -32,6 +32,7 @@ z['auto_pts'] = {
     'project_path': '/path/to/project',
     'workspace': 'zephyr-master',
     'board': 'nrf52',
+    'board_id': '',
     'enable_max_logs': False,
     'retry': 2,
     'bd_addr': '',

--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -87,26 +87,29 @@ def source_zephyr_env(zephyr_wd):
     return env
 
 
-def build_and_flash(zephyr_wd, board, conf_file=None):
+def build_and_flash(zephyr_wd, board, board_id, conf_file=None):
     """Build and flash Zephyr binary
     :param zephyr_wd: Zephyr source path
     :param board: IUT
+    :param board_id: Segger ID
     :param conf_file: configuration file to be used
     :return: TTY path
     """
-    logging.debug("{}: {} {} {}". format(build_and_flash.__name__, zephyr_wd,
-                                         board, conf_file))
+    logging.debug("{}: {} {} {} {}". format(build_and_flash.__name__,
+                                            zephyr_wd, board,
+                                            board_id, conf_file))
     tester_dir = os.path.join(zephyr_wd, "tests", "bluetooth", "tester")
 
     # Set Zephyr project env variables
     env = source_zephyr_env(zephyr_wd)
 
-    cmd = ['west',  'build', '-p', 'auto', '-b', board]
+    cmd_build = ['west',  'build', '-p', 'auto', '-b', board]
     if conf_file:
-        cmd.extend(('--', '-DCONF_FILE={}'.format(conf_file)))
+        cmd_build.extend(('--', '-DCONF_FILE={}'.format(conf_file)))
+    check_call(cmd_build, env=env, cwd=tester_dir)
 
-    check_call(cmd, env=env, cwd=tester_dir)
-    check_call(['west', 'flash'], env=env, cwd=tester_dir)
+    cmd_flash = ['west', 'flash', '--snr', board_id]
+    check_call(cmd_flash, env=env, cwd=tester_dir)
 
     return get_tty_path("J-Link")
 
@@ -272,7 +275,8 @@ def run_tests(args, iut_config):
                           value['overlay'])
 
         tty = build_and_flash(args["project_path"],
-                              autopts2board[args["board"]],
+                              args["board"],
+                              args["board_id"],
                               config)
         logging.debug("TTY path: %s" % tty)
 

--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -161,13 +161,6 @@ def apply_overlay(zephyr_wd, base_conf, cfg_name, overlay):
     os.chdir(cwd)
 
 
-autopts2board = {
-    None: None,
-    'nrf52': 'nrf52840dk_nrf52840',
-    'reel_board' : 'reel_board'
-}
-
-
 def get_tty_path(name):
     """Returns tty path (eg. /dev/ttyUSB0) of serial device with specified name
     :param name: device name

--- a/ptsprojects/zephyr/iutctl.py
+++ b/ptsprojects/zephyr/iutctl.py
@@ -22,6 +22,8 @@ import serial
 from pybtp import defs
 from pybtp.types import BTPError
 from pybtp.iutctl_common import BTPWorker, BTP_ADDRESS, RTT2PTY
+from bot.config import BotProjects
+
 
 log = logging.debug
 ZEPHYR = None
@@ -312,7 +314,7 @@ class Board:
         Dependency: nRF5x command line tools
 
         """
-        return 'nrfjprog -f nrf52 -r'
+        return 'nrfjprog -f nrf52 -s {} -r'.format(BotProjects[0]['auto_pts']['board_id'])
 
     def _get_reset_cmd_reel(self):
         """Return reset command for Reel_Board DUT

--- a/ptsprojects/zephyr/iutctl.py
+++ b/ptsprojects/zephyr/iutctl.py
@@ -209,14 +209,14 @@ class Board:
 
     arduino_101 = "arduino_101"
     c1000 = "c1000"
-    nrf52 = "nrf52"
+    nrf5x = "nrf5x"
     reel  = "reel_board"
 
     # for command line options
     names = [
         arduino_101,
         c1000,
-        nrf52,
+        nrf5x,
         reel
     ]
 
@@ -268,7 +268,7 @@ class Board:
         reset_cmd_getters = {
             self.arduino_101: self._get_reset_cmd_arduino_101,
             self.c1000: self._get_reset_cmd_c1000,
-            self.nrf52: self._get_reset_cmd_nrf52,
+            self.nrf5x: self._get_reset_cmd_nrf5x,
             self.reel: self._get_reset_cmd_reel
         }
 
@@ -308,13 +308,13 @@ class Board:
         return self.get_openocd_reset_cmd(openocd_bin, openocd_scripts,
                                           openocd_cfg)
 
-    def _get_reset_cmd_nrf52(self):
-        """Return reset command for nRF52 DUT
+    def _get_reset_cmd_nrf5x(self):
+        """Return reset command for nRF52 and nRF53 DUT
 
         Dependency: nRF5x command line tools
 
         """
-        return 'nrfjprog -f nrf52 -s {} -r'.format(BotProjects[0]['auto_pts']['board_id'])
+        return 'nrfjprog -r -s ' + BotProjects[0]['auto_pts']['board_id']
 
     def _get_reset_cmd_reel(self):
         """Return reset command for Reel_Board DUT
@@ -345,7 +345,8 @@ def init(kernel_image, tty_file, board=None, use_rtt2pty=False):
     """
     global ZEPHYR
 
-    ZEPHYR = ZephyrCtl(kernel_image, tty_file, board, use_rtt2pty)
+    board_family = (board[:4] + 'x') if ('nrf5' in board) else board
+    ZEPHYR = ZephyrCtl(kernel_image, tty_file, board_family, use_rtt2pty)
 
 
 def cleanup():


### PR DESCRIPTION
Multi device support with given segger id (board id). More than one device can be connected simultaneously.
Tried with nrf52832, nrf52840 and nrf5340
Retains old behaviour if board_id is not given.