### PR TITLE
PTS 8.0.1 Mynewt fixes

### DIFF
--- a/ptsprojects/mynewt/gap_wid.py
+++ b/ptsprojects/mynewt/gap_wid.py
@@ -57,6 +57,15 @@ def hdl_wid_5(desc):
     return True
 
 
+def hdl_wid_9(desc):
+    stack = get_stack()
+
+    btp.gap_set_conn()
+
+    btp.gap_adv_ind_on(ad=stack.gap.ad, sd=stack.gap.sd)
+    return True
+
+
 def hdl_wid_10(desc):
     btp.gap_stop_discov()
     return btp.check_discov_results(discovered=True)

--- a/ptsprojects/mynewt/gatt_wid.py
+++ b/ptsprojects/mynewt/gatt_wid.py
@@ -1293,6 +1293,40 @@ def hdl_wid_147(desc):
     return True
 
 
+def hdl_wid_151(desc):
+    chrcs = btp.gatts_get_attrs(type_uuid='2803')
+    for chrc in chrcs:
+        handle, perm, type_uuid = chrc
+
+        chrc_data = btp.gatts_get_attr_val(btp.pts_addr_type_get(),
+                                           btp.pts_addr_get(), handle)
+        if not chrc_data:
+            continue
+
+        att_rsp, val_len, val = chrc_data
+
+        hdr = '<BH'
+        hdr_len = struct.calcsize(hdr)
+        uuid_len = val_len - hdr_len
+
+        prop, handle, chrc_uuid = struct.unpack("<BH%ds" % uuid_len, val)
+        chrc_value_attr = btp.gatts_get_attrs(start_handle=handle,
+                                              end_handle=handle)
+        if not chrc_value_attr:
+            continue
+
+        handle, perm, type_uuid = chrc_value_attr[0]
+        if perm & Perm.read and perm & Perm.write:
+            chrc_value_data = btp.gatts_get_attr_val(btp.pts_addr_type_get(),
+                                                 btp.pts_addr_get(), handle)
+        if not chrc_value_data:
+            continue
+
+        _, val_len, _ = chrc_value_data
+        if val_len == 1:
+            return '{0:04x}'.format(handle, 'x')
+
+
 def hdl_wid_304(desc):
     MMI.reset()
     MMI.parse_description(desc)

--- a/ptsprojects/mynewt/gatt_wid.py
+++ b/ptsprojects/mynewt/gatt_wid.py
@@ -1327,6 +1327,40 @@ def hdl_wid_151(desc):
             return '{0:04x}'.format(handle, 'x')
 
 
+def hdl_wid_152(desc):
+    chrcs = btp.gatts_get_attrs(type_uuid='2803')
+    for chrc in chrcs:
+        handle, perm, type_uuid = chrc
+
+        chrc_data = btp.gatts_get_attr_val(btp.pts_addr_type_get(),
+                                           btp.pts_addr_get(), handle)
+        if not chrc_data:
+            continue
+
+        att_rsp, val_len, val = chrc_data
+
+        hdr = '<BH'
+        hdr_len = struct.calcsize(hdr)
+        uuid_len = val_len - hdr_len
+
+        prop, handle, chrc_uuid = struct.unpack("<BH%ds" % uuid_len, val)
+        chrc_value_attr = btp.gatts_get_attrs(start_handle=handle,
+                                              end_handle=handle)
+        if not chrc_value_attr:
+            continue
+
+        handle, perm, type_uuid = chrc_value_attr[0]
+        if perm & Perm.read and perm & Perm.write:
+            chrc_value_data = btp.gatts_get_attr_val(btp.pts_addr_type_get(),
+                                                 btp.pts_addr_get(), handle)
+        if not chrc_value_data:
+            continue
+
+        _, val_len, _ = chrc_value_data
+        if val_len == 300:
+            return '{0:04x}'.format(handle, 'x')
+
+
 def hdl_wid_304(desc):
     MMI.reset()
     MMI.parse_description(desc)

--- a/ptsprojects/stack.py
+++ b/ptsprojects/stack.py
@@ -570,6 +570,8 @@ class L2cap:
         if chan is None:
             logging.error("unknown channel")
             return
+        # Remove channel from saved channels
+        self.channels.remove(chan)
 
         chan.disconnected(psm, bd_addr_type, bd_addr, reason)
 

--- a/wid/l2cap.py
+++ b/wid/l2cap.py
@@ -21,7 +21,7 @@ import struct
 import sys
 import time
 
-from ptsprojects.stack import get_stack
+from ptsprojects.stack import get_stack, L2cap
 from pybtp import btp
 from pybtp.types import BTPError
 
@@ -320,6 +320,12 @@ def hdl_wid_100(desc):
 
 
 def hdl_wid_101(desc):
+    # wait for potential pending disconnect events
+    time.sleep(5)
+    stack = get_stack()
+    channels = stack.l2cap.rx_data_get_all(10)
+    if len(channels) == 0:
+        return True
     btp.l2cap_disconn(0)
     return True
 

--- a/wid/l2cap.py
+++ b/wid/l2cap.py
@@ -292,7 +292,7 @@ def hdl_wid_57(desc):
     if not channel:
         return False
 
-    btp.l2cap_send_data(0, '00' * (channel.peer_mps * 4))
+    btp.l2cap_send_data(0, '00' * (channel.peer_mps))
     return True
 
 


### PR DESCRIPTION
Tests that cannot be fixed for now are:
- GAP/SEC/SEM/BV-29-C - PTS errata CASE0070978 - first alternative of test ending is not working
- L2CAP/ECFC/BV-24-C - TSE 15582 - Test demands reconfiguration of MPS, which has static size in Mynewt (as it's not required to be dynamic as per Core spec)