### PR TITLE
l2cap:wid 57 - send 4 frames of peer_mps size

### DIFF
--- a/ptsprojects/mynewt/l2cap.py
+++ b/ptsprojects/mynewt/l2cap.py
@@ -37,7 +37,7 @@ from wid import l2cap_wid_hdl
 le_psm = 128
 le_psm_eatt = 0x27
 psm_unsupported = 241
-le_initial_mtu = 120
+le_initial_mtu = 264
 le_mps = 100
 
 

--- a/wid/l2cap.py
+++ b/wid/l2cap.py
@@ -292,7 +292,7 @@ def hdl_wid_57(desc):
     if not channel:
         return False
 
-    btp.l2cap_send_data(0, '00' * (channel.peer_mps))
+    btp.l2cap_send_data(0, '00' * (channel.peer_mps * 4 - 2))
     return True
 
 


### PR DESCRIPTION
Test L2CAP/LE/CFC/BV-06-C requires from us to send 4 frames of peer_mps
size. The credits allowing IUT to send them are coming in doses of 1, 1
and 2. We need to reserve 2 octets for size field in first frame.