### PR TITLE
var_store_get_wrong_passkey: convert pk to int before comparison

### DIFF
--- a/pybtp/btp.py
+++ b/pybtp/btp.py
@@ -1061,6 +1061,7 @@ def var_store_get_wrong_passkey(description):
     passkey = get_stack().gap.get_passkey()
 
     # Passkey is in range 0-999999
+    passkey = int(passkey)
     if passkey > 0:
         return str(passkey - 1).zfill(6)
     else:


### PR DESCRIPTION
gap_passkey_disp_ev_ saves passkey as string so we need to convert it
to int before comparing to int.