### PR TITLE
bot: Add logs cleanup before running tests and change logs zipping way

### DIFF
--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -45,10 +45,12 @@ import xmlrpc.client
 import xmlrpc.server
 import winutils
 import ptscontrol
+from os.path import dirname, abspath
 from config import SERVER_PORT
 from queue import Queue
 
 log = logging.debug
+PROJECT_DIR = dirname(abspath(__file__))
 
 
 class PyPTSWithXmlRpcCallback(ptscontrol.PyPTS):
@@ -251,7 +253,7 @@ class Server(threading.Thread):
 
         logging.basicConfig(format=format,
                             filename=log_filename,
-                            filemode='w',
+                            filemode='a',
                             level=logging.DEBUG)
 
         c = wmi.WMI()
@@ -319,6 +321,11 @@ if __name__ == "__main__":
     winutils.exit_if_admin()
     args = SvrArgumentParser("PTS automation server").parse_args()
     queue = Queue()
+
+    with os.scandir(PROJECT_DIR) as it:
+        for file in it:
+            if file.name.startswith('autoptsserver_') and file.name.endswith('.log'):
+                os.remove(file)
 
     superguard = SuperGuard(float(args.superguard), queue)
     if args.superguard:

--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -158,15 +158,12 @@ def delete_workspaces():
         with os.scandir(directory) as it:
             for file in it:
                 if file.is_dir() and depth > 0:
-                    recursive(os.path.join(directory, file.name), depth)
+                    recursive(file.path, depth)
                 elif file.name.startswith('temp_') and file.name.endswith('.pqw6'):
-                    filepath = directory + os.sep + file.name
-                    newfilepath = filepath + '.deleted_' + now + '.old'
-                    os.rename(filepath, newfilepath)
+                    os.remove(file)
 
     depth = 4
-    now = datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    recursive('workspaces', depth)
+    recursive(os.path.join(PROJECT_DIR, 'workspaces'), depth)
 
 
 def recover_pts(ykush_ports=None):

--- a/bot/common.py
+++ b/bot/common.py
@@ -497,6 +497,17 @@ def release_device(jlink_srn):
         devices_in_use.remove(jlink_srn)
 
 
+def pre_cleanup():
+    """Perform cleanup before test run
+    :return: None
+    """
+    try:
+        shutil.copytree("logs", "oldlogs", dirs_exist_ok=True)
+        shutil.rmtree("logs")
+    except OSError:
+        pass
+
+
 def cleanup():
     """Perform cleanup
     :return: None

--- a/bot/mynewt.py
+++ b/bot/mynewt.py
@@ -348,6 +348,8 @@ def compose_mail(args, mail_cfg, mail_ctx):
 def main(cfg):
     print("Mynewt bot start!")
 
+    bot.common.pre_cleanup()
+
     start_time = time.time()
 
     args = cfg['auto_pts']

--- a/bot/mynewt.py
+++ b/bot/mynewt.py
@@ -363,7 +363,7 @@ def main(cfg):
     report_file = bot.common.make_report_xlsx(results, summary, regressions,
                                               descriptions)
     report_txt = bot.common.make_report_txt(results, repo_status)
-    logs_file = bot.common.archive_recursive("logs")
+    logs_folder = bot.common.archive_testcases("logs")
 
     build_info_file = get_build_info_file(os.path.abspath(args['project_path']))
 
@@ -374,7 +374,7 @@ def main(cfg):
         url = drive.new_workdir(args['board'])
         drive.upload(report_file)
         drive.upload(report_txt)
-        drive.upload(logs_file)
+        drive.upload_folder(logs_folder)
         drive.upload(build_info_file)
         drive.upload("TestCase.db")
 

--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -437,7 +437,7 @@ def main(cfg):
     report_file = bot.common.make_report_xlsx(results, summary, regressions,
                                               descriptions)
     report_txt = bot.common.make_report_txt(results, zephyr_hash["desc"])
-    logs_file = bot.common.archive_recursive("logs")
+    logs_folder = bot.common.archive_testcases("logs")
 
     end_time = time.time()
 
@@ -446,7 +446,7 @@ def main(cfg):
         url = drive.new_workdir(args['board'])
         drive.upload(report_file)
         drive.upload(report_txt)
-        drive.upload(logs_file)
+        drive.upload_folder(logs_folder)
         drive.upload("TestCase.db")
 
     if 'mail' in cfg:

--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -406,6 +406,8 @@ def compose_mail(args, mail_cfg, mail_ctx):
 
 def main(cfg):
 
+    bot.common.pre_cleanup()
+
     start_time = time.time()
 
     args = cfg['auto_pts']


### PR DESCRIPTION
Move old logs from logs/ into oldlogs/, so after a test run is complete, logs.zip contains only logs from last run.

Compress logs into separate .zip files instead of one large .zip, so it will be easier to download from disk logs of just a single test case.

Remove old broken temp workspaces instead of collecting them.