### PR TITLE
common: Fix AttributeError at args parsing

### DIFF
--- a/autoptsclient_common.py
+++ b/autoptsclient_common.py
@@ -1221,7 +1221,7 @@ class Client:
             board_power(args.ykush, True)
             time.sleep(1)
 
-        if 'tty_file' in args:
+        if 'tty_file' in args and args.tty_file:
             tty_file = args.tty_file
 
             if tty_file.startswith("COM"):


### PR DESCRIPTION
AttributeError: 'NoneType' object has no attribute 'startswith'
that occured when trying to run autoptsclient-zephyr.py with qemu.