### PR TITLE
common: Do not run recovery steps when INCONC or FAIL

### DIFF
--- a/autoptsclient_common.py
+++ b/autoptsclient_common.py
@@ -1010,7 +1010,8 @@ def run_test_cases(ptses, test_case_instances, args):
                 finally:
                     print(exeption_msg)
 
-            if timeout or args.recovery and (exeption_msg != '' or status != 'PASS'):
+            if timeout or args.recovery and \
+                    (exeption_msg != '' or status not in {'PASS', 'INCONC', 'FAIL'}):
                 run_recovery(args, ptses)
 
             if status == 'PASS' or stats.run_count == args.retry:


### PR DESCRIPTION
as these are valid PTS results, not caused by problems with connection
to server, like XML-RPC ERROR.
(--recovery option feature)