### PR TITLE
autoptsserver: Fix superguard option

### DIFF
--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -205,7 +205,7 @@ class SuperGuard(threading.Thread):
         while not self.end:
             idle_num = 0
             for srv in self.servers:
-                if time.time() - srv.last_restart() > self.timeout:
+                if time.time() - srv.last_start() > self.timeout:
                     idle_num += 1
 
             if idle_num == len(self.servers) and idle_num != 0:
@@ -234,9 +234,9 @@ class Server(threading.Thread):
         self.args = args
         self.pts = None
 
-    def last_restart(self):
+    def last_start(self):
         if self.pts:
-            return self.pts.last_restart_time
+            return self.pts.last_start_time
         return time.time()
 
     def main(self, args):

--- a/ptscontrol.py
+++ b/ptscontrol.py
@@ -256,7 +256,7 @@ class PyPTS:
         self._recov_in_progress = False
 
         self._temp_workspace_path = None
-        self.last_restart_time = None
+        self.last_start_time = time.time()
 
         # This is done to have valid _pts in case client does not restart_pts
         # and uses other methods. Normally though, the client should
@@ -385,8 +385,6 @@ class PyPTS:
         """
 
         log("%s", self.restart_pts.__name__)
-
-        self.last_restart_time = time.time()
 
         # Startup of ptscontrol doesn't have PTS pid yet set - no pts running
         if self._pts_proc:
@@ -607,6 +605,8 @@ class PyPTS:
 
         log("Starting %s %s %s", self.run_test_case.__name__, project_name,
             test_case_name)
+
+        self.last_start_time = time.time()
 
         self._pts_logger.set_test_case_name(test_case_name)
 


### PR DESCRIPTION
The timeout was badly compared because the time has been counted since
the last PTS restart and the PTS is not restarted on each test case.
Now the time is counted from the start of a test case.