### PR TITLE
Generate unique names for IUT

### DIFF
--- a/autoptsclient_common.py
+++ b/autoptsclient_common.py
@@ -321,6 +321,17 @@ def get_my_ip_address():
     return my_ip_address
 
 
+def get_unique_name(pts):
+    name = 'Tester'
+
+    # get address of PTS dongle IUT is connecting to
+    pts_addr = pts.q_bd_addr.replace(":", "")
+    #use last 6 characters of PTS dongle adress
+    name += "_" + pts_addr[6:12]
+
+    return name.encode('utf-8')
+
+
 get_my_ip_address.cached_address = None
 
 

--- a/ptsprojects/bluez/gap.py
+++ b/ptsprojects/bluez/gap.py
@@ -30,6 +30,7 @@ except ImportError:  # running this module as script
 from pybtp import btp
 from pybtp.types import Addr, IOCap, UUID, Prop, Perm, AdType, AdFlags
 import binascii
+from autoptsclient_common import get_unique_name
 from ptsprojects.stack import get_stack
 from wid.gap import hdl_wid_161
 from .gap_wid import gap_wid_hdl
@@ -80,12 +81,15 @@ def set_pixits(ptses):
 
     pts = ptses[0]
 
+    global iut_device_name
+    iut_device_name = get_unique_name(pts)
+
     ad_str_flags = str(AdType.flags).zfill(2) + \
                    str(AdFlags.br_edr_not_supp).zfill(2)
     ad_str_flags_len = str(len(ad_str_flags) // 2).zfill(2)
     ad_str_name_short = str(AdType.name_short).zfill(2) + \
                         binascii.hexlify(iut_device_name)
-    ad_str_name_short_len = str(len(ad_str_name_short) / 2).zfill(2)
+    ad_str_name_short_len = format((len(ad_str_name_short) // 2), 'x').zfill(2)
     ad_str_manufacturer_data = str(format(AdType.manufacturer_data, 'x')).zfill(2) + \
                                iut_manufacturer_data
     ad_str_manufacturer_data_len = str(len(ad_str_manufacturer_data) / 2).zfill(2)

--- a/ptsprojects/bluez/sm.py
+++ b/ptsprojects/bluez/sm.py
@@ -31,6 +31,7 @@ except ImportError:  # running this module as script
 from pybtp import btp
 from pybtp.types import Addr, IOCap
 from ptsprojects.stack import get_stack
+from autoptsclient_common import get_unique_name
 from .sm_wid import sm_wid_hdl
 
 
@@ -44,6 +45,8 @@ def set_pixits(ptses):
     ptses -- list of PyPTS instances"""
 
     pts = ptses[0]
+    global iut_device_name
+    iut_device_name = get_unique_name(pts)
 
     pts.set_pixit("SM", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
     pts.set_pixit("SM", "TSPX_SMP_pin_code", "111111")
@@ -120,7 +123,7 @@ def test_cases(ptses):
 
     stack = get_stack()
 
-    stack.gap_init()
+    stack.gap_init(name=iut_device_name)
 
     pre_conditions = [TestFunc(btp.core_reg_svc_gap),
                       TestFunc(btp.gap_read_ctrl_info),

--- a/ptsprojects/bluez/sm_wid.py
+++ b/ptsprojects/bluez/sm_wid.py
@@ -17,6 +17,7 @@ import logging
 import sys
 from pybtp import btp
 from wid.sm import sm_wid_hdl as gen_wid_hdl
+from ptsprojects.stack import get_stack
 
 log = logging.debug
 
@@ -56,6 +57,7 @@ def hdl_wid_109(desc):
 
 
 def hdl_wid_115(desc):
+    stack = get_stack()
     btp.gap_set_conn()
-    btp.gap_adv_ind_on()
+    btp.gap_adv_ind_on(ad=stack.gap.ad)
     return True

--- a/ptsprojects/mynewt/gap.py
+++ b/ptsprojects/mynewt/gap.py
@@ -31,6 +31,7 @@ except ImportError:  # running this module as script
 from pybtp import btp
 from pybtp.types import Addr, IOCap, AdType, AdFlags, Prop, Perm
 from . import gatt
+from autoptsclient_common import get_unique_name
 from ptsprojects.stack import get_stack
 from .gap_wid import gap_wid_hdl, gap_wid_hdl_failed_read, gap_wid_hdl_mode1_lvl2
 
@@ -70,20 +71,12 @@ init_gatt_db = [TestFunc(btp.core_reg_svc_gatt),
                 TestFunc(btp.gatts_start_server)]
 
 
-iut_device_name = 'Tester'.encode('utf-8')
 iut_manufacturer_data = 'ABCD'.encode('utf-8')
 iut_ad_uri = '000168747470733A2F2F7777772E626C7565746F'
 iut_appearance = '1111'
 iut_svc_data = '1111'
 iut_flags = '11'
 iut_svcs = '1111'
-
-
-class AdData:
-    ad_manuf = (AdType.manufacturer_data, 'ABCD')
-    ad_name_sh = (AdType.name_short, bytes.hex(iut_device_name))
-    ad_tx_pwr = (AdType.tx_power, '00')
-    ad_uri = (AdType.uri, iut_ad_uri)
 
 
 # Advertising data
@@ -105,12 +98,15 @@ def set_pixits(ptses):
 
     pts = ptses[0]
 
+    global iut_device_name
+    iut_device_name = get_unique_name(pts)
+
     ad_str_flags = str(AdType.flags).zfill(2) + \
                    str(AdFlags.br_edr_not_supp).zfill(2)
     ad_str_flags_len = str(len(ad_str_flags) // 2).zfill(2)
     ad_str_name_short = str(AdType.name_short).zfill(2) + \
                         bytes.hex(iut_device_name)
-    ad_str_name_short_len = str(len(ad_str_name_short) // 2).zfill(2)
+    ad_str_name_short_len = format((len(ad_str_name_short) // 2), 'x').zfill(2)
     ad_pixit = ad_str_flags_len + ad_str_flags + ad_str_name_short_len + \
                ad_str_name_short
 

--- a/ptsprojects/mynewt/gatt.py
+++ b/ptsprojects/mynewt/gatt.py
@@ -33,6 +33,7 @@ from pybtp.types import UUID, Addr, IOCap, Prop, Perm
 from time import sleep
 import logging, coloredlogs
 from ptsprojects.stack import get_stack
+from autoptsclient_common import get_unique_name
 from ptsprojects.mynewt.gatt_wid import gatt_wid_hdl
 from ptsprojects.mynewt.gattc_wid import gattc_wid_hdl
 import struct
@@ -139,6 +140,9 @@ def set_pixits(ptses):
     ptses -- list of PyPTS instances"""
 
     pts = ptses[0]
+
+    global iut_device_name
+    iut_device_name = get_unique_name(pts)
 
     pts.set_pixit("GATT", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
     pts.set_pixit("GATT", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
@@ -289,7 +293,7 @@ def test_cases(ptses):
 
     stack = get_stack()
 
-    stack.gap_init()
+    stack.gap_init(iut_device_name)
 
     pts.update_pixit_param("GATT", "TSPX_delete_link_key", "TRUE")
     pts.update_pixit_param("GATT", "TSPX_delete_ltk", "TRUE")

--- a/ptsprojects/mynewt/l2cap.py
+++ b/ptsprojects/mynewt/l2cap.py
@@ -31,6 +31,7 @@ except ImportError:  # running this module as script
 from pybtp import btp
 from pybtp.types import Addr
 from ptsprojects.stack import get_stack, L2cap
+from autoptsclient_common import get_unique_name
 from wid import l2cap_wid_hdl
 
 
@@ -54,6 +55,9 @@ def set_pixits(ptses):
     ptses -- list of PyPTS instances"""
 
     pts = ptses[0]
+
+    global iut_device_name
+    iut_device_name = get_unique_name(pts)
 
     pts.set_pixit("L2CAP", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
     pts.set_pixit("L2CAP", "TSPX_bd_addr_iut_le", "DEADBEEFDEAD")
@@ -119,7 +123,7 @@ def test_cases(ptses):
 
     stack = get_stack()
 
-    stack.gap_init()
+    stack.gap_init(iut_device_name)
 
     common = [TestFunc(btp.core_reg_svc_gap),
                       TestFunc(btp.core_reg_svc_l2cap),

--- a/ptsprojects/mynewt/mesh.py
+++ b/ptsprojects/mynewt/mesh.py
@@ -40,6 +40,7 @@ from uuid import uuid4
 from binascii import hexlify
 import random
 from time import sleep
+from autoptsclient_common import get_unique_name
 
 
 device_uuid = hexlify(uuid4().bytes)
@@ -56,6 +57,9 @@ def set_pixits(ptses):
     ptses -- list of PyPTS instances"""
 
     pts = ptses[0]
+
+    global iut_device_name
+    iut_device_name = get_unique_name(pts)
 
     pts.set_pixit("MESH", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
     pts.set_pixit("MESH", "TSPX_bd_addr_additional_whitelist", "")
@@ -166,7 +170,7 @@ def test_cases(ptses):
     rand_in_actions = random.choice(in_actions) if in_size else 0
     crpl_size = 10  # Maximum capacity of the replay protection list
 
-    stack.gap_init()
+    stack.gap_init(iut_device_name)
     stack.mesh_init(device_uuid, oob, out_size, rand_out_actions, in_size,
                     rand_in_actions, crpl_size)
 

--- a/ptsprojects/mynewt/sm.py
+++ b/ptsprojects/mynewt/sm.py
@@ -30,6 +30,7 @@ except ImportError:  # running this module as script
 
 from pybtp import btp
 from pybtp.types import Addr, IOCap
+from autoptsclient_common import get_unique_name
 from ptsprojects.stack import get_stack
 from .sm_wid import sm_wid_hdl
 
@@ -44,6 +45,9 @@ def set_pixits(ptses):
     ptses -- list of PyPTS instances"""
 
     pts = ptses[0]
+
+    global iut_device_name
+    iut_device_name = get_unique_name(pts)
 
     pts.set_pixit("SM", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
     pts.set_pixit("SM", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
@@ -71,10 +75,14 @@ def test_cases(ptses):
     stack.gap_init()
 
     pre_conditions = [TestFunc(btp.core_reg_svc_gap),
+                      TestFunc(stack.gap_init, iut_device_name),
                       TestFunc(btp.gap_read_ctrl_info),
                       TestFunc(lambda: pts.update_pixit_param(
                           "SM", "TSPX_bd_addr_iut",
                           stack.gap.iut_addr_get_str())),
+                      TestFunc(lambda: pts.update_pixit_param(
+                          "SM", "TSPX_iut_device_name_in_adv_packet_for_random_address",
+                          iut_device_name)),
                       TestFunc(lambda: pts.update_pixit_param(
                           "SM", "TSPX_OOB_Data", stack.gap.oob_legacy)),
                       TestFunc(lambda: pts.update_pixit_param(

--- a/ptsprojects/zephyr/dis.py
+++ b/ptsprojects/zephyr/dis.py
@@ -32,6 +32,7 @@ except ImportError:  # running this module as script
 from pybtp import btp
 from pybtp.types import Addr, Prop, Perm
 from . import gatt
+from autoptsclient_common import get_unique_name
 from ptsprojects.stack import get_stack
 from ptsprojects.zephyr.dis_wid import dis_wid_hdl
 
@@ -65,6 +66,12 @@ class DIS_DB:
 # all values in little endian
 dis_pnp_char_val = '0100E5FE110011'
 
+iut_manufacturer_data = 'ABCD'
+iut_appearance = '1111'
+iut_svc_data = '1111'
+iut_flags = '11'
+iut_svcs = '1111'
+iut_attr_db_off = 0x000b
 
 def set_pixits(ptses):
     """Setup DIS profile PIXITS for workspace. Those values are used for test
@@ -76,6 +83,8 @@ def set_pixits(ptses):
     ptses -- list of PyPTS instances"""
 
     pts = ptses[0]
+    global iut_device_name
+    iut_device_name = get_unique_name(pts)
 
     pts.set_pixit("DIS", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
     pts.set_pixit("DIS", "TSPX_iut_device_name_in_adv_packet_for_random_address", iut_device_name)
@@ -112,15 +121,6 @@ init_server = [TestFunc(btp.core_reg_svc_gatt),
                         gatt.Perm.read, DIS_DB.CHR_PnP_ID),
                TestFunc(btp.gatts_set_val, 0, dis_pnp_char_val),
                TestFunc(btp.gatts_start_server)]
-
-
-iut_device_name = 'Tester'.encode('utf-8')
-iut_manufacturer_data = 'ABCD'
-iut_appearance = '1111'
-iut_svc_data = '1111'
-iut_flags = '11'
-iut_svcs = '1111'
-iut_attr_db_off = 0x000b
 
 
 def test_cases(ptses):

--- a/ptsprojects/zephyr/gap.py
+++ b/ptsprojects/zephyr/gap.py
@@ -33,6 +33,7 @@ from pybtp import btp
 from pybtp.types import Addr, IOCap, AdType, AdFlags, Prop, Perm
 import binascii
 from . import gatt
+from autoptsclient_common import get_unique_name
 from ptsprojects.stack import get_stack
 from .gap_wid import gap_wid_hdl, gap_wid_hdl_mode1_lvl2, gap_wid_hdl_mode1_lvl4, gap_wid_hdl_failed_read
 
@@ -74,30 +75,12 @@ init_gatt_db = [TestFunc(btp.core_reg_svc_gatt),
                 TestFunc(btp.gatts_set_val, 0, '04'),
                 TestFunc(btp.gatts_start_server)]
 
-iut_device_name = 'Tester'.encode('utf-8')
+
 iut_manufacturer_data = 'ABCD'
 iut_appearance = '1111'
 iut_svc_data = '1111'
 iut_flags = '11'
 iut_svcs = '1111'
-iut_attr_db_off = 0x000b
-
-
-class AdData:
-    ad_manuf = (AdType.manufacturer_data, 'ABCD')
-    ad_name_sh = (AdType.name_short, binascii.hexlify(iut_device_name))
-
-
-# Advertising data
-ad = [(AdType.uuid16_some, '1111'),
-      (AdType.gap_appearance, '1111'),
-      (AdType.name_short, binascii.hexlify('Tester'.encode('utf-8'))),
-      (AdType.manufacturer_data, '11111111'),
-      (AdType.uuid16_svc_data, '111111')]
-
-
-def __get_attr_u16_hdl_str(offset):
-    return '{0:04x}'.format(iut_attr_db_off + offset, 'x')
 
 
 def set_pixits(ptses):
@@ -111,12 +94,15 @@ def set_pixits(ptses):
 
     pts = ptses[0]
 
+    global iut_device_name
+    iut_device_name = get_unique_name(pts)
+
     ad_str_flags = str(AdType.flags).zfill(2) + \
         str(AdFlags.br_edr_not_supp).zfill(2)
     ad_str_flags_len = str(len(ad_str_flags) // 2).zfill(2)
     ad_str_name_short = str(AdType.name_short).zfill(2) + \
         bytes.hex(iut_device_name)
-    ad_str_name_short_len = str(len(ad_str_name_short) // 2).zfill(2)
+    ad_str_name_short_len = format((len(ad_str_name_short) // 2), 'x').zfill(2)
     ad_pixit = ad_str_flags_len + ad_str_flags + ad_str_name_short_len + \
         ad_str_name_short
 

--- a/ptsprojects/zephyr/gatt.py
+++ b/ptsprojects/zephyr/gatt.py
@@ -30,6 +30,7 @@ except ImportError:  # running this module as script
 from pybtp import btp
 from pybtp.types import UUID, Addr, IOCap, Prop, Perm
 import logging
+from autoptsclient_common import get_unique_name
 from ptsprojects.stack import get_stack
 from ptsprojects.zephyr.gatt_wid import gatt_wid_hdl
 from ptsprojects.zephyr.gattc_wid import gattc_wid_hdl
@@ -119,6 +120,9 @@ def set_pixits(ptses):
 
     pts = ptses[0]
 
+    global iut_device_name
+    iut_device_name = get_unique_name(pts)
+
     pts.set_pixit("GATT", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
     pts.set_pixit("GATT", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
     pts.set_pixit("GATT", "TSPX_security_enabled", "FALSE")
@@ -172,6 +176,7 @@ def test_cases_server(ptses):
     stack = get_stack()
 
     pre_conditions = [TestFunc(btp.core_reg_svc_gap),
+                      TestFunc(stack.gap_init, iut_device_name),
                       TestFunc(btp.gap_read_ctrl_info),
                       TestFunc(lambda: pts.update_pixit_param(
                           "GATT", "TSPX_bd_addr_iut",
@@ -185,6 +190,7 @@ def test_cases_server(ptses):
                       TestFunc(btp.gap_set_gendiscov)]
 
     pre_conditions_1 = [TestFunc(btp.core_reg_svc_gap),
+                        TestFunc(stack.gap_init, iut_device_name),
                         TestFunc(btp.core_reg_svc_gatt),
                         TestFunc(btp.gap_read_ctrl_info),
                         TestFunc(lambda: pts.update_pixit_param(
@@ -708,7 +714,7 @@ def test_cases(ptses):
 
     stack = get_stack()
 
-    stack.gap_init()
+    stack.gap_init(iut_device_name)
 
     test_cases = test_cases_client(ptses[0])
     test_cases += test_cases_server(ptses)

--- a/ptsprojects/zephyr/l2cap.py
+++ b/ptsprojects/zephyr/l2cap.py
@@ -31,6 +31,7 @@ except ImportError:  # running this module as script
 from pybtp import btp, defs
 from pybtp.types import Addr, L2capSecLevels
 from ptsprojects.stack import get_stack, L2cap
+from autoptsclient_common import get_unique_name
 from wid import l2cap_wid_hdl
 
 
@@ -53,6 +54,9 @@ def set_pixits(ptses):
     ptses -- list of PyPTS instances"""
 
     pts = ptses[0]
+
+    global iut_device_name
+    iut_device_name = get_unique_name(pts)
 
     pts.set_pixit("L2CAP", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
     pts.set_pixit("L2CAP", "TSPX_bd_addr_iut_le", "DEADBEEFDEAD")
@@ -121,7 +125,7 @@ def test_cases(ptses):
 
     stack = get_stack()
 
-    stack.gap_init()
+    stack.gap_init(iut_device_name)
 
     common = [TestFunc(btp.core_reg_svc_gap),
                       TestFunc(btp.core_reg_svc_l2cap),

--- a/ptsprojects/zephyr/mesh.py
+++ b/ptsprojects/zephyr/mesh.py
@@ -40,7 +40,7 @@ from uuid import uuid4
 from binascii import hexlify
 import random
 from time import sleep
-
+from autoptsclient_common import get_unique_name
 
 def set_pixits(ptses):
     """Setup MESH profile PIXITS for workspace. Those values are used for test
@@ -52,6 +52,9 @@ def set_pixits(ptses):
     ptses -- list of PyPTS instances"""
 
     pts = ptses[0]
+
+    global iut_device_name
+    iut_device_name = get_unique_name(pts)
 
     pts.set_pixit("MESH", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
     pts.set_pixit("MESH", "TSPX_bd_addr_additional_whitelist", "")
@@ -188,7 +191,7 @@ def test_cases(ptses):
     rand_in_actions = random.choice(in_actions) if in_size else 0
     crpl_size = 10  # Maximum capacity of the replay protection list
 
-    stack.gap_init()
+    stack.gap_init(iut_device_name)
     stack.mesh_init(device_uuid, oob, out_size, rand_out_actions, in_size,
                     rand_in_actions, crpl_size)
 

--- a/ptsprojects/zephyr/sm.py
+++ b/ptsprojects/zephyr/sm.py
@@ -30,6 +30,7 @@ except ImportError:  # running this module as script
 
 from pybtp import btp
 from pybtp.types import Addr, IOCap
+from autoptsclient_common import get_unique_name
 from ptsprojects.stack import get_stack
 from .sm_wid import sm_wid_hdl
 
@@ -44,6 +45,9 @@ def set_pixits(ptses):
     ptses -- list of PyPTS instances"""
 
     pts = ptses[0]
+
+    global iut_device_name
+    iut_device_name = get_unique_name(pts)
 
     pts.set_pixit("SM", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
     pts.set_pixit("SM", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
@@ -65,7 +69,6 @@ def test_cases(ptses):
     pts = ptses[0]
 
     pts_bd_addr = pts.q_bd_addr
-    iut_device_name = 'Tester'
 
     stack = get_stack()
     stack.gap_init(name=iut_device_name)

--- a/wid/dis.py
+++ b/wid/dis.py
@@ -16,6 +16,7 @@
 import logging
 import sys
 from pybtp import btp
+from ptsprojects.stack import get_stack
 
 log = logging.debug
 
@@ -35,6 +36,7 @@ def dis_wid_hdl(wid, description, test_case_name, logs=True):
 
 # wid handlers section begin
 def hdl_wid_20001(desc):
+    stack = get_stack()
     btp.gap_set_conn()
-    btp.gap_adv_ind_on()
+    btp.gap_adv_ind_on(ad=stack.gap.ad)
     return True

--- a/wid/gap.py
+++ b/wid/gap.py
@@ -939,8 +939,9 @@ def hdl_wid_1002(desc):
 
 
 def hdl_wid_20001(desc):
+    stack = get_stack()
     btp.gap_set_conn()
-    btp.gap_adv_ind_on()
+    btp.gap_adv_ind_on(ad=stack.gap.ad)
     return True
 
 

--- a/wid/gatt.py
+++ b/wid/gatt.py
@@ -106,9 +106,10 @@ COMPARED_VALUE = []
 
 # wid handlers section begin
 def hdl_wid_1(desc):
+    stack = get_stack()
     btp.gap_set_conn()
     btp.gap_set_gendiscov()
-    btp.gap_adv_ind_on()
+    btp.gap_adv_ind_on(ad=stack.gap.ad)
     return True
 
 

--- a/wid/l2cap.py
+++ b/wid/l2cap.py
@@ -58,9 +58,10 @@ def hdl_wid_15(desc):
     :param desc: Action: Place the IUT in connectable mode.
     :return:
     """
+    stack = btp.get_stack()
     btp.gap_set_conn()
     btp.gap_set_gendiscov()
-    btp.gap_adv_ind_on()
+    btp.gap_adv_ind_on(ad=stack.gap.ad)
 
     return True
 
@@ -278,9 +279,10 @@ def hdl_wid_56(desc):
     :param desc: Action: Place the IUT in connectable mode.
     :return:
     """
+    stack = btp.get_stack()
     btp.gap_set_conn()
     btp.gap_set_gendiscov()
-    btp.gap_adv_ind_on()
+    btp.gap_adv_ind_on(ad=stack.gap.ad)
 
     return True
 
@@ -533,9 +535,10 @@ def hdl_wid_262(desc):
 
 
 def hdl_wid_20001(desc):
+    stack = btp.get_stack()
     btp.gap_set_conn()
     btp.gap_set_gendiscov()
-    btp.gap_adv_ind_on()
+    btp.gap_adv_ind_on(ad=stack.gap.ad)
     return True
 
 

--- a/wid/sm.py
+++ b/wid/sm.py
@@ -169,8 +169,9 @@ def hdl_wid_1009(desc):
 
 
 def hdl_wid_20001(desc):
+    stack = get_stack()
     btp.gap_set_conn()
-    btp.gap_adv_ind_on()
+    btp.gap_adv_ind_on(ad=stack.gap.ad)
     return True
 
 


### PR DESCRIPTION
When 2 or more IUTs are under test at the same time and they share the
name, PTS might choose wrong board and connect to it. Now, last 3 parts
of PTS dongle address are appended to the end of IUTs' name to
distinguish them from each other.

This affects only tests that rely on IXIT
"TSPX_iut_device_name_in_adv_packet_for_random_address", as only then
this name is actually used. This means that default device name stays
the same as "Tester" for GATT (uses static address), L2CAP and MESH
test suites.