### PR TITLE
Fix waiting for socat process to stop

### DIFF
--- a/ptsprojects/mynewt/iutctl.py
+++ b/ptsprojects/mynewt/iutctl.py
@@ -146,6 +146,10 @@ class MynewtCtl:
         if self.rtt2pty:
             self.rtt2pty.stop()
 
+        if self.socat_process:
+            self.socat_process.terminate()
+            self.socat_process.wait();
+            self.socat_process = None
 
 class MynewtCtlStub:
     '''Mynewt OS Control Class with stubs for testing'''

--- a/ptsprojects/zephyr/iutctl.py
+++ b/ptsprojects/zephyr/iutctl.py
@@ -260,6 +260,10 @@ class ZephyrCtl:
         if self.rtt2pty:
             self.rtt2pty.stop()
 
+        if self.socat_process:
+            self.socat_process.terminate()
+            self.socat_process.wait();
+            self.socat_process = None
 
 class ZephyrCtlStub:
     '''Zephyr OS Control Class with stubs for testing'''

--- a/pybtp/iutctl_common.py
+++ b/pybtp/iutctl_common.py
@@ -135,9 +135,6 @@ class BTPSocket(object):
             self.sock.close()
         except:
             pass
-        # TODO We should wait for the [FIN, ACK] packet to arrive or
-        # next connection could fail(on Windows race occurred)
-        time.sleep(2)
         self.sock = None
         self.conn = None
         self.addr = None


### PR DESCRIPTION
When stopping client should wait for socat process to terminate.
Otherwise we may end up with connection error on next start if
process scheduling is unlucky (seems to happen more often on Windows).
This also allows to get rid of sleep(2) while closing BTP socket saving
4 seconds of every test run.