### PR TITLE
Add stress test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This may contain few sections:
     - `board` - IUT used. Currently nrf52 is supported only
     - `enable_max_logs` - enable debug logs
     - `retry` - maximum repeat count per test
+    - `stress test` - repeat every test `retry` number of times, even if result was PASS
     - `bd_addr` - IUT Bluetooth Address (optional)
 - `mail` - Mail configuration (optional)
     - `sender` - sender e-mail address

--- a/autoptsclient_common.py
+++ b/autoptsclient_common.py
@@ -1014,7 +1014,7 @@ def run_test_cases(ptses, test_case_instances, args):
                     (exeption_msg != '' or status not in {'PASS', 'INCONC', 'FAIL'}):
                 run_recovery(args, ptses)
 
-            if status == 'PASS' or stats.run_count == args.retry:
+            if (status == 'PASS' and not args.stress_test) or stats.run_count == args.retry:
                 if TEST_CASE_DB:
                     TEST_CASE_DB.update_statistics(test_case, duration, status)
 
@@ -1065,6 +1065,9 @@ class CliParser(argparse.ArgumentParser):
         self.add_argument("-r", "--retry", type=int, default=0,
                           help="Repeat test if failed. Parameter specifies "
                                "maximum repeat count per test")
+
+        self.add_argument("--stress_test", action='store_true', default=False,
+                          help="Repeat every test even if previous result was PASS")
 
         self.add_argument("-S", "--srv_port", type=int, nargs="+", default=[SERVER_PORT],
                           help="Specify the server port number")

--- a/bot/mynewt.py
+++ b/bot/mynewt.py
@@ -202,6 +202,7 @@ class PtsInitArgs(object):
         self.bd_addr = args["bd_addr"]
         self.enable_max_logs = args["enable_max_logs"]
         self.retry = args["retry"]
+        self.stress_test = args["stress_test"]
         self.test_cases = []
         self.excluded = []
         self.srv_port = args["srv_port"]

--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -225,6 +225,7 @@ class PtsInitArgs(object):
         self.bd_addr = args["bd_addr"]
         self.enable_max_logs = args["enable_max_logs"]
         self.retry = args["retry"]
+        self.stress_test = args["stress_test"]
         self.test_cases = []
         self.excluded = []
         self.srv_port = args["srv_port"]


### PR DESCRIPTION
Add mode in which retry is always executed, even if test passes.
This allows to execute every test multiple times regardless
of the result.