### PR TITLE
bot: Make git config optional

### DIFF
--- a/bot/mynewt.py
+++ b/bot/mynewt.py
@@ -338,8 +338,11 @@ def main(cfg):
 
     args = cfg['auto_pts']
 
-    repos_info = bot.common.update_repos(args['project_path'], cfg["git"])
-    repo_status = make_repo_status(repos_info)
+    if 'git' in cfg:
+        repos_info = bot.common.update_repos(args['project_path'], cfg["git"])
+        repo_status = make_repo_status(repos_info)
+    else:
+        repo_status = ''
 
     summary, results, descriptions, regressions = \
         run_tests(args, cfg.get('iut_config', {}))

--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -339,8 +339,11 @@ def main(cfg):
                                         'bluetooth', 'tester', 'outdir',
                                         'zephyr', 'zephyr.elf')
 
-    zephyr_hash = bot.common.update_repos(args['project_path'],
-                                          cfg["git"])['zephyr']
+    if 'git' in cfg:
+        zephyr_hash = bot.common.update_repos(args['project_path'],
+                                              cfg['git'])['zephyr']
+    else:
+        zephyr_hash = {'desc': '', 'commit': ''}
 
     if 'ykush' in args:
         autoptsclient.board_power(args['ykush'], True)


### PR DESCRIPTION
config.py configuration:
z['git'] = {
...
}
is now optional, for zephyr and mynewt.