### PR TITLE
 autoptsclient autoptsserver: Fix start/end run behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,13 +292,10 @@ This feature was created to enable long runs of bot without supervision, because
 
 **Recover autoptsserver after exception**
 
-After python exception caught, kills **all** existing processes of PTS.exe, Fts.exe on Windows machine, cleans temporary PTS workspaces, and tries to restart autoptsserver. So if you need 2 autoptsserver instances, e.g. for MESH tests, this is the proper way to run them with recovery:
+Autoptsserver can recover itself after python exception or after request received from autoptsclient.
+If you have YKUSH hub, you can run server with option --ykush, so recovery steps will include re-plugin of PTS dongles:
 
-    $ python autoptsserver.py -S 65000 65002 --recovery
-    
-If you have YKUSH hub, you can run with option --ykush, so recovery steps will include re-plugin of PTS dongles:
-
-    $ python autoptsserver.py -S 65000 65002 --recovery --ykush 1 2
+    $ python autoptsserver.py -S 65000 65002 --ykush 1 2
 
 where 1 and 2 are numbers of YKUSH USB ports (More about [YKUSH hub](https://www.yepkit.com/products/ykush)).
 
@@ -308,7 +305,8 @@ Helpful --superguard option will blindly trigger recovery after given amount of 
 
 **Recover autoptsclient after exception**
 
-Recovery of autoptsclient is triggered after python exception or test case result other than PASS, INCONC or FAIL. It sends recovery request to autoptsserver, so server has to run in recovery mode too.
+Recovery of autoptsclient can be enabled with --recovery option and is triggered after python exception or test case result other than PASS, INCONC or FAIL.
+Then it sends recovery request to autoptsserver, restarting and reinitializing PTSes.
 
     $ python ./autoptsclient-zephyr.py zephyr-master -t COM3 -b nrf52 --recovery
 

--- a/bot/mynewt.py
+++ b/bot/mynewt.py
@@ -229,28 +229,16 @@ def run_tests(args, iut_config):
         if 'overlay' in value:
             _args[config_default].excluded += _args[config].test_cases
 
-    while True:
-        try:
-            ptses = autoptsclient.init_pts(_args[config_default],
-                                           "mynewt_" + str(args["board"]))
+    ptses = []
+    autoptsclient.init_pts(_args[config_default], ptses,
+                           "mynewt_" + str(args["board"]))
+    btp.init(get_iut)
 
-            btp.init(get_iut)
+    # Main instance of PTS
+    pts = ptses[0]
 
-            # Main instance of PTS
-            pts = ptses[0]
-
-            # Read PTS Version and keep it for later use
-            args['pts_ver'] = "%s" % pts.get_version()
-        except Exception as exc:
-            logging.exception(exc)
-            if _args[config_default].recovery:
-                ptses = exc.args[1]
-                for pts in ptses:
-                    autoptsclient.recover_autoptsserver(pts)
-                time.sleep(20)
-                continue
-            raise exc
-        break
+    # Read PTS Version and keep it for later use
+    args['pts_ver'] = "%s" % pts.get_version()
 
     stack.init_stack()
     stack_inst = stack.get_stack()

--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -205,28 +205,16 @@ def run_tests(args, iut_config, tty):
         if 'overlay' in value:
             _args[config_default].excluded += _args[config].test_cases
 
-    while True:
-        try:
-            ptses = autoptsclient.init_pts(_args[config_default],
-                                           "zephyr_" + str(args["board"]))
+    ptses = []
+    autoptsclient.init_pts(_args[config_default], ptses,
+                           "zephyr_" + str(args["board"]))
+    btp.init(get_iut)
 
-            btp.init(get_iut)
+    # Main instance of PTS
+    pts = ptses[0]
 
-            # Main instance of PTS
-            pts = ptses[0]
-
-            # Read PTS Version and keep it for later use
-            args['pts_ver'] = "%s" % pts.get_version()
-        except Exception as exc:
-            logging.exception(exc)
-            if _args[config_default].recovery:
-                ptses = exc.args[1]
-                for pts in ptses:
-                    autoptsclient.recover_autoptsserver(pts)
-                time.sleep(20)
-                continue
-            raise exc
-        break
+    # Read PTS Version and keep it for later use
+    args['pts_ver'] = "%s" % pts.get_version()
 
     stack.init_stack()
     stack_inst = stack.get_stack()

--- a/ptsprojects/stack.py
+++ b/ptsprojects/stack.py
@@ -679,6 +679,13 @@ class Synch:
         self._pending_responses = []
         self._sync_callbacks = sync_callbacks
 
+    def reinit(self, sync_callbacks):
+        self._synch_table.clear()
+        self._pending_responses.clear()
+        self._sync_callbacks.clear()
+        for cb in sync_callbacks:
+            self._sync_callbacks.append(cb)
+
     def add_synch_element(self, elem):
         self._synch_table.append(SynchElem(elem))
 
@@ -805,7 +812,10 @@ class Stack:
         self.gatt = Gatt()
 
     def synch_init(self, sync_callbacks):
-        self.synch = Synch(sync_callbacks)
+        if not self.synch:
+            self.synch = Synch(sync_callbacks)
+        else:
+            self.synch.reinit(sync_callbacks)
 
     def cleanup(self):
         if self.gap:


### PR DESCRIPTION
Fixes ctrl+c behaviour under Windows by setting global RUN_END flag, only for simple client for now.

Fixes #513 issue with restarting PTS instances. Thread lock prevents restart of PTSes at the same time, so they won't steal each others dongles.

Fixes logging of multiple autoptsserver threads. Logs for second instance was never created. Now they share one log file and logs are distinguished by thread name column.
