### PR TITLE
common: Fix shutting down after Ctrl+C interruption

### DIFF
--- a/bot/mynewt.py
+++ b/bot/mynewt.py
@@ -231,8 +231,9 @@ def run_tests(args, iut_config):
 
     while True:
         try:
-            ptses = autoptsclient.init_pts(_args[config_default],
-                                           "mynewt_" + str(args["board"]))
+            ptses = []
+            autoptsclient.init_pts(_args[config_default], ptses,
+                                   "mynewt_" + str(args["board"]))
 
             btp.init(get_iut)
 

--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -207,8 +207,9 @@ def run_tests(args, iut_config, tty):
 
     while True:
         try:
-            ptses = autoptsclient.init_pts(_args[config_default],
-                                           "zephyr_" + str(args["board"]))
+            ptses = []
+            autoptsclient.init_pts(_args[config_default], ptses,
+                                   "zephyr_" + str(args["board"]))
 
             btp.init(get_iut)
 


### PR DESCRIPTION
Needed after removing os._exit() at end of run, so console won't hang because of unclosed server thread. The issue occurred mainly under Windows. Shutdown takes now around 10-15 seconds.