### PR TITLE
Mynewt: fix GATT/SR/GAW/BV-01-C

### DIFF
--- a/ptsprojects/mynewt/gatt_wid.py
+++ b/ptsprojects/mynewt/gatt_wid.py
@@ -162,7 +162,9 @@ def hdl_wid_75(desc):
     handle = int(MMI.args[0], 16)
     value = MMI.args[1]
 
-    time.sleep(5)
+    # write was unsuccessful
+    if not btp.gatts_verify_write_success(desc):
+        return False
 
     attr = btp.gatts_get_attr_val(btp.pts_addr_type_get(),
                                   btp.pts_addr_get(), handle)


### PR DESCRIPTION
Before verifying data written by PTS we should handle
gatts_attr_value_changed_ev - calling gatts_get_attr_val first will
lead to receiving value change event when we want response to command -
op code error will occur. Receiving value change event also means
that there's actual data to be checked.