### PR TITLE
wid: Ignore error from L2CAP disconnect

### DIFF
--- a/wid/l2cap.py
+++ b/wid/l2cap.py
@@ -339,7 +339,10 @@ def hdl_wid_100(desc):
 def hdl_wid_101(desc):
     l2cap = get_stack().l2cap
     for channel in l2cap.channels:
-        btp.l2cap_disconn(channel.id)
+        try:
+            btp.l2cap_disconn(channel.id)
+        except BTPError:
+            logging.debug("Ignoring expected error on L2CAP disconnect")
     return True
 
 


### PR DESCRIPTION
In some tests (eg L2CAP/ECFC/BV-02-C) host is expected to autonomously
disconnect L2CAP channel on LT invalid behaviour. But PTS seems to be
asking for explicit disconnect and depending on timing BTP command may
fail if channel was already disconnected.