### PR TITLE
common: Make adding new boards more generic

### DIFF
--- a/autoptsclient-mynewt.py
+++ b/autoptsclient-mynewt.py
@@ -18,13 +18,12 @@
 """Mynewt auto PTS client"""
 
 import autoptsclient_common as autoptsclient
-import ptsprojects.mynewt as autoprojects
 from ptsprojects.mynewt.iutctl import get_iut
 
 
 class MynewtClient(autoptsclient.Client):
     def __init__(self):
-        super().__init__(get_iut, 'mynewt', autoprojects.iutctl.Board.names)
+        super().__init__(get_iut, 'mynewt')
 
 
 def main():

--- a/bot/config.py.mynewt.sample
+++ b/bot/config.py.mynewt.sample
@@ -33,6 +33,8 @@ m['auto_pts'] = {
     'local_ip' : ['192.168.0.100'],
     'project_path': '/path/to/project',
     'workspace': 'Mynewt Nimble Host',
+    # 'debugger_srn': 'xxxxxxxx',
+    # 'tty_file': '/dev/ttyUSB',
     # 'database_file': 'path/to/mynewtTestCase.db',
     # 'store': True,
     'board': 'nordic_pca10056',

--- a/ptsprojects/boards/__init__.py
+++ b/ptsprojects/boards/__init__.py
@@ -1,0 +1,173 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2021, Intel Corporation.
+# Copyright (c) 2021, Codecoup.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+import os
+import sys
+import shlex
+import serial.tools.list_ports
+import logging
+import pkgutil
+import importlib
+import subprocess
+
+# For each new board just create a <new-board-name>.py file that contains reset_cmd() function and list
+# of supported boards.
+
+log = logging.debug
+devices_in_use = []
+
+
+class Board:
+    """HW DUT board"""
+
+    def __init__(self, board_name, iutctl):
+        """Constructor of board"""
+
+        self.name = board_name
+        self.iutctl = iutctl
+        self.reset_cmd = self.get_reset_cmd()
+
+    def reset(self):
+        """Reset HW DUT board with
+        """
+        log("About to reset DUT: %r", self.reset_cmd)
+
+        reset_process = subprocess.Popen(shlex.split(self.reset_cmd),
+                                         shell=False,
+                                         stdout=self.iutctl.iut_log_file,
+                                         stderr=self.iutctl.iut_log_file)
+
+        if reset_process.wait(20):
+            logging.error("reset failed")
+
+    def get_reset_cmd(self):
+        """Setup reset command"""
+
+        board_mod = importlib.import_module(__package__ + '.' + self.name)
+
+        if board_mod is None:
+            raise Exception("Board name %s is not supported!" % self.name)
+
+        return board_mod.reset_cmd(self.iutctl)
+
+
+def get_build_and_flash(board_name):
+    board_mod = importlib.import_module(__package__ + '.' + board_name)
+
+    if board_mod is None:
+        raise Exception("Board name %s is not supported!" % board_name)
+
+    try:
+        return getattr(board_mod, 'build_and_flash')
+    except AttributeError:
+        return None
+
+
+def get_available_boards(project):
+    names = []
+
+    for m in pkgutil.iter_modules(__path__):
+        board_mod = importlib.import_module(__package__ + '.' + m.name)
+
+        if project in board_mod.supported_projects:
+            names.append(m.name)
+
+    return names
+
+
+def get_openocd_reset_cmd(openocd_bin, openocd_scripts, openocd_cfg):
+    """Compute openocd reset command"""
+    if not os.path.isfile(openocd_bin):
+        raise Exception("openocd {} not found!".format(openocd_bin))
+
+    if not os.path.isdir(openocd_scripts):
+        raise Exception("openocd scripts {} not found!".format(openocd_scripts))
+
+    if not os.path.isfile(openocd_cfg):
+        raise Exception("openocd config {} not found!".format(openocd_cfg))
+
+    reset_cmd = ('%s -s %s -f %s -c "init" -c "targets 1" '
+                 '-c "reset halt" -c "reset run" -c "shutdown"' %
+                 (openocd_bin, openocd_scripts, openocd_cfg))
+
+    return reset_cmd
+
+
+def get_device_list():
+    """Returns dictionary of <tty>: <jlink_srn> (eg. {'/dev/ttyUSB0': 'xxxxxx'}) of found devices"""
+
+    device_list = {}
+
+    for dev in serial.tools.list_ports.comports():
+        if dev.serial_number is not None:
+            device_list[dev.device] = dev.serial_number[3:]
+
+    return device_list
+
+
+def get_free_device():
+    """Returns tty path and jlink serial number of a free device."""
+    devices = get_device_list()
+
+    for dev in devices.keys():
+        if dev not in devices_in_use:
+            devices_in_use.append(dev)
+            return dev, devices[dev]
+
+    return None, None
+
+
+def get_debugger_snr(tty):
+    """Return jlink serial number of the device with the given tty.
+    """
+    jlink = None
+    devices = get_device_list()
+    if sys.platform == 'win32':
+        tty = tty_to_com(tty)
+
+    for dev in devices.keys():
+        if dev == tty:
+            jlink = devices[dev]
+            break
+
+    return jlink
+
+
+def release_device(tty):
+    if tty and tty in devices_in_use:
+        devices_in_use.remove(tty)
+
+
+def tty_exists(tty):
+    if tty is None:
+        return False
+
+    if sys.platform == 'win32' and tty.startswith('/dev/ttyS'):
+        tty = tty_to_com(tty)
+
+    return tty in [port.device for port in serial.tools.list_ports.comports()]
+
+
+def com_to_tty(com):
+    if com.startswith('COM'):
+        return '/dev/ttyS' + str(int(com['COM'.__len__():]) - 1)
+    return None
+
+
+def tty_to_com(tty):
+    if tty.startswith('/dev/ttyS'):
+        return 'COM' + str(int(tty['/dev/ttyS'.__len__():]) + 1)
+    return None

--- a/ptsprojects/boards/dialog_da1469x_dk_pro.py
+++ b/ptsprojects/boards/dialog_da1469x_dk_pro.py
@@ -1,0 +1,142 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2021, Intel Corporation.
+# Copyright (c) 2021, Codecoup.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+import logging
+import os
+import sys
+from bot.mynewt import check_call
+
+supported_projects = ['mynewt']
+
+
+def reset_cmd(iutctl):
+    """Return reset command for Dialog da1469x dk pro
+
+    Dependency: nRF5x command line tools
+    """
+
+    if sys.platform == "win32":
+        jlink = 'JLink'
+    else:
+        jlink = 'JLinkExe'
+
+    reset_jlink = 'reset.jlink'
+
+    if not os.path.exists(reset_jlink):
+        with open(reset_jlink, 'x') as f:
+            f.write('r\nq')
+
+    return '{} -nogui 1 -if swd -speed 4000 -device CORTEX-M33 -commanderscript {}' \
+        .format(jlink, reset_jlink)
+
+
+def build_and_flash(project_path, board, overlay=None):
+    """Build and flash Mynewt binary
+    :param project_path: Mynewt source path
+    :param board: IUT
+    :param overlay: configuration map to be used
+    """
+    logging.debug("%s: %s %s %s", build_and_flash.__name__, project_path,
+                  board, overlay)
+
+    board = 'dialog_da1469x-dk-pro'
+    check_call('rm -rf bin/'.split(), cwd=project_path)
+    check_call('rm -rf targets/da1469x_boot/'.split(),
+               cwd=project_path)
+    check_call('rm -rf targets/da1469x_flash_loader/'.split(), cwd=project_path)
+    check_call('rm -rf targets/dialog_cmac/'.split(), cwd=project_path)
+    check_call('rm -rf targets/da1469x_bttester/'.split(), cwd=project_path)
+
+    check_call('newt target create da1469x_boot'.split(),
+               cwd=project_path)
+    check_call('newt target create da1469x_flash_loader'.split(),
+               cwd=project_path)
+    check_call('newt target create dialog_cmac'.split(), cwd=project_path)
+    check_call('newt target create da1469x_bttester'.split(), cwd=project_path)
+
+    check_call(
+        'newt target set da1469x_boot bsp=@apache-mynewt-core/hw/bsp/{0}'.format(
+            board).split(), cwd=project_path)
+    check_call(
+        'newt target set da1469x_boot app=@mcuboot/boot/mynewt'.split(), cwd=project_path)
+
+    check_call(
+        'newt target set da1469x_flash_loader bsp=@apache-mynewt-core/hw/bsp/{}'.format(board).split(),
+        cwd=project_path)
+    check_call(
+        'newt target set da1469x_flash_loader app=@apache-mynewt-core/apps/flash_loader'.split(), cwd=project_path)
+    check_call(
+        'newt target set da1469x_flash_loader syscfg=FLASH_LOADER_DL_SZ=0x10000:RAM_RESIDENT=1'.split(),
+        cwd=project_path)
+
+    check_call(
+        'newt target set dialog_cmac bsp=@apache-mynewt-core/hw/bsp/dialog_cmac'.split(), cwd=project_path)
+    check_call(
+        'newt target set dialog_cmac app=@apache-mynewt-nimble/apps/blehci'.split(), cwd=project_path)
+    check_call('newt target set dialog_cmac build_profile=speed'.split(), cwd=project_path)
+
+    with open(os.path.join(project_path, 'targets/dialog_cmac/syscfg.yml'), 'w') as f:
+        f.write('''syscfg.vals:
+  MCU_DEEP_SLEEP: 1
+  MCU_SLP_TIMER: 1
+  MCU_SLP_TIMER_32K_ONLY: 1
+
+  BLE_HCI_TRANSPORT: dialog_cmac
+
+  # LL recommended settings (decreasing timing values is not recommended)
+  BLE_LL_CFG_FEAT_CTRL_TO_HOST_FLOW_CONTROL: 1
+  BLE_LL_CONN_INIT_MIN_WIN_OFFSET: 2
+  BLE_LL_RFMGMT_ENABLE_TIME: 20
+  BLE_LL_SCHED_AUX_MAFS_DELAY: 150
+  BLE_LL_SCHED_AUX_CHAIN_MAFS_DELAY: 150
+
+  # NOTE: set public address in target settings
+  BLE_PUBLIC_DEV_ADDR: "(uint8_t[6]){0xff, 0xff, 0xff, 0xff, 0xff, 0xff}"
+
+  BLE_EXT_ADV: 1
+  BLE_PERIODIC_ADV: 1
+  BLE_LL_CFG_FEAT_LE_2M_PHY: 1
+  BLE_LL_NUM_SCAN_DUP_ADVS: 256
+''')
+
+    check_call(
+        'newt target set da1469x_bttester bsp=@apache-mynewt-core/hw/bsp/{}'.format(board).split(), cwd=project_path)
+    check_call(
+        'newt target set da1469x_bttester app=@apache-mynewt-nimble/apps/bttester'.split(),
+        cwd=project_path)
+    check_call('newt target set da1469x_bttester build_profile=debug'.split(), cwd=project_path)
+    check_call('newt target set da1469x_bttester syscfg='
+               'BLE_HCI_TRANSPORT=dialog_cmac:'
+               'CMAC_IMAGE_TARGET_NAME=dialog_cmac'.split(), cwd=project_path)
+
+    if overlay is not None:
+        config = ':'.join(['{}={}'.format(k, v) for k, v in list(overlay.items())])
+        check_call('newt target set da1469x_bttester syscfg={}'.format(config).split(),
+                   cwd=project_path)
+
+    check_call('newt build dialog_cmac'.split(), cwd=project_path)
+    check_call('newt build da1469x_flash_loader'.split(), cwd=project_path)
+    check_call('newt build da1469x_boot'.split(), cwd=project_path)
+    check_call('newt build da1469x_bttester'.split(), cwd=project_path)
+
+    check_call('newt create-image -2 da1469x_flash_loader timestamp'.split(),
+               cwd=project_path)
+    check_call('newt create-image -2 da1469x_boot timestamp'.split(),
+               cwd=project_path)
+    check_call('newt create-image -2 da1469x_bttester timestamp'.split(), cwd=project_path)
+
+    check_call('newt load da1469x_flash_loader'.split(), cwd=project_path)
+    check_call('newt load da1469x_boot'.split(), cwd=project_path)
+    check_call('newt load da1469x_bttester'.split(), cwd=project_path)

--- a/ptsprojects/boards/nordic_pca10056.py
+++ b/ptsprojects/boards/nordic_pca10056.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
-
 #
 # auto-pts - The Bluetooth PTS Automation Framework
 #
-# Copyright (c) 2017, Intel Corporation.
+# Copyright (c) 2021, Intel Corporation.
+# Copyright (c) 2021, Codecoup.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms and conditions of the GNU General Public License,
@@ -15,22 +14,17 @@
 # more details.
 #
 
-"""Zephyr auto PTS client"""
-import autoptsclient_common as autoptsclient
-from ptsprojects.zephyr.iutctl import get_iut
+supported_projects = ['zephyr', 'mynewt']
 
 
-class ZephyrClient(autoptsclient.Client):
-    def __init__(self):
-        super().__init__(get_iut, 'zephyr')
+def reset_cmd(iutctl):
+    """Return reset command for nRF52 DUT
 
+    Dependency: nRF5x command line tools
+    """
+    with_srn = ''
 
-def main():
-    """Main."""
+    if iutctl.debugger_snr:
+        with_srn = ' -s {}'.format(iutctl.debugger_snr)
 
-    client = ZephyrClient()
-    client.start()
-
-
-if __name__ == "__main__":
-    main()
+    return 'nrfjprog -f nrf52 -r {}'.format(with_srn)

--- a/ptsprojects/boards/nrf52.py
+++ b/ptsprojects/boards/nrf52.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
-
 #
 # auto-pts - The Bluetooth PTS Automation Framework
 #
-# Copyright (c) 2017, Intel Corporation.
+# Copyright (c) 2021, Intel Corporation.
+# Copyright (c) 2021, Codecoup.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms and conditions of the GNU General Public License,
@@ -15,22 +14,17 @@
 # more details.
 #
 
-"""Zephyr auto PTS client"""
-import autoptsclient_common as autoptsclient
-from ptsprojects.zephyr.iutctl import get_iut
+supported_projects = ['zephyr']
 
 
-class ZephyrClient(autoptsclient.Client):
-    def __init__(self):
-        super().__init__(get_iut, 'zephyr')
+def reset_cmd(iutctl):
+    """Return reset command for nRF52 DUT
 
+    Dependency: nRF5x command line tools
+    """
+    with_srn = ''
 
-def main():
-    """Main."""
+    if iutctl.debugger_snr:
+        with_srn = ' -s {}'.format(iutctl.debugger_snr)
 
-    client = ZephyrClient()
-    client.start()
-
-
-if __name__ == "__main__":
-    main()
+    return 'nrfjprog -f nrf52 -r {}'.format(with_srn)

--- a/ptsprojects/boards/reel_board.py
+++ b/ptsprojects/boards/reel_board.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python
-
 #
 # auto-pts - The Bluetooth PTS Automation Framework
 #
-# Copyright (c) 2017, Intel Corporation.
+# Copyright (c) 2021, Intel Corporation.
+# Copyright (c) 2021, Codecoup.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms and conditions of the GNU General Public License,
@@ -15,22 +14,12 @@
 # more details.
 #
 
-"""Zephyr auto PTS client"""
-import autoptsclient_common as autoptsclient
-from ptsprojects.zephyr.iutctl import get_iut
+supported_projects = ['zephyr']
 
 
-class ZephyrClient(autoptsclient.Client):
-    def __init__(self):
-        super().__init__(get_iut, 'zephyr')
+def reset_cmd(iutctl):
+    """Return reset command for Reel_Board DUT
 
-
-def main():
-    """Main."""
-
-    client = ZephyrClient()
-    client.start()
-
-
-if __name__ == "__main__":
-    main()
+    Dependency: pyocd command line tools
+    """
+    return 'pyocd cmd -c reset'

--- a/pybtp/iutctl_common.py
+++ b/pybtp/iutctl_common.py
@@ -244,24 +244,6 @@ class BTPWorker(BTPSocket):
         self.event_handler_cb = event_handler
 
 
-def get_debugger_snr(tty_file):
-    debuggers = subprocess.Popen('nrfjprog --com',
-                                 shell=True,
-                                 stdout=subprocess.PIPE
-                                 ).stdout.read().decode()
-
-    if sys.platform == "win32":
-        COM = "COM" + str(int(tty_file["/dev/ttyS".__len__():]) + 1)
-        reg = "[0-9]+(?=\s+" + COM + ".+)"
-    else:
-        reg = "[0-9]+(?=\s+" + tty_file + ".+)"
-
-    try:
-        return re.findall(reg, debuggers)[0]
-    except:
-        sys.exit("No debuggers associated with the device found")
-
-
 class RTT:
     def __init__(self):
         self.read_thread = None


### PR DESCRIPTION
Move reset commands of boards to separate module files.
Replace nrfjprog in searching for a free device serial port and jlink serial number.
Add build and flash for dialog_da1469x-dk-pro.
Add tty_file and debugger_srn options to config of bot.