### PR TITLE
zephyr: Fix MESH/SR/MPXS/BV-09-C

### DIFF
--- a/ptsprojects/zephyr/mesh.py
+++ b/ptsprojects/zephyr/mesh.py
@@ -315,9 +315,6 @@ def test_cases(ptses):
         ZTestCase("MESH", "MESH/NODE/TNPT/BV-08-C", cmds=pre_conditions +
                   [TestFunc(btp.mesh_store_net_data)],
                   generic_wid_hdl=mesh_wid_hdl),
-        ZTestCase("MESH", "MESH/SR/MPXS/BV-09-C", cmds=pre_conditions +
-                  [TestFunc(lambda: get_stack().mesh.proxy_identity_enable())],
-                  generic_wid_hdl=mesh_wid_hdl),
         ZTestCase("MESH", "MESH/CFGCL/KR/BV-01-C", cmds=pre_conditions_prov,
                   generic_wid_hdl=mesh_wid_hdl),
         ZTestCase("MESH", "MESH/CFGCL/KR/BV-02-C", cmds=pre_conditions_prov,

--- a/wid/mesh.py
+++ b/wid/mesh.py
@@ -1735,6 +1735,16 @@ def hdl_wid_373(desc):
     return True
 
 
+def hdl_wid_394(desc):
+    """
+    Implements:
+    :param desc: Please start advertising the Mesh Proxy Service with Node Identity.
+    :return:
+    """
+    btp.mesh_proxy_identity()
+    return True
+
+
 def hdl_wid_500(desc):
     """
     Implements:


### PR DESCRIPTION
PTS now implements WID for enabling Node Identity so no need for this
workaround.