### PR TITLE
bot: zephyr: Remove L2CAP/ECFC/BV-38-C test

### DIFF
--- a/bot/iut_config/zephyr.py
+++ b/bot/iut_config/zephyr.py
@@ -83,7 +83,6 @@ iut_config = {
             'L2CAP/ECFC/BV-33-C',
             'L2CAP/ECFC/BV-34-C',
             'L2CAP/ECFC/BV-35-C',
-            'L2CAP/ECFC/BV-38-C',
             'L2CAP/ECFC/BV-41-C',
         ]
     },


### PR DESCRIPTION
This is BR/EDR test and it is not supported by IUT.