### PR TITLE
btp: Fix GAP Pairing Failed event handling

### DIFF
--- a/doc/btp_spec.txt
+++ b/doc/btp_spec.txt
@@ -690,8 +690,8 @@ Events:
 
 		Controller Index:	<controller id>
 		Event parameters:	Address_Type (1 octet)
-							Address (6 octets)
-							Reason (6 octets)
+					Address (6 octets)
+					Reason (1 octet)
 
 		This event can be sent when IUT pairing procedure fails with
 		specified reason.

--- a/ptsprojects/stack.py
+++ b/ptsprojects/stack.py
@@ -154,7 +154,7 @@ class Gap:
 
         self.passkey = Property(None)
         self.conn_params = Property(None)
-        self.pairing_failed_rcvd = False
+        self.pairing_failed_rcvd = Property(False)
 
         # bond_lost data (addr_type, addr)
         self.bond_lost_ev_data = Property(None)
@@ -265,11 +265,10 @@ class Gap:
 
             while flag.is_set():
                 if self.pairing_failed_rcvd:
-                    self.pairing_failed_rcvd = False
                     t.cancel()
                     break
 
-        return True
+        return self.pairing_failed_rcvd
 
 
 class Mesh:

--- a/pybtp/btp/gap.py
+++ b/pybtp/btp/gap.py
@@ -239,7 +239,7 @@ def gap_pairing_failed_ev_(gap, data, data_len):
 
     logging.debug("received %r", data)
 
-    fmt = '<B6sH'
+    fmt = '<B6sB'
     if len(data) != struct.calcsize(fmt):
         raise BTPError("Invalid data length")
 


### PR DESCRIPTION
gap_wait_for_pairing_fail() was always returning true.