### PR TITLE
wid: Always call BTP pair on wid 108

### DIFF
--- a/doc/btp_spec.txt
+++ b/doc/btp_spec.txt
@@ -426,7 +426,10 @@ Commands and responses:
 					Address (6 octets)
 		Return Parameters:	<none>
 
-		This command is used to initiate pairing with remote.
+		This command is used to initiate security with remote. If
+		peer is already paired IUT is expected to enable security
+		(encryption) with peer. If peer is not paired IUT shall
+		start pairing process.
 
 		In case of an error, the error response will be returned.
 

--- a/wid/gap.py
+++ b/wid/gap.py
@@ -474,9 +474,6 @@ def hdl_wid_106(desc):
 
 
 def hdl_wid_108(desc):
-    if desc == 'Please start the Bonding Procedure in bondable mode.':
-        return True
-
     btp.gap_pair()
     return True
 


### PR DESCRIPTION
We don't have separate pair and set_secutiry_level BTP commands so
just clarify expected bahviour on BTP Pair and always call it on
WID 108.