### PR TITLE
zephyr: Remove custom wid 46 handler

### DIFF
--- a/ptsprojects/zephyr/gap_wid.py
+++ b/ptsprojects/zephyr/gap_wid.py
@@ -76,10 +76,6 @@ def gap_wid_hdl_mode1_lvl4(wid, description, test_case_name):
     return gap_wid_hdl(wid, description, test_case_name)
 
 
-def hdl_wid_46(desc):
-    return True
-
-
 def hdl_wid_73(desc):
     btp.gattc_read_uuid(btp.pts_addr_type_get(None), btp.pts_addr_get(None),
                         '0001', 'FFFF', UUID.device_name)


### PR DESCRIPTION
This was affecting GAP/CONN/CPUP/BV-10-C test as IUT is asked to
explicitly update connection parameters.