### PR TITLE
ptsproject: Fix not reinitializing GAP between tests

### DIFF
--- a/ptsprojects/stack.py
+++ b/ptsprojects/stack.py
@@ -904,9 +904,6 @@ class Stack:
 
     def gap_init(self, name=None, manufacturer_data=None, appearance=None,
                  svc_data=None, flags=None, svcs=None, uri=None):
-        if self.gap:
-            return
-
         self.gap = Gap(name, manufacturer_data, appearance, svc_data, flags,
                        svcs, uri)
 


### PR DESCRIPTION
GAP service was not re-initialized between tests resulting in random
failures.

This is a short term solution, in long term we should redesign on how
things are initialized and cleanup during testrun.