### PR TITLE
bot: zephyr: Add GAP/CONN/GCEP/BV-06-C to privacy overlay

### DIFF
--- a/bot/iut_config/zephyr.py
+++ b/bot/iut_config/zephyr.py
@@ -166,6 +166,7 @@ iut_config = {
             'GAP/CONN/ACEP/BV-03-C',
             'GAP/CONN/DCEP/BV-05-C',
             'GAP/CONN/GCEP/BV-05-C',
+            'GAP/CONN/GCEP/BV-06-C',
             'GAP/CONN/NCON/BV-02-C',
             'GAP/CONN/UCON/BV-06-C',
             'GAP/BROB/BCST/BV-03-C',

--- a/bot/iut_config/zephyr.py
+++ b/bot/iut_config/zephyr.py
@@ -165,6 +165,7 @@ iut_config = {
             'GAP/PRIV/CONN/BV-11-C',
             'GAP/CONN/ACEP/BV-03-C',
             'GAP/CONN/DCEP/BV-05-C',
+            'GAP/CONN/DCEP/BV-06-C',
             'GAP/CONN/GCEP/BV-05-C',
             'GAP/CONN/GCEP/BV-06-C',
             'GAP/CONN/NCON/BV-02-C',


### PR DESCRIPTION
GAP/CONN/GCEP/BV-06-C requires privacy support enabled.