### PR TITLE
btp: encode string message as utf-8 in core_log_message

### DIFF
--- a/pybtp/btp/btp.py
+++ b/pybtp/btp/btp.py
@@ -381,9 +381,7 @@ def core_unreg_svc_rsp_succ():
 def core_log_message(message):
     logging.debug("%s", core_log_message.__name__)
 
-    message_data = bytearray(message)
-    data = bytearray(struct.pack('H', len(message_data)))
-    data.extend(message_data)
+    data = bytearray(struct.pack('H', len(message)) + message.encode('utf-8'))
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*CORE['log_message'], data=data)


### PR DESCRIPTION
bytearray(message) for message of type string fails. encoding it in utf-8 fixes this. 