### PR TITLE
zephyr: Fix GAP/SEC/AUT/BV-21-C test

### DIFF
--- a/ptsprojects/zephyr/gap.py
+++ b/ptsprojects/zephyr/gap.py
@@ -266,7 +266,9 @@ def test_cases(ptses):
                             post_wid=108, skip_call=(1,))],
                   generic_wid_hdl=gap_wid_hdl),
         ZTestCase("GAP", "GAP/SEC/AUT/BV-21-C",
-                  cmds=pre_conditions,
+                  cmds=pre_conditions +
+                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only),
+                   TestFunc(btp.gap_pair, post_wid=108)],
                   generic_wid_hdl=gap_wid_hdl),
         # TODO: Inform about lost bond
         ZTestCase("GAP", "GAP/SEC/AUT/BV-22-C",


### PR DESCRIPTION
This test require extra pairing post WID108 despite provided WID
description.