### PR TITLE
zephyr: Fix GAP/CONN/PRDA/BV-02-C test

### DIFF
--- a/ptsprojects/zephyr/gap.py
+++ b/ptsprojects/zephyr/gap.py
@@ -222,6 +222,10 @@ def test_cases(ptses):
                   cmds=pre_conditions + init_gatt_db +
                   [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
                   generic_wid_hdl=gap_wid_hdl),
+        ZTestCase("GAP", "GAP/CONN/PRDA/BV-02-C",
+                  cmds=pre_conditions +
+                  [TestFunc(btp.gap_pair, post_wid=108)],
+                   generic_wid_hdl=gap_wid_hdl),
         ZTestCase("GAP", "GAP/SEC/AUT/BV-11-C",
                   cmds=pre_conditions + init_gatt_db +
                   [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],


### PR DESCRIPTION
This test require extra pairing post WID108 despite provided WID
description.