### PR TITLE
autoptsclient_common: don't restart PTS for not-implemented test cases

### DIFF
--- a/autoptsclient_common.py
+++ b/autoptsclient_common.py
@@ -1017,7 +1017,7 @@ def run_test_cases(ptses, test_case_instances, args):
                     print(exeption_msg)
 
             if timeout or args.recovery and \
-                    (exeption_msg != '' or status not in {'PASS', 'INCONC', 'FAIL'}):
+                    (exeption_msg != '' or status not in {'PASS', 'INCONC', 'FAIL', "NOT_IMPLEMENTED"}):
                 run_recovery(args, ptses)
 
             if (status == 'PASS' and not args.stress_test) or stats.run_count == args.retry:


### PR DESCRIPTION
I'd like to argue that there's no point in restarting PTS if a test case is not implemented by the local pts project :)
(I did disable a lot of them as PTS was hanging in some of them. Now that I got a YKUSH hub, I can also just re-enable them)