### PR TITLE
wid/gatt: WID 10 should store response to verify

### DIFF
--- a/wid/gatt.py
+++ b/wid/gatt.py
@@ -183,7 +183,7 @@ def hdl_wid_4(_: WIDParams):
 def hdl_wid_10(_: WIDParams):
     btp.gattc_disc_all_prim(btp.pts_addr_type_get(),
                             btp.pts_addr_get())
-    btp.gattc_disc_all_prim_rsp()
+    btp.gattc_disc_all_prim_rsp(store_rsp=True)
     return True
 
 


### PR DESCRIPTION
Without this flag we will not store uuids and won't be able to verify
them in WID 17 in test GATT/CL/GAD/BV-01-C.

If the array with verify values are empty then auto-pts returns true
so it means it doesn't perform the check.