### PR TITLE
zephyr: make west flash work when multiple boards are connected

### DIFF
--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -25,7 +25,7 @@ import collections
 import serial
 import autoptsclient_common as autoptsclient
 import ptsprojects.zephyr as autoprojects
-from ptsprojects.boards import get_available_boards, get_free_device, tty_to_com, release_device
+from ptsprojects.boards import get_available_boards, get_debugger_snr, get_free_device, tty_to_com, release_device
 from ptsprojects.testcase_db import DATABASE_FILE
 from ptsprojects.zephyr.iutctl import get_iut, log
 from pathlib import Path
@@ -55,7 +55,7 @@ def build_and_flash(zephyr_wd, board, tty, conf_file=None):
 
     bot.common.check_call(cmd, cwd=tester_dir)
     bot.common.check_call(['west', 'flash', '--skip-rebuild',
-                           '--board-dir', tty], cwd=tester_dir)
+                           '--snr',  get_debugger_snr(tty)], cwd=tester_dir)
 
 
 def flush_serial(tty):


### PR DESCRIPTION
Currently, when multiple boards are connected `nrfjprog` prompts the user to manually choose a board. Giving the `--snr` argument to `west flash` makes `nrfjprog` choose the correct board automatically.

Passing `tty` as the value for `--board-dir` seems to be an error. `--board-dir` should be something like `${ZEPHYR_BASE}/boards/arm/nrf52840dk_nrf52840` if one wants to override the default.