### PR TITLE
Wid functions for read multiple variable length

### DIFF
--- a/ptsprojects/mynewt/gatt_wid.py
+++ b/ptsprojects/mynewt/gatt_wid.py
@@ -345,17 +345,6 @@ def hdl_wid_142(desc):
     return True
 
 
-def hdl_wid_147(desc):
-    MMI.reset()
-    MMI.parse_description(desc)
-
-    hdl1 = MMI.args[0]
-    hdl2 = MMI.args[1]
-    btp.gattc_read_multiple_var(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
-    btp.gattc_read_multiple_var(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
-    return True
-
-
 def hdl_wid_400(desc):
     log("Mynewt sends EATT supported bit")
     return '0000'

--- a/pybtp/btp/gatt.py
+++ b/pybtp/btp/gatt.py
@@ -829,13 +829,7 @@ def gattc_read_long(bd_addr_type, bd_addr, hdl, off, modif_off=None):
     iutctl.btp_socket.send(*GATTC['read_long'], data=data_ba)
 
 
-def gattc_read_multiple(bd_addr_type, bd_addr, *hdls):
-    logging.debug("%s %r %r %r", gattc_read_multiple.__name__, bd_addr_type,
-                  bd_addr, hdls)
-    iutctl = get_iut()
-
-    gap_wait_for_connection()
-
+def _create_read_multiple_req(bd_addr_type, bd_addr, *hdls):
     data_ba = bytearray()
 
     bd_addr_ba = addr2btp_ba(bd_addr)
@@ -849,7 +843,16 @@ def gattc_read_multiple(bd_addr_type, bd_addr, *hdls):
     data_ba.extend(bd_addr_ba)
     data_ba.extend(chr(len(hdls)).encode('utf-8'))
     data_ba.extend(hdls_ba)
+    return data_ba
 
+def gattc_read_multiple(bd_addr_type, bd_addr, *hdls):
+    logging.debug("%s %r %r %r", gattc_read_multiple.__name__, bd_addr_type,
+                  bd_addr, hdls)
+    iutctl = get_iut()
+
+    gap_wait_for_connection()
+
+    data_ba = _create_read_multiple_req(bd_addr_type, bd_addr, *hdls)
     iutctl.btp_socket.send(*GATTC['read_multiple'], data=data_ba)
 
 
@@ -860,20 +863,7 @@ def gattc_read_multiple_var(bd_addr_type, bd_addr, *hdls):
 
     gap_wait_for_connection()
 
-    data_ba = bytearray()
-
-    bd_addr_ba = addr2btp_ba(bd_addr)
-    hdls_j = ''.join(hdl for hdl in hdls)
-    hdls_byte_table = [hdls_j[i:i + 2] for i in range(0, len(hdls_j), 2)]
-    hdls_swp = ''.join([c[1] + c[0] for c in zip(hdls_byte_table[::2],
-                                                 hdls_byte_table[1::2])])
-    hdls_ba = binascii.unhexlify(bytearray(hdls_swp))
-
-    data_ba.extend(chr(bd_addr_type))
-    data_ba.extend(bd_addr_ba)
-    data_ba.extend(chr(len(hdls)))
-    data_ba.extend(hdls_ba)
-
+    data_ba = _create_read_multiple_req(bd_addr_type, bd_addr, *hdls)
     iutctl.btp_socket.send(*GATTC['read_multiple_var'], data=data_ba)
 
 

--- a/wid/gatt.py
+++ b/wid/gatt.py
@@ -1690,7 +1690,7 @@ def hdl_wid_141(params: WIDParams):
 
     hdl1 = MMI.args[0]
     hdl2 = MMI.args[1]
-    btp.gattc_read_multiple(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
+    btp.gattc_read_multiple_var(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
     return '0000'
 
 

--- a/wid/gatt.py
+++ b/wid/gatt.py
@@ -1737,6 +1737,23 @@ def hdl_wid_147(params: WIDParams):
     return True
 
 
+def hdl_wid_148(params: WIDParams):
+    """
+    Please send two Read Multiple Variable Length characteristic requests using these handles: 'XXXX'O 'XXXX'O
+    Required Bearers are "EATT" bearers.
+
+    Description: Verify that the Implementation Under Test (IUT) can receive multiple characteristics.
+    """
+    MMI.reset()
+    MMI.parse_description(params.description)
+
+    hdl1 = MMI.args[0]
+    hdl2 = MMI.args[1]
+    btp.gattc_read_multiple_var(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
+    btp.gattc_read_multiple_var(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
+    return True
+
+
 def hdl_wid_139(params: WIDParams):
     MMI.reset()
     MMI.parse_description(params.description)

--- a/wid/gatt.py
+++ b/wid/gatt.py
@@ -1720,6 +1720,23 @@ def hdl_wid_144(_: WIDParams):
     return True
 
 
+def hdl_wid_147(params: WIDParams):
+    """
+    Please send two Read Multiple Variable Length characteristic requests using these handles: 'XXXX'O 'XXXX'O
+    Required Bearers are "ATT" and "EATT" bearer.
+
+    Description: Verify that the Implementation Under Test (IUT) can receive multiple characteristics.
+    """
+    MMI.reset()
+    MMI.parse_description(params.description)
+
+    hdl1 = MMI.args[0]
+    hdl2 = MMI.args[1]
+    btp.gattc_read_multiple_var(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
+    btp.gattc_read_multiple_var(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
+    return True
+
+
 def hdl_wid_139(params: WIDParams):
     MMI.reset()
     MMI.parse_description(params.description)


### PR DESCRIPTION
- Some wid functions were missing when running tests for read multiple variable length characteristics for Zephyr.
- One wid was reading multiple (not variable length) when the description asked for variable length read.