### PR TITLE
Doing multiple attempts to connect dongle

### DIFF
--- a/ptscontrol.py
+++ b/ptscontrol.py
@@ -652,7 +652,7 @@ class PyPTS:
 
         except pythoncom.com_error as e:
             error_code = parse_ptscontrol_error(e)
-
+            self.stop_test_case(project_name, test_case_name)
             self.recover_pts()
 
         log("Done %s %s %s out: %s", self.run_test_case.__name__,


### PR DESCRIPTION
During long PTS runs, especially with multiple dongles connected, we've seen lots of issues when auto-pts can't reconnect the dongle, after a test timeout for example. These changes fix it in majority of cases, at least.