### PR TITLE
zephyr bot: add recover option for boards with app-protect

### DIFF
--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -55,7 +55,7 @@ def build_and_flash(zephyr_wd, board, tty, conf_file=None):
         cmd = ['bash.exe', '-c', '-i', cmd]  # bash.exe == wsl
 
     bot.common.check_call(cmd, cwd=tester_dir)
-    bot.common.check_call(['west', 'flash', '--skip-rebuild',
+    bot.common.check_call(['west', 'flash', '--skip-rebuild', '--recover',
                            '--snr',  get_debugger_snr(tty)], cwd=tester_dir)
 
 


### PR DESCRIPTION
* The nRF5340 has a flash read-back protection feature. When flash read-back protection is active, you will need to recover the chip before reflashing. If you are flashing with west, run this command for more details on the related --recover option.
* Adding recovery does not affect existing devices.
https://docs.zephyrproject.org/latest/boards/arm/nrf5340dk_nrf5340/doc/index.html#flashing