### PR TITLE
common: Handle GATT Notification Ev asynchronously

### DIFF
--- a/ptsprojects/stack.py
+++ b/ptsprojects/stack.py
@@ -850,6 +850,8 @@ class Gatt:
         self.server_db = GattDB()
         self.last_unique_uuid = 0
         self.verify_values = []
+        self.notification_events = []
+        self.notification_ev_received = Event()
 
     def attr_value_set(self, handle, value):
         attr = self.server_db.attr_lookup_handle(handle)
@@ -894,6 +896,14 @@ class Gatt:
 
         logging.debug("timed out")
         return None
+
+    def notification_ev_recv(self, addr_type, addr, notif_type, handle, data):
+        self.notification_events.append((addr_type, addr, notif_type, handle, data))
+        self.notification_ev_received.set()
+
+    def wait_notification_ev(self, timeout=None):
+        self.notification_ev_received.wait(timeout)
+        self.notification_ev_received.clear()
 
 
 class Stack:

--- a/wid/gatt.py
+++ b/wid/gatt.py
@@ -1000,9 +1000,15 @@ def hdl_wid_82(_: WIDParams):
 
 
 def hdl_wid_90(_: WIDParams):
-    btp.gattc_notification_ev(btp.pts_addr_get(),
-                              btp.pts_addr_type_get(), 1)
-    return True
+    stack = get_stack()
+    gatt = stack.gatt
+
+    gatt.wait_notification_ev(timeout=5)
+
+    assert gatt.notification_events
+    addr_type, addr, notif_type, _, _ = gatt.notification_events[0]
+
+    return (addr_type, addr, notif_type) == (btp.pts_addr_type_get(), btp.pts_addr_get(),  1)
 
 
 def hdl_wid_91(params: WIDParams):
@@ -1048,7 +1054,15 @@ def hdl_wid_92(params: WIDParams):
 
 
 def hdl_wid_95(_: WIDParams):
-    return True
+    stack = get_stack()
+    gatt = stack.gatt
+
+    gatt.wait_notification_ev(timeout=5)
+
+    assert gatt.notification_events
+    addr_type, addr, notif_type, _, _ = gatt.notification_events[0]
+
+    return (addr_type, addr, notif_type) == (btp.pts_addr_type_get(), btp.pts_addr_get(),  2)
 
 
 def hdl_wid_96(_: WIDParams):
@@ -1096,9 +1110,6 @@ def hdl_wid_99(params: WIDParams):
 
     btp.gattc_cfg_indicate(btp.pts_addr_type_get(), btp.pts_addr_get(),
                            1, handle)
-
-    btp.gattc_notification_ev(btp.pts_addr_get(),
-                              btp.pts_addr_type_get(), 2)
 
     return True
 


### PR DESCRIPTION
This change prevents blocking RX while waiting for a Notification Ev.

Relevant to GATT/CL/GAN and GATT/CL/GAI tests.