### PR TITLE
common: Fix post parsing treatment of bot's superguard

### DIFF
--- a/bot/common.py
+++ b/bot/common.py
@@ -92,7 +92,7 @@ class BotConfigArgs(Namespace):
         self.stress_test = args.get('stress_test', False)
         self.ykush = args.get('ykush', None)
         self.recovery = args.get('recovery', False)
-        self.superguard = 60 * float(args.get('superguard', 0))
+        self.superguard = float(args.get('superguard', 0))
 
 
 class BotClient(Client):


### PR DESCRIPTION
Superguard timeout is given by user in minutes, so to convert them to seconds, the time is multiplied by 60. For bot, that was done twice, firstly by bot arg parser, secondly by common client arg parser.