### PR TITLE
ptscontrol: Fix StopTestCase parameter exception

### DIFF
--- a/ptscontrol.py
+++ b/ptscontrol.py
@@ -688,7 +688,7 @@ class PyPTS:
         log("%s %s %s", self.stop_test_case.__name__, project_name,
             test_case_name)
 
-        self._pts.StopTestCase(project_name, test_case_name)
+        self._pts.StopTestCase()
 
     def get_test_case_count_from_tss_file(self, project_name):
         """Returns the number of test cases that are available in the specified


### PR DESCRIPTION
StopTestCase does not take parameters anymore. Fixes exception:
xmlrpc.client.Fault: <Fault 1: "<class 'TypeError'>:
StopTestCase() takes 1 positional argument but 3 were given">