### PR TITLE
common: Fix Client progress indication

### DIFF
--- a/autoptsclient_common.py
+++ b/autoptsclient_common.py
@@ -572,7 +572,8 @@ class TestCaseRunStats:
         elem.attrib["status"] = status
 
         regression = bool(elem.attrib["status"] != "PASS" and elem.attrib["status_previous"] == "PASS")
-        progress = bool(elem.attrib["status"] == "PASS" and elem.attrib["status_previous"] != "PASS")
+        progress = bool(elem.attrib["status"] == "PASS" and elem.attrib["status_previous"] != "PASS" \
+                        and elem.attrib["status_previous"] != "None")
 
         elem.attrib["regression"] = str(regression)
         elem.attrib["progress"] = str(progress)


### PR DESCRIPTION
The test result was marked as progress even when there was no database
records with previous status for that test case.