### PR TITLE
Zephyr: bot: use -i instead of depreciated --snr

### DIFF
--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -56,7 +56,7 @@ def build_and_flash(zephyr_wd, board, tty, conf_file=None):
 
     bot.common.check_call(cmd, cwd=tester_dir)
     bot.common.check_call(['west', 'flash', '--skip-rebuild', '--recover',
-                           '--snr',  get_debugger_snr(tty)], cwd=tester_dir)
+                           '-i',  get_debugger_snr(tty)], cwd=tester_dir)
 
 
 def flush_serial(tty):


### PR DESCRIPTION
Currently while flashing, we receive a warning about the below depreciation. This pr uses the newer argument to select snr

-- west flash: using runner nrfjprog
WARNING: runners: Argument --snr is deprecated, use -i/--dev-id instead.
-- runners.nrfjprog: Recovering and erasing all flash memory.
