### PR TITLE
Add support for new GAP/SEC/SEM tests in PTS 8.2

### DIFF
--- a/bot/iut_config/zephyr.py
+++ b/bot/iut_config/zephyr.py
@@ -96,6 +96,8 @@ iut_config = {
             'GAP/SEC/SEM/BV-26-C',
             'GAP/SEC/SEM/BV-27-C',
             'GAP/SEC/SEM/BV-28-C',
+            'GAP/SEC/SEM/BV-58-C',
+            'GAP/SEC/SEM/BV-61-C',
             'GAP/SEC/SEM/BV-29-C',
             'GAP/SEC/SEM/BI-09-C',
             'GAP/SEC/SEM/BI-10-C',

--- a/ptsprojects/zephyr/gap.py
+++ b/ptsprojects/zephyr/gap.py
@@ -32,8 +32,7 @@ class CHAR:
     name = (None, None, None, UUID.device_name)
 
 
-init_gatt_db = [TestFunc(btp.core_reg_svc_gatt),
-                TestFunc(btp.gatts_add_svc, 0, UUID.VND16_1),
+init_gatt_db = [TestFunc(btp.gatts_add_svc, 0, UUID.VND16_1),
                 TestFunc(btp.gatts_add_char, 0, Prop.read,
                          Perm.read | Perm.read_authn,
                          UUID.VND16_2),
@@ -196,6 +195,9 @@ def test_cases(ptses):
             "GAP", "TSPX_iut_invalid_connection_latency", format(0x0000, '04x'))),
         TestFunc(lambda: pts.update_pixit_param(
             "GAP", "TSPX_iut_invalid_conn_update_supervision_timeout", format(0x0c80, '04x'))),
+
+        TestFunc(btp.core_reg_svc_gatt),
+        TestFunc(stack.gatt_init),
 
         # We do this on test case, because previous one could update
         # this if RPA was used by PTS

--- a/wid/gap.py
+++ b/wid/gap.py
@@ -22,7 +22,7 @@ from time import sleep
 
 from ptsprojects.stack import get_stack
 from pybtp import btp, types
-from pybtp.types import Prop, Perm, UUID, AdType, bdaddr_reverse, WIDParams
+from pybtp.types import Prop, Perm, UUID, AdType, bdaddr_reverse, WIDParams, IOCap
 
 log = logging.debug
 
@@ -930,11 +930,100 @@ def hdl_wid_227(_: WIDParams):
 
 def hdl_wid_232(_: WIDParams):
     stack = get_stack()
-
     stack.gap.ad[AdType.advertising_interval_long] = "000030"
-
     btp.gap_adv_ind_on(ad=stack.gap.ad)
 
+    return True
+
+def hdl_wid_234(params: WIDParams):
+    pattern = re.compile(r"0x([0-9a-fA-F]+)")
+    params = pattern.findall(params.description)
+    if not params:
+        logging.error("parsing error")
+        return False
+
+    handle = params[0]
+
+    btp.gattc_cfg_indicate(btp.pts_addr_type_get(), btp.pts_addr_get(),
+                           1, handle)
+
+    return True
+
+
+def hdl_wid_235(params: WIDParams):
+    pattern = re.compile(r"0x([0-9a-fA-F]+)")
+    params = pattern.findall(params.description)
+    if not params:
+        logging.error("parsing error")
+        return False
+
+    handle = params[0]
+
+    btp.gattc_cfg_notify(btp.pts_addr_type_get(), btp.pts_addr_get(),
+                           1, handle)
+
+    return True
+
+
+def hdl_wid_236(_: WIDParams):
+    # Please confirm that IUT does not send a GATT_HandleValueIndication to the Upper Tester
+    stack = get_stack()
+    gatt = stack.gatt
+
+    gatt.wait_notification_ev(timeout=5)
+
+    if gatt.notification_events:
+        return False
+
+    return True
+
+
+def hdl_wid_237(_: WIDParams):
+    # Please confirm that IUT send a GATT_HandleValueIndication to the Upper Tester
+    stack = get_stack()
+    gatt = stack.gatt
+
+    gatt.wait_notification_ev(timeout=5)
+
+    if gatt.notification_events:
+        return True
+
+    return False
+
+def hdl_wid_238(_: WIDParams):
+    # Please confirm that IUT does not send a GATT_HandleValueNotification  to the Upper Tester
+    stack = get_stack()
+    gatt = stack.gatt
+
+    gatt.wait_notification_ev(timeout=5)
+
+    if gatt.notification_events:
+        return False
+
+    return True
+
+
+def hdl_wid_239(_: WIDParams):
+    # Please confirm that IUT send a GATT_HandleValueNotification  to the Upper Tester
+    stack = get_stack()
+    gatt = stack.gatt
+
+    gatt.wait_notification_ev(timeout=5)
+
+    if gatt.notification_events:
+        return True
+
+    return False
+
+def hdl_wid_240(_: WIDParams):
+    # confirm IUT in sec mode 1 level 2
+    btp.gap_set_io_cap(IOCap.no_input_output)
+    return True
+
+
+def hdl_wid_241(_: WIDParams):
+    # confirm IUT in sec mode 1 level 3
+    btp.gap_set_io_cap(IOCap.keyboard_display)
     return True
 
 


### PR DESCRIPTION
This includes support for required new WIDs. Also GAP tests now always
initialize GATT service as this is used in GAP tests too.