### PR TITLE
Stablize the tests failing randomly

### DIFF
--- a/ptsprojects/stack.py
+++ b/ptsprojects/stack.py
@@ -274,6 +274,21 @@ class Gap:
 
         return self.pairing_failed_rcvd.data
 
+    def gap_wait_for_lost_bond(self, timeout=5):
+        if self.bond_lost_ev_data.data is None:
+            flag = Event()
+            flag.set()
+
+            t = Timer(timeout, timeout_cb, [flag])
+            t.start()
+
+            while flag.is_set():
+                if self.bond_lost_ev_data.data:
+                    t.cancel()
+                    break
+
+        return self.bond_lost_ev_data.data
+
 
 class Mesh:
     def __init__(self, uuid, uuid_lt2=None):
@@ -700,6 +715,23 @@ class L2cap:
 
         while flag.is_set():
             if not self.is_connected(chan_id):
+                t.cancel()
+                return True
+
+        return False
+
+    def wait_for_connection(self, chan_id, timeout=5):
+        if self.is_connected(chan_id):
+            return True
+
+        flag = Event()
+        flag.set()
+
+        t = Timer(timeout, timeout_cb, [flag])
+        t.start()
+
+        while flag.is_set():
+            if self.is_connected(chan_id):
                 t.cancel()
                 return True
 

--- a/pybtp/btp/gap.py
+++ b/pybtp/btp/gap.py
@@ -357,6 +357,12 @@ def gap_wait_for_pairing_fail(timeout=30):
     return stack.gap.gap_wait_for_pairing_fail(timeout)
 
 
+def gap_wait_for_lost_bond(timeout=30):
+    stack = get_stack()
+
+    return stack.gap.gap_wait_for_lost_bond(timeout)
+
+
 def gap_adv_ind_on(ad=None, sd=None, duration=AdDuration.forever, own_addr_type=OwnAddrType.le_identity_address):
     logging.debug("%s %r %r", gap_adv_ind_on.__name__, ad, sd)
 

--- a/wid/gap.py
+++ b/wid/gap.py
@@ -384,6 +384,7 @@ def hdl_wid_76(_: WIDParams):
 
 def hdl_wid_77(_: WIDParams):
     try:
+        btp.gap_wait_for_connection(5)
         btp.gap_disconn()
     except types.BTPError:
         logging.debug("Ignoring expected error on disconnect")
@@ -680,6 +681,7 @@ def hdl_wid_142(_: WIDParams):
 
 
 def hdl_wid_143(_: WIDParams):
+    btp.gap_wait_for_lost_bond(5)
     return bool(get_stack().gap.bond_lost_ev_data.data)
 
 

--- a/wid/l2cap.py
+++ b/wid/l2cap.py
@@ -109,6 +109,7 @@ def hdl_wid_38(_: WIDParams):
     description: Upper Tester command IUT to send a nonsegmented LE data packet to the PTS with any values.
     """
     stack = get_stack()
+    stack.l2cap.wait_for_connection(0)
     channel = stack.l2cap.chan_lookup_id(0)
     if not channel:
         return False
@@ -171,6 +172,7 @@ def hdl_wid_43(_: WIDParams):
     """
     stack = get_stack()
     l2cap = stack.l2cap
+    l2cap.wait_for_connection(0)
     channel = l2cap.chan_lookup_id(0)
     if not channel:
         return False
@@ -271,6 +273,7 @@ def hdl_wid_56(_: WIDParams):
 def hdl_wid_57(_: WIDParams):
     stack = get_stack()
     l2cap = stack.l2cap
+    l2cap.wait_for_connection(0)
     channel = l2cap.chan_lookup_id(0)
     if not channel:
         return False


### PR DESCRIPTION
Following tests are failing randomly due to race conditions between
former WID's event and current WID (that expects the event) timing.
The events arrives late as just couple of miliseconds in failure case.

- GAP/CONN/DCEP/BV-03-C: Connected event arrives late
- GAP/CONN/GCEP/BV-02-C:  Connected event arrives late
- GAP/SEC/AUT/BV-21-C: The bonding lost happens late
- L2CAP/COS/CFC/BV-02-C: L2CAP channel connection event arrives late
- L2CAP/COS/CFC/BV-01-C: L2CAP channel connection event arrives late
- L2CAP/LE/CFC/BV-06-C : L2CAP channel connection event arrives late