### PR TITLE
Fix GAP tests that use GATT server

### DIFF
--- a/ptsprojects/mynewt/gap.py
+++ b/ptsprojects/mynewt/gap.py
@@ -33,8 +33,7 @@ class CHAR:
     name = (None, None, None, UUID.device_name)
 
 
-init_gatt_db = [TestFunc(btp.core_reg_svc_gatt),
-                TestFunc(btp.gatts_add_svc, 0, gatt.PTS_DB.SVC),
+init_gatt_db = [TestFunc(btp.gatts_add_svc, 0, gatt.PTS_DB.SVC),
                 TestFunc(btp.gatts_add_char, 0, Prop.read,
                          Perm.read | Perm.read_authn,
                          gatt.PTS_DB.CHR_READ_WRITE_AUTHEN),
@@ -193,6 +192,8 @@ def test_cases(ptses):
             "TRUE" if stack.gap.iut_addr_is_random() else "FALSE")),
         TestFunc(lambda: pts.update_pixit_param(
             "GAP", "TSPX_delete_ltk", "TRUE")),
+
+        TestFunc(btp.core_reg_svc_gatt),
 
         # We do this on test case, because previous one could update
         # this if RPA was used by PTS

--- a/ptsprojects/zephyr/gap.py
+++ b/ptsprojects/zephyr/gap.py
@@ -197,7 +197,6 @@ def test_cases(ptses):
             "GAP", "TSPX_iut_invalid_conn_update_supervision_timeout", format(0x0c80, '04x'))),
 
         TestFunc(btp.core_reg_svc_gatt),
-        TestFunc(stack.gatt_init),
 
         # We do this on test case, because previous one could update
         # this if RPA was used by PTS

--- a/wid/gap.py
+++ b/wid/gap.py
@@ -551,7 +551,6 @@ def hdl_wid_135(_: WIDParams):
 
 
 def hdl_wid_136(_: WIDParams):
-    btp.core_reg_svc_gatt()
     btp.gatts_add_svc(0, UUID.VND16_1)
     btp.gatts_add_char(0, Prop.read | Prop.auth_swrite,
                        Perm.read | Perm.write_authn, UUID.VND16_2)


### PR DESCRIPTION
GAP WID handlers are using GATT BTP directly so stak should not
initialize GATT support, only BTP service.

This fix regression with GAP/SEC/CSIGN tests.