### PR TITLE
wid: Add a new wid to be ready for next pts release

### DIFF
--- a/wid/l2cap.py
+++ b/wid/l2cap.py
@@ -310,6 +310,11 @@ def hdl_wid_60(params: WIDParams):
     return False
 
 
+def hdl_wid_61(_: WIDParams):
+    """description: Please confirm the IUT does not send the L2CAP Data to the Upper Tester."""
+    return True
+
+
 def hdl_wid_100(_: WIDParams):
     l2cap = get_stack().l2cap
     for channel in l2cap.channels:


### PR DESCRIPTION
**Note: This is fixing an issue that will happen on next PTS release, you can wait to merge or just merge as it is independent change with no harm.**

It looks L2CAP/LE/CID/BI-01-C will fail on next pts
release (>8.2.0). The test will be adding new step
as WID=61 to confirm IUT does not send any l2cap data.

PTS software case:
CASE0072383 (L2CAP/LE/CID/BI-01-C): Updated Test procedure
for utilizing K-frame instead of signaling packet.

I came across with the issue while testing the L2CAP.ets patch (shared in [CASE0072529](https://bluetooth.service-now.com/ess/case_detail.do?sysparm_document_key=x_bsig_case_manage_case,c95e41771b6585100999a9bfbd4bcb2e)) with all l2cap tests. 