### PR TITLE
bot/zephyr: Add support for more Secure Connection GAP tests

### DIFF
--- a/bot/iut_config/zephyr.py
+++ b/bot/iut_config/zephyr.py
@@ -101,6 +101,10 @@ iut_config = {
             'GAP/SEC/SEM/BV-29-C',
             'GAP/SEC/SEM/BI-09-C',
             'GAP/SEC/SEM/BI-10-C',
+            'GAP/SEC/SEM/BI-20-C',
+            'GAP/SEC/SEM/BI-21-C',
+            'GAP/SEC/SEM/BI-22-C',
+            'GAP/SEC/SEM/BI-23-C',
         ]
     },
 


### PR DESCRIPTION
Those test require Secure Connections and key size validation.