### PR TITLE
mynewt: Fix RTT buffer name of IUT debug logger

### DIFF
--- a/ptsprojects/mynewt/iutctl.py
+++ b/ptsprojects/mynewt/iutctl.py
@@ -103,7 +103,7 @@ class MynewtCtl:
             log_file = os.path.join(self.test_case.log_dir,
                                     self.test_case.name.replace('/', '_') +
                                     '_iutctl.log')
-            self.rtt_logger.start('Logger', log_file, self.debugger_snr)
+            self.rtt_logger.start('Terminal', log_file, self.debugger_snr)
 
     def rtt_logger_stop(self):
         if self.rtt_logger:


### PR DESCRIPTION
RTT buffer with "Logger" name has never been configured. Previously None was luckily
casted to 0, the index of the true logging buffer, which is "Terminal".

Note: Logging via RTT buffer 0 can colide with BTP communicattion via UART.
To prevent data loss, set CONSOLE_UART_FLOW_CONTROL: UART_FLOW_CTL_RTS_CTS