### PR TITLE
zephyr: Fix L2CAP/ECFC/BV-29-C test

### DIFF
--- a/ptsprojects/zephyr/l2cap.py
+++ b/ptsprojects/zephyr/l2cap.py
@@ -192,6 +192,10 @@ def test_cases(ptses):
         ZTestCase("L2CAP", "L2CAP/ECFC/BV-15-C",
                   pre_conditions_keysize,
                   generic_wid_hdl=l2cap_wid_hdl),
+        ZTestCase("L2CAP", "L2CAP/ECFC/BV-29-C",
+                  pre_conditions_success +
+                  [TestFunc(lambda: stack.l2cap.num_channels_set(1))],
+                  generic_wid_hdl=l2cap_wid_hdl),
         ZTestCase("L2CAP", "L2CAP/ECFC/BI-01-C",
                   pre_conditions_success +
                   [TestFunc(lambda: stack.l2cap.num_channels_set(1))],


### PR DESCRIPTION
This test required 1 channel to be created on connection.