### PR TITLE
wid/gatt_client: fix import paths after refactor

### DIFF
--- a/autopts/wid/gatt_client.py
+++ b/autopts/wid/gatt_client.py
@@ -23,10 +23,10 @@ import socket
 import struct
 import sys
 
-from pybtp import btp
-from pybtp.types import Prop, Perm, IOCap, UUID, WIDParams, GATTErrorCodes
-from ptsprojects.testcase import MMI
-from ptsprojects.stack import get_stack, GattPrimary, GattService, GattSecondary, GattServiceIncluded, \
+from autopts.pybtp import btp
+from autopts.pybtp.types import Prop, Perm, IOCap, UUID, WIDParams, GATTErrorCodes
+from autopts.ptsprojects.testcase import MMI
+from autopts.ptsprojects.stack import get_stack, GattPrimary, GattService, GattSecondary, GattServiceIncluded, \
     GattCharacteristic, GattCharacteristicDescriptor, GattDB
 
 log = logging.debug


### PR DESCRIPTION
Running autopts_bot.py after the refactor gave the following error:

> Traceback (most recent call last):
  File "autoptsclient_bot.py", line 31, in <module>
    from autopts.bot.mynewt import main as mynewt
  File "/work/tests/ble_conf/pts/auto-pts_client/autopts/bot/mynewt.py", line 28, in <module>
    from autopts.ptsprojects.mynewt.iutctl import get_iut, log
  File "/work/tests/ble_conf/pts/auto-pts_client/autopts/ptsprojects/mynewt/__init__.py", line 16, in <module>
    import autopts.ptsprojects.mynewt.gap
  File "/work/tests/ble_conf/pts/auto-pts_client/autopts/ptsprojects/mynewt/gap.py", line 23, in <module>
    from autopts.ptsprojects.mynewt import gatt
  File "/work/tests/ble_conf/pts/auto-pts_client/autopts/ptsprojects/mynewt/gatt.py", line 24, in <module>
    from autopts.ptsprojects.mynewt.gatt_wid import gatt_wid_hdl
  File "/work/tests/ble_conf/pts/auto-pts_client/autopts/ptsprojects/mynewt/gatt_wid.py", line 27, in <module>
    from autopts.wid.gatt_client import gatt_cl_wid_hdl
  File "/work/tests/ble_conf/pts/auto-pts_client/autopts/wid/gatt_client.py", line 26, in <module>
    from pybtp import btp
ModuleNotFoundError: No module named 'pybtp'

Update the import paths in gatt_client.py to the new folder structure.