### PR TITLE
zephyr: Add support for delayed unpair

### DIFF
--- a/autopts/ptsprojects/zephyr/gap.py
+++ b/autopts/ptsprojects/zephyr/gap.py
@@ -21,7 +21,7 @@ from autopts.client import get_unique_name
 from autopts.ptsprojects.stack import get_stack
 from autopts.ptsprojects.testcase import TestFunc
 from autopts.ptsprojects.zephyr.ztestcase import ZTestCase
-from autopts.ptsprojects.zephyr.gap_wid import gap_wid_hdl, gap_wid_hdl_mode1_lvl2, gap_wid_hdl_mode1_lvl4
+from autopts.ptsprojects.zephyr.gap_wid import gap_wid_hdl, gap_wid_hdl_mode1_lvl2, gap_wid_hdl_mode1_lvl4, gap_wid_hdl_delayed_unpair
 
 
 class SVC:
@@ -303,7 +303,7 @@ def test_cases(ptses):
         ZTestCase("GAP", "GAP/SEC/CSIGN/BI-03-C",
                   cmds=pre_conditions + init_gatt_db +
                   [TestFunc(btp.gap_set_io_cap, IOCap.no_input_output)],
-                  generic_wid_hdl=gap_wid_hdl),
+                  generic_wid_hdl=gap_wid_hdl_delayed_unpair),
         ZTestCase("GAP", "GAP/SEC/CSIGN/BI-04-C",
                   cmds=pre_conditions +
                   [TestFunc(btp.gap_set_io_cap, IOCap.no_input_output)],

--- a/autopts/ptsprojects/zephyr/gap_wid.py
+++ b/autopts/ptsprojects/zephyr/gap_wid.py
@@ -16,6 +16,7 @@
 import logging
 import socket
 import sys
+import time
 
 from autopts.pybtp import btp
 from autopts.pybtp.types import UUID, AdType, UriScheme
@@ -75,6 +76,18 @@ def gap_wid_hdl_mode1_lvl4(wid, description, test_case_name):
         return hdl_wid_139_mode1_lvl4(description)
     return gap_wid_hdl(wid, description, test_case_name)
 
+
+def gap_wid_hdl_delayed_unpair(wid, description, test_case_name):
+    if wid == 135:
+        log("%s, %r, %r, %s", gap_wid_hdl_delayed_unpair.__name__, wid, description,
+            test_case_name)
+        return True
+    if wid == 77:
+        log("%s, %r, %r, %s", gap_wid_hdl_delayed_unpair.__name__, wid, description,
+            test_case_name)
+        btp.gap_unpair()
+        return True
+    return gap_wid_hdl(wid, description, test_case_name)
 
 def hdl_wid_73(desc):
     btp.gattc_read_uuid(btp.pts_addr_type_get(None), btp.pts_addr_get(None),


### PR DESCRIPTION
Zephyr is disconnecting link on unpairing device and this was causing
races if link disconnected before PTS handled response to WID resulting
in test failures.

This patch adds custom WID handler that unpairs device on disconnect
request instead of unpair.

This was affecting GAP/SEC/CSIGN/BI-03-C