### PR TITLE
zephyr: Make GATT/SR/GAW/BV-13-C pass consistently

### DIFF
--- a/autopts/ptsprojects/zephyr/gatt.py
+++ b/autopts/ptsprojects/zephyr/gatt.py
@@ -487,7 +487,7 @@ def test_cases_server(ptses):
                   pre_conditions_1 + init_server_5,
                   generic_wid_hdl=gatt_wid_hdl),
         ZTestCase("GATT", "GATT/SR/GAW/BV-13-C",
-                  pre_conditions_1 + init_server_5,
+                  pre_conditions_1 + init_server_6,
                   generic_wid_hdl=gatt_wid_hdl),
         ZTestCase("GATT", "GATT/SR/GAW/BV-14-C",
                   pre_conditions_1 + init_server_6,


### PR DESCRIPTION
PTS seems to randomly choose characteristics for writes in that test
which results in authentication error if unlucky. Use database 6
which has only 1 long writable characteristic for consistent results.