### PR TITLE
Fixing issues with BlueZ cli argument handling and BTPWorker initialization

### DIFF
--- a/autopts/client.py
+++ b/autopts/client.py
@@ -1076,7 +1076,7 @@ class Client:
         self.boards = get_available_boards(name)
         self.ptses = []
         self.args = None
-        self.arg_parser = parser_class(cli_support=autoprojects.iutctl.CLI_SUPPORT, board_names=self.boards, stack_name=name)
+        self.arg_parser = parser_class(cli_support=autoprojects.iutctl.CLI_SUPPORT, board_names=self.boards)
         self.prev_sigint_handler = None
 
     def start(self, args=None):

--- a/autopts/client.py
+++ b/autopts/client.py
@@ -1066,8 +1066,8 @@ class Client:
         """
         param get_iut: function from autoptsprojects.<project>.iutctl
         param project: name of project
-        param boards: name list of supported boards
-        param args: parsed argument namespace
+        param name: name of stack
+        param parser_class: argument parser
         """
         self.test_cases = None
         self.get_iut = get_iut
@@ -1076,7 +1076,7 @@ class Client:
         self.boards = get_available_boards(name)
         self.ptses = []
         self.args = None
-        self.arg_parser = parser_class(cli_support=autoprojects.iutctl.CLI_SUPPORT, board_names=self.boards)
+        self.arg_parser = parser_class(cli_support=autoprojects.iutctl.CLI_SUPPORT, board_names=self.boards, stack_name=name)
         self.prev_sigint_handler = None
 
     def start(self, args=None):

--- a/autopts/ptsprojects/bluez/README.md
+++ b/autopts/ptsprojects/bluez/README.md
@@ -49,7 +49,8 @@ usage: autoptsclient-bluez.py [-h] [-i IP_ADDR [IP_ADDR ...]]
                               [-l LOCAL_ADDR [LOCAL_ADDR ...]] [-a BD_ADDR]
                               [-d] [-c TEST_CASES [TEST_CASES ...]]
                               [-e EXCLUDED [EXCLUDED ...]] [-r RETRY]
-                              workspace btpclient_path
+                              [--btpclient_path BTPCLIENT_PATH]
+                              workspace
 
 PTS automation client
 
@@ -78,6 +79,8 @@ optional arguments:
   -r RETRY, --retry RETRY
                         Repeat test if failed. Parameter specifies maximum
                         repeat count per test
+  --btpclient_path BTPCLIENT_PATH
+                        Path to btpclient.
 ```
 
 ### Example
@@ -86,7 +89,7 @@ optional arguments:
 # Run all GAP test cases.
 # AutoPTS Server IP: 192.168.0.18
 # Local IP Address:  192.168.0.15
-./autoptsclient-bluez.py "C:\Users\tester\Documents\Profile Tuning Suite\bluez\bluez.pqw6" /home/han1/work/bluez/tools/btpclient -i 192.168.0.18 -l 192.168.0.15 -c GAP
+./autoptsclient-bluez.py "C:\Users\tester\Documents\Profile Tuning Suite\bluez\bluez.pqw6" --btpclient_path=/home/han1/work/bluez/tools/btpclient -i 192.168.0.18 -l 192.168.0.15 -c GAP
 ```
 
 ### Logs

--- a/autopts/ptsprojects/bluez/iutctl.py
+++ b/autopts/ptsprojects/bluez/iutctl.py
@@ -20,7 +20,7 @@ import socket
 
 from autopts.pybtp import defs
 from autopts.pybtp.types import BTPError
-from autopts.pybtp.iutctl_common import BTPWorker, BTP_ADDRESS
+from autopts.pybtp.iutctl_common import BTPSocketSrv, BTPWorker, BTP_ADDRESS
 
 log = logging.debug
 IUT = None
@@ -48,14 +48,17 @@ class IUTCtl:
 
         self.btpclient_path = args.btpclient_path
         self.btp_socket = None
+        self.btp_address = BTP_ADDRESS
+        self.socket_srv = None
         self.iut_process = None
 
     def start(self):
         """Starts the IUT"""
 
         log("%s.%s", self.__class__, self.start.__name__)
-        self.btp_socket = BTPWorker()
-        self.btp_socket.open()
+        self.socket_srv = BTPSocketSrv()
+        self.socket_srv.open(self.btp_address)
+        self.btp_socket = BTPWorker(self.socket_srv)
 
         iut_cmd = get_iut_cmd(self.btpclient_path)
 

--- a/autopts/ptsprojects/bluez/iutctl.py
+++ b/autopts/ptsprojects/bluez/iutctl.py
@@ -27,7 +27,7 @@ IUT = None
 
 # IUT log file object
 IUT_LOG_FO = None
-CLI_SUPPORT = ['btp_py']
+CLI_SUPPORT = ['btp_py', 'btpclient_path']
 
 
 def get_iut_cmd(btpclient_path):

--- a/cliparser.py
+++ b/cliparser.py
@@ -26,7 +26,7 @@ from autopts.utils import usb_power
 
 
 class CliParser(argparse.ArgumentParser):
-    def __init__(self, cli_support=None, board_names=None, add_help=True, stack_name=None):
+    def __init__(self, cli_support=None, board_names=None, add_help=True):
         super().__init__(description='PTS automation client', add_help=add_help)
 
         self.add_argument("-i", "--ip_addr", nargs="+",

--- a/cliparser.py
+++ b/cliparser.py
@@ -138,7 +138,7 @@ class CliParser(argparse.ArgumentParser):
             self.add_argument("--btp-tcp-port", type=str, default=64000,
                               help="Port for external btp client over TCP/IP.")
 
-        if stack_name == "bluez":
+        if 'btpclient_path' in self.cli_support:
             self.add_argument("--btpclient_path", type=str, default=None,
                               help="Path to btpclient.")
 

--- a/cliparser.py
+++ b/cliparser.py
@@ -26,7 +26,7 @@ from autopts.utils import usb_power
 
 
 class CliParser(argparse.ArgumentParser):
-    def __init__(self, *, cli_support=None, board_names=None, add_help=True, stack_name=None):
+    def __init__(self, cli_support=None, board_names=None, add_help=True, stack_name=None):
         super().__init__(description='PTS automation client', add_help=add_help)
 
         self.add_argument("-i", "--ip_addr", nargs="+",

--- a/cliparser.py
+++ b/cliparser.py
@@ -26,7 +26,7 @@ from autopts.utils import usb_power
 
 
 class CliParser(argparse.ArgumentParser):
-    def __init__(self, cli_support=None, board_names=None, add_help=True):
+    def __init__(self, *, cli_support=None, board_names=None, add_help=True, stack_name=None):
         super().__init__(description='PTS automation client', add_help=add_help)
 
         self.add_argument("-i", "--ip_addr", nargs="+",
@@ -137,6 +137,10 @@ class CliParser(argparse.ArgumentParser):
                               help="IP for external btp client over TCP/IP.")
             self.add_argument("--btp-tcp-port", type=str, default=64000,
                               help="Port for external btp client over TCP/IP.")
+
+        if stack_name == "bluez":
+            self.add_argument("--btpclient_path", type=str, default=None,
+                              help="Path to btpclient.")
 
         self.add_positional_args()
 


### PR DESCRIPTION
Fixing issues with BlueZ cli argument handling and BTPWorker initialization not being updated for BlueZ stack.

Positional argument for BlueZ btpclient conflicts with positional kernel argument. This makes BlueZ stack fail with uninitialized variable `btpclient_path`. Changed cli for btpclient path setting to an optional option `--btpclient_path`. This may no impact is imposed on other stacks, and the option is only shown in help for the relevant BlueZ stack.

Updated BlueZ iutctl according to refactored BTPWorker, that now requires a socket parameter.