### PR TITLE
gatt: Add reading response for ATT_READ_MULTIPLE_VAR_REQ

### DIFF
--- a/autopts/pybtp/btp/gatt.py
+++ b/autopts/pybtp/btp/gatt.py
@@ -1615,6 +1615,27 @@ def gattc_read_multiple_rsp(store_val=False, store_rsp=False):
         if store_val:
             add_to_verify_values((binascii.hexlify(values[0])).decode().upper())
 
+def gattc_read_multiple_var_rsp(store_val=False, store_rsp=False):
+    iutctl = get_iut()
+
+    tuple_hdr, tuple_data = iutctl.btp_socket.read()
+    logging.debug("%s received %r %r", gattc_read_multiple_var_rsp.__name__,
+                  tuple_hdr, tuple_data)
+
+    btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
+                  defs.GATT_READ_MULTIPLE_VAR)
+
+    rsp, values = gatt_dec_read_rsp(tuple_data[0])
+    logging.debug("%s %r %r", gattc_read_multiple_var_rsp.__name__, rsp, values)
+
+    if store_rsp or store_val:
+        clear_verify_values()
+
+        if store_rsp:
+            add_to_verify_values(att_rsp_str[rsp])
+
+        if store_val:
+            add_to_verify_values((binascii.hexlify(values[0])).decode().upper())
 
 def gattc_write_rsp(store_rsp=False, timeout=None):
     iutctl = get_iut()

--- a/autopts/wid/gatt.py
+++ b/autopts/wid/gatt.py
@@ -1665,7 +1665,13 @@ def hdl_wid_140(params: WIDParams):
     hdl1 = MMI.args[0]
     hdl2 = MMI.args[1]
     btp.gattc_read_multiple_var(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
-    return '0000'
+
+    if params.test_case_name.startswith("GATT/CL/GAR/BI"):
+        btp.gattc_read_multiple_var_rsp(store_rsp=True, store_val=False)
+    else:
+        btp.gattc_read_multiple_var_rsp(store_rsp=False, store_val=True)
+
+    return True
 
 
 def hdl_wid_141(params: WIDParams):
@@ -1675,7 +1681,12 @@ def hdl_wid_141(params: WIDParams):
     hdl1 = MMI.args[0]
     hdl2 = MMI.args[1]
     btp.gattc_read_multiple_var(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
-    return '0000'
+    if params.test_case_name.startswith("GATT/CL/GAR/BI"):
+        btp.gattc_read_multiple_var_rsp(store_rsp=True, store_val=False)
+    else:
+        btp.gattc_read_multiple_var_rsp(store_rsp=False, store_val=True)
+
+    return True
 
 
 def hdl_wid_142(params: WIDParams):


### PR DESCRIPTION
Not reading the response causes the following tests to fail:
GATT/CL/GAR/BV-08-C
GATT/CL/GAR/BI-36-C
GATT/CL/GAR/BI-38-C
GATT/CL/GAR/BI-40-C
GATT/CL/GAR/BI-44-C

Now, the response or received value to the request is read, and is available when it is checked.