### PR TITLE
Fix bisect tool

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -15,6 +15,7 @@
 import copy
 import logging
 import os
+import pathlib
 import re
 import subprocess
 import sys
@@ -944,6 +945,12 @@ def update_repos(project_path, git_config):
 
         if conf.get('west_update', False):
             bot.common.check_call(['west', 'update'], cwd=repo_path)
+
+        if conf.get('rm_pycache', False):
+            for p in pathlib.Path(repo_path).rglob('*.py[co]'):
+                p.unlink()
+            for p in pathlib.Path(repo_path).rglob('__pycache__'):
+                p.rmdir()
 
     return repos_dict
 

--- a/tools/cron/autopts_bisect.py
+++ b/tools/cron/autopts_bisect.py
@@ -130,6 +130,9 @@ def bisect(cfg, test_case, good_commit, bad_commit=''):
     report = os.path.join(AUTOPTS_REPO, 'report.txt')
     res = None
 
+    if os.path.exists(report):
+        os.remove(report)
+
     try:
         if res := bisect_start(project_repo):
             raise Exception('bisect_start failed: {}'.format(res))
@@ -146,6 +149,7 @@ def bisect(cfg, test_case, good_commit, bad_commit=''):
                 raise Exception('Bot failed during bisect run')
             with open(report) as f:
                 content = f.read()
+            os.remove(report)
             if 'PASS' in content:
                 print(res := bisect_good(project_repo))
             else:


### PR DESCRIPTION
Fixes for:
- report.txt from previous run prevented the bisect tool from stop in case of build failure.
- sometimes after repo update pycaches remains with old compilation