### PR TITLE
zephyr: gatt: Modify GATT database for test

### DIFF
--- a/autopts/ptsprojects/zephyr/gatt.py
+++ b/autopts/ptsprojects/zephyr/gatt.py
@@ -298,9 +298,6 @@ def test_cases_server(ptses):
                      TestFunc(btp.gap_adv_ind_on, start_wid=1)]
 
     init_server_5 = [TestFunc(btp.gatts_add_svc, 0, UUID.VND16_1),
-                     TestFunc(btp.gatts_add_char, 0, Prop.read | Prop.write,
-                              Perm.read | Perm.write_authn, UUID.VND16_2),
-                     TestFunc(btp.gatts_set_val, 0, Value.long_4),
                      TestFunc(btp.gatts_add_char, 0,
                               Prop.read | Prop.write,
                               Perm.read | Perm.write, UUID.VND16_3),
@@ -310,12 +307,8 @@ def test_cases_server(ptses):
                      TestFunc(btp.gatts_set_val, 0, Value.long_4),
                      TestFunc(btp.gatts_add_char, 0,
                               Prop.read | Prop.write,
-                              Perm.read | Perm.write_authz, UUID.VND16_5),
+                              Perm.read | Perm.write, UUID.VND16_5),
                      TestFunc(btp.gatts_set_val, 0, Value.long_4),
-                     TestFunc(btp.gatts_add_char, 0, Prop.read | Prop.write,
-                              Perm.read | Perm.write_enc, UUID.VND16_5),
-                     TestFunc(btp.gatts_set_val, 0, Value.long_4),
-                     TestFunc(btp.gatts_set_enc_key_size, 0, 0x0f),
                      TestFunc(btp.gatts_add_char, 0,
                               Prop.read | Prop.write,
                               Perm.read | Perm.write, UUID.VND16_6),


### PR DESCRIPTION
GATT/SR/GAW/BV-12-C fails occasionally, because PTS gets ATT
Insufficient Authentication/Authorization error for ATT Prepare Write.
This removes security requirements for attributes, as none of the test
cases that uses init_server_5 makes use of it.

1/3   GATT    GATT/SR/GAW/BV-10-C   PASS            48.488
2/3   GATT    GATT/SR/GAW/BV-09-C   PASS            35.655
3/3   GATT    GATT/SR/GAW/BV-12-C   PASS            44.965