### PR TITLE
wid: Fix race condition in l2cap credit based connection

### DIFF
--- a/autopts/ptsprojects/stack.py
+++ b/autopts/ptsprojects/stack.py
@@ -703,7 +703,6 @@ class L2cap:
     def is_connected(self, chan_id):
         chan = self.chan_lookup_id(chan_id)
         if chan is None:
-            logging.error("unknown channel")
             return False
 
         return chan.is_connected(10)

--- a/autopts/wid/l2cap.py
+++ b/autopts/wid/l2cap.py
@@ -475,6 +475,7 @@ def hdl_wid_254(_: WIDParams):
 
 
 def hdl_wid_255(params: WIDParams):
+    """ description: Please send L2CAP Credit Based Connection REQ to PTS."""
     stack = get_stack()
 
     if params.test_case_name == "L2CAP/TIM/BV-03-C":
@@ -483,6 +484,10 @@ def hdl_wid_255(params: WIDParams):
     else:
         l2cap = stack.l2cap
         btp.l2cap_conn(None, None, l2cap.psm, l2cap.initial_mtu, l2cap.num_channels, 1, l2cap.hold_credits)
+
+        # Wait until all channels connected to avoid race condition between channel connection and new received wid
+        for channel_id in range(l2cap.num_channels):
+            l2cap.wait_for_connection(channel_id)
 
     return True
 


### PR DESCRIPTION
Depending on the HW setup and board tested, some tests may fail if a
new WID is received before before a credit based L2CAP channel
is actually connected.

The scenario goes:
 1. l2cap wid 255 is called
 2. The next L2CAP wid is received, expecting do do something with
    the connected channel(s)
 3. l2cap_connected_ev is received

This problem has been observed with the following tests on nrf53.
- L2CAP/ECFC/BV-06-C
- L2CAP/ECFC/BV-08-C
- L2CAP/ECFC/BV-23-C