### PR TITLE
bot: Split errata.yaml into multiple files

### DIFF
--- a/autopts/bot/mynewt.py
+++ b/autopts/bot/mynewt.py
@@ -20,6 +20,7 @@ import os
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 from autopts import bot
 from autopts.client import Client
@@ -27,6 +28,9 @@ from autopts.ptsprojects.boards import get_free_device, release_device, get_buil
     get_board_type
 from autopts.ptsprojects.mynewt.iutctl import get_iut, log
 from autopts.ptsprojects.testcase_db import DATABASE_FILE
+
+
+PROJECT_NAME = Path(__file__).stem
 
 
 def check_call(cmd, env=None, cwd=None, shell=True):
@@ -211,9 +215,9 @@ def main(cfg):
     pts_logs, xmls = bot.common.pull_server_logs(MynewtBotConfigArgs(args))
 
     report_file = bot.common.make_report_xlsx(results, summary, regressions,
-                                              progresses, descriptions, xmls)
+                                              progresses, descriptions, xmls, PROJECT_NAME)
     report_txt = bot.common.make_report_txt(results, regressions,
-                                            progresses, repo_status)
+                                            progresses, repo_status, PROJECT_NAME)
     logs_folder = bot.common.archive_testcases("logs")
 
     build_info_file = get_build_info_file(os.path.abspath(args['project_path']))

--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -36,6 +36,9 @@ from autopts.ptsprojects.testcase_db import DATABASE_FILE
 from autopts.ptsprojects.zephyr.iutctl import get_iut, log
 
 
+PROJECT_NAME = Path(__file__).stem
+
+
 def flush_serial(tty):
     """Clear the serial port buffer
     :param tty: file path of the terminal
@@ -245,9 +248,9 @@ def main(cfg):
     pts_logs, xmls = bot.common.pull_server_logs(args_ns)
 
     report_file = bot.common.make_report_xlsx(results, summary, regressions,
-                                              progresses, descriptions, xmls)
+                                              progresses, descriptions, xmls, PROJECT_NAME)
     report_txt = bot.common.make_report_txt(results, regressions,
-                                            progresses, repo_status)
+                                            progresses, repo_status, PROJECT_NAME)
 
     end_time = time.time()
     end_time_stamp = datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")

--- a/errata/common.yaml
+++ b/errata/common.yaml
@@ -1,7 +1,6 @@
-# To add note to reports about awaited errata, list them here e.g.:
+# To add note to the reports about awaited errata, list them here e.g.:
 # GAP/CONN/NCON/BV-01-C: CASE00xxxxx
 # GAP/CONN/NCON/BV-02-C: CASE00xxxxx
-
 
 GAP/CONN/CPUP/BV-04-C: CASE0072503
 GAP/CONN/CPUP/BV-05-C: CASE0072503
@@ -71,10 +70,7 @@ MESH/PVNR/PROV/BI-18-C: https://github.com/zephyrproject-rtos/zephyr/pull/38464
 MESH/NODE/PROV/BI-02-C: https://github.com/zephyrproject-rtos/zephyr/pull/38250
 MESH/NODE/CFG/MP/BI-03-C: https://github.com/zephyrproject-rtos/zephyr/pull/38360
 MESH/NODE/FRND/FN/BV-08-C: https://github.com/zephyrproject-rtos/zephyr/pull/38312
-MMDL/SR/LLC/BV-04-C: CASE0071690 CASE0071677 - https://github.com/nrfconnect/sdk-nrf/pull/5585
-MMDL/SR/SCE/BV-03-C: CASE0071374 - https://github.com/nrfconnect/sdk-nrf/pull/5614
 MMDL/SR/LCTLT/BV-02-C: CASE0071445 https://www.bluetooth.org/tse/errata_view.cfm?errata_id=17080
-MMDL/SR/LHSL/BV-08-C: https://github.com/nrfconnect/sdk-nrf/pull/5636
 MMDL/CL/SNR/BV-07-C: CASE0071833
 MMDL/CL/SNR/BV-08-C: CASE0071833
 MMDL/CL/SNR/BV-09-C: CASE0071833

--- a/errata/mynewt.yaml
+++ b/errata/mynewt.yaml
@@ -1,0 +1,3 @@
+# To add note to the reports about awaited errata, list them here e.g.:
+# GAP/CONN/NCON/BV-01-C: CASE00xxxxx
+# GAP/CONN/NCON/BV-02-C: CASE00xxxxx

--- a/errata/zephyr.yaml
+++ b/errata/zephyr.yaml
@@ -1,0 +1,7 @@
+# To add note to the reports about awaited errata, list them here e.g.:
+# GAP/CONN/NCON/BV-01-C: CASE00xxxxx
+# GAP/CONN/NCON/BV-02-C: CASE00xxxxx
+
+MMDL/SR/LLC/BV-04-C: CASE0071690 CASE0071677 - https://github.com/nrfconnect/sdk-nrf/pull/5585
+MMDL/SR/SCE/BV-03-C: CASE0071374 - https://github.com/nrfconnect/sdk-nrf/pull/5614
+MMDL/SR/LHSL/BV-08-C: https://github.com/nrfconnect/sdk-nrf/pull/5636


### PR DESCRIPTION
There is one errata/common.yaml which can be overwritten with errata/<project_name>.yaml.