### PR TITLE
Fix L2CAP WID 108 implementation

### DIFF
--- a/autopts/wid/l2cap.py
+++ b/autopts/wid/l2cap.py
@@ -379,6 +379,8 @@ def hdl_wid_107(_: WIDParams):
 
 
 def hdl_wid_108(_: WIDParams):
+    """ desciption: Please configure the IUT into LE Security and start pairing process."""
+    btp.gap_pair()
     return True
 
 


### PR DESCRIPTION
This WID requires IUT to start pairing.
This was affecting L2CAP/ECFC/BV-13-C and L2CAP/ECFC/BV-15-C
tests (with custom ETS from PTS issue).