### PR TITLE
common: Terminate PTS and BPV after run

### DIFF
--- a/autopts/client.py
+++ b/autopts/client.py
@@ -500,6 +500,7 @@ def shutdown_pts(ptses):
             'http://%s/' % pts.__getattribute__('_ServerProxy__host'),
             allow_none=True)
         proxy.unregister_xmlrpc_ptscallback()
+        proxy.shutdown_pts_bpv()
 
         if isinstance(pts.callback_thread, CallbackThread):
             pts.callback_thread.stop()

--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -322,6 +322,7 @@ class Server(threading.Thread):
         self.server.register_function(self.delete_file, 'delete_file')
         self.server.register_function(self.ready, 'ready')
         self.server.register_function(self.get_system_model, 'get_system_model')
+        self.server.register_function(self.shutdown_pts_bpv, 'shutdown_pts_bpv')
         self.server.register_instance(self.pts)
         self.server.register_introspection_functions()
         self.server.timeout = 1.0
@@ -392,6 +393,10 @@ class Server(threading.Thread):
             os.remove(file_path)
         elif os.path.isdir(file_path):
             shutil.rmtree(file_path, ignore_errors=True)
+
+    def shutdown_pts_bpv(self):
+        kill_all_processes('PTS.exe')
+        kill_all_processes('Fts.exe')
 
 
 def multi_main(_args, _superguard):


### PR DESCRIPTION
Sometimes PTS or BPV does not release a handle to a log file after a test case is completed. After the last test case PTS and BPV are not restarted, so to avoid autoptsbot failure with the exception: "The process cannot access the file because it is being used by another process", lets terminate them before saving the logs.