### PR TITLE
Fix for MMDL/CL/SNR/BV-13-C after PTS patch

### DIFF
--- a/autopts/wid/mmdl.py
+++ b/autopts/wid/mmdl.py
@@ -815,8 +815,16 @@ def sensor_column_status(params):
 
 def sensor_series_get(params):
     sensor_id = params['PropertyId']
-    raw_value_x1 = hex(params['RawValueX1'])[2:]
-    raw_value_x2 = hex(params['RawValueX2'])[2:]
+    if params['RawValueX1'] is None:
+        raw_value_x1 = '10'
+    else:
+        raw_value_x1 = hex(params['RawValueX1'])[2:]
+
+    if params['RawValueX2'] is None:
+        raw_value_x2 = '20'
+    else:
+        raw_value_x2 = hex(params['RawValueX2'])[2:]
+
     btp.mmdl_sensor_series_get(sensor_id, raw_value_x1 + raw_value_x2)
     return True
 


### PR DESCRIPTION
PTS does not request now specific Raw Values X's to be sent;
let's set 0x10, 0x20 if None is specified.