### PR TITLE
client: bot: Move pts/bpv shutdown

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -817,6 +817,8 @@ def pull_server_logs(args):
         with ServerProxy("http://{}:{}/".format(server_addr[i], server_port[i]),
                          allow_none=True, ) as proxy:
             file_list = proxy.list_workspace_tree(workspace_dir)
+            proxy.shutdown_pts_bpv()
+
             if len(file_list) == 0:
                 continue
 

--- a/autopts/client.py
+++ b/autopts/client.py
@@ -500,7 +500,6 @@ def shutdown_pts(ptses):
             'http://%s/' % pts.__getattribute__('_ServerProxy__host'),
             allow_none=True)
         proxy.unregister_xmlrpc_ptscallback()
-        proxy.shutdown_pts_bpv()
 
         if isinstance(pts.callback_thread, CallbackThread):
             pts.callback_thread.stop()


### PR DESCRIPTION
Shutdown of Bluetooth Protocol Viewer is only helpful while pulling server logs after bot run. It is annoying when analyzing test cases with simple client.