### PR TITLE
errata/common: cleanup Mesh tests

### DIFF
--- a/errata/common.yaml
+++ b/errata/common.yaml
@@ -43,26 +43,6 @@ MESH/NODE/KR/BI-05-C: TSE19039
 MESH/NODE/KR/BV-02-C: TSE19039
 MESH/NODE/KR/BV-03-C: TSE19039
 MESH/NODE/IVU/BI-06-C: TSE18991 TCW1571
-MESH/CFGCL/KR/BV-04-C: Fixed in 8.1.0
-MESH/NODE/PROV/BV-10-C: CASE0071466 Fixed in 8.1.0
-MESH/NODE/CFG/HBP/BV-02-C: CASE0071465 Fixed in 8.1.0
-MESH/CFGCL/CFG/SL/BV-01-C: CASE0071125 Fixed in 8.1.0
-MESH/PVNR/PROV/BV-01-C: https://github.com/zephyrproject-rtos/zephyr/pull/38492
-MESH/PVNR/PROV/BV-02-C: https://github.com/zephyrproject-rtos/zephyr/pull/38492
-MESH/PVNR/PROV/BV-03-C: https://github.com/zephyrproject-rtos/zephyr/pull/38492
-MESH/PVNR/PROV/BV-04-C: https://github.com/zephyrproject-rtos/zephyr/pull/38492
-MESH/PVNR/PROV/BV-05-C: https://github.com/zephyrproject-rtos/zephyr/pull/38492
-MESH/PVNR/PROV/BV-06-C: https://github.com/zephyrproject-rtos/zephyr/pull/38492
-MESH/PVNR/PROV/BV-08-C: https://github.com/zephyrproject-rtos/zephyr/pull/38492
-MESH/NODE/PROV/BV-02-C: https://github.com/zephyrproject-rtos/zephyr/pull/38492
-MESH/NODE/PROV/BV-04-C: https://github.com/zephyrproject-rtos/zephyr/pull/38492
-MESH/NODE/PROV/BV-05-C: https://github.com/zephyrproject-rtos/zephyr/pull/38492
-MESH/NODE/PROV/BV-06-C: https://github.com/zephyrproject-rtos/zephyr/pull/38492
-MESH/NODE/PROV/BV-08-C: https://github.com/zephyrproject-rtos/zephyr/pull/38492
-MESH/PVNR/PROV/BI-18-C: https://github.com/zephyrproject-rtos/zephyr/pull/38464
-MESH/NODE/PROV/BI-02-C: https://github.com/zephyrproject-rtos/zephyr/pull/38250
-MESH/NODE/CFG/MP/BI-03-C: https://github.com/zephyrproject-rtos/zephyr/pull/38360
-MESH/NODE/FRND/FN/BV-08-C: https://github.com/zephyrproject-rtos/zephyr/pull/38312
 MMDL/CL/SNR/BV-07-C: CASE0071833
 MMDL/CL/SNR/BV-08-C: CASE0071833
 MMDL/CL/SNR/BV-09-C: CASE0071833


### PR DESCRIPTION
Removed testcases that pass, either because patch was merged or PTS fixed an issue.