### PR TITLE
wid: Accept partial matches for GATT WID 35

### DIFF
--- a/autopts/pybtp/btp/btp.py
+++ b/autopts/pybtp/btp/btp.py
@@ -193,6 +193,48 @@ def verify_description(description):
     return True
 
 
+def verify_description_truncated(description):
+    """A function to verify that truncated values are in PTS MMI description.
+
+    Verification is successful if the PTS MMI description contains a value
+    starting with the value under verification.
+
+    Returns True if verification is successful, False if not.
+
+    description -- MMI description
+
+    """
+    logging.debug("description=%r", description)
+
+    description_values = re.findall(r"(?:'|=\s+)([0-9-xA-Fa-f]{2,})", description)
+    logging.debug("Description values: %r", description_values)
+
+    verify_values = get_verify_values()
+    logging.debug("Verifying values: %r", verify_values)
+
+    # verify_values shall not be a string: all its characters will be verified
+    assert isinstance(verify_values, list), "verify_values should be a list!"
+
+    verify_values = list(map(str.upper, verify_values))
+    description_values = list(map(str.upper, description_values))
+
+    unverified_desc = [x for x in description_values if x not in verify_values]
+    if unverified_desc:
+        logging.debug("Verifying for partial matches: %r", unverified_desc)
+
+        for desc_value in unverified_desc:
+            matches = [x for x in verify_values if desc_value.startswith(x) and len(x) > 8]
+            if not matches:
+                logging.debug("Verification failed, %r not in verify values", desc_value)
+                return False
+
+    logging.debug("All verifications passed")
+
+    clear_verify_values()
+
+    return True
+
+
 def verify_multiple_read_description(description):
     """A function to verify that merged multiple read att values are in
 

--- a/autopts/wid/gatt.py
+++ b/autopts/wid/gatt.py
@@ -570,7 +570,8 @@ def hdl_wid_34(_: WIDParams):
     return True
 
 def hdl_wid_35(params: WIDParams):
-    return btp.verify_description(params.description)
+    # Partial matches are allowed for WID 35 as the verify values may be truncated to ATT_MTU
+    return btp.verify_description_truncated(params.description)
 
 
 def hdl_wid_40(params: WIDParams):


### PR DESCRIPTION
The GATT/CL/GAR/BV-03-C test case may randomly return very long description values, which will be truncated to ATT_MTU unless read using ATT_READ_BLOB_REQ. 
Accepting partial matches is valid as confirmed by BT SIG support and fixes these intermittent test case failures.

An example of one such long description is:

```
Please confirm IUT received Attribute Handle = '0025'O Value = '3131313131323232323233333333333434343434353535353536363636363737373737383838383839393939393030303030313131313132323232323333333333343434343435353535353636363636373737373738383838383939393939303030303031313131313232323232333333333334343434343535353535363636363637373737373838383838393939393930303030303131313131323232323233333333333434343434353535353536363636363737373737383838383839393939393030303030313131313132323232323333333333343434343435353535353636363636373737373738383838383939393939303030303031313131313232323232333333333334343434343535353535363636363637373737373838383838393939393930303030303131313131323232323233333333333434343434353535353536363636363737373737383838383839393939393030303030313131313132323232323333333333343434343435353535353636363636373737373738383838383939393939303030303031313131313232323232333333333334343434343535353535363636363637373737373838383838393939393930303030303131313131323232323233333333333434343434353535353536363636363737373737383838383839393939393030303030313233343536373839303132'O  in random selected adopted database. ATT_READ_BLOB_REQ PDU can be used to read the remaining octets of a long attribute value. Click Yes if IUT received it, otherwise click No.

Description: Verify that the Implementation Under Test (IUT) can send Read by type request to PTS random select adopted database.
```