### PR TITLE
Add test specific retry count

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ configurations and reporting the results.
 - Fetching recent project sources
 - Applying changes to project configuration files via "iut_config"
 with "overlay" that need to be applied for "test_cases"
+- setting test-specific retry count via "retry_config"
 - Building ZephyrOS/MynewtOS image
 - Flashing board
 - Running all the test cases
@@ -280,6 +281,9 @@ specific changes in IUT configuration. It consists of dict of configuration
 names and related key: value pairs:
     - `overlay` - changes in config to be applied
     - `test_cases` - test cases to be ran with this config
+- `retry_config` - allows to set test-specific retry count. This value overrides
+default setting `retry`, allowing to both increase and decrease it. This setting
+is in form of dictionary of testcase names and retry counts (as `int`)
 * `scheduler` - Scheduler configuration (optional)
     - `weekday`: "time" dictionary.
 

--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -45,6 +45,7 @@ from autopts import bot
 from autopts import client as autoptsclient
 from autopts.client import CliParser, Client
 from autopts.ptsprojects.testcase_db import DATABASE_FILE
+from autopts.bot.iut_config.zephyr import retry_config
 
 SCOPES = 'https://www.googleapis.com/auth/drive'
 CLIENT_SECRET_FILE = 'client_secret.json'
@@ -161,7 +162,7 @@ class BotClient(Client):
             self.apply_config(_args[config], config, self.iut_config[config])
 
             status_count, results_dict, regressions, progresses = \
-                autoptsclient.run_test_cases(self.ptses, self.test_cases, _args[config])
+                autoptsclient.run_test_cases(self.ptses, self.test_cases, _args[config], retry_config)
 
             total_regressions += regressions
             total_progresses += progresses

--- a/autopts/bot/iut_config/mynewt.py
+++ b/autopts/bot/iut_config/mynewt.py
@@ -150,3 +150,6 @@ iut_config = {
         ]
     },
 }
+
+retry_config = {
+}

--- a/autopts/bot/iut_config/nrf.py
+++ b/autopts/bot/iut_config/nrf.py
@@ -34,3 +34,6 @@ iut_config_mesh = {
     #     "test_cases": ['MESH/NODE/CFG/NKL/BI-03-C']
     # },
 }
+
+retry_config = {
+}

--- a/autopts/bot/iut_config/zephyr.py
+++ b/autopts/bot/iut_config/zephyr.py
@@ -164,3 +164,6 @@ iut_config = {
         ]
     },
 }
+
+retry_config = {
+}


### PR DESCRIPTION
This commit adds configuration for bot that allows to set alternative to default setting of retries for certain tests. This allows to override default setting, which still will be valid for rest of the tests. This custom value can be smaller than default, when we know test doesn't pass and this helps us save time on retrying it, or larger, when we know test passes but not consistently, and may require more retries.