### PR TITLE
Revert "zephyr: gatt: add a new database init_server_9"

### DIFF
--- a/autopts/ptsprojects/zephyr/gatt.py
+++ b/autopts/ptsprojects/zephyr/gatt.py
@@ -241,6 +241,10 @@ def test_cases_server(ptses):
                               Prop.read | Prop.write | Prop.notify | Prop.indicate,
                               Perm.read | Perm.write, UUID.VND16_2),
                      TestFunc(btp.gatts_set_val, 0, Value.eight_bytes_1),
+                     TestFunc(btp.gatts_add_char, 0,
+                              Prop.read | Prop.write | Prop.notify | Prop.indicate,
+                              Perm.read | Perm.write, UUID.VND16_3),
+                     TestFunc(btp.gatts_set_val, 0, Value.eight_bytes_1),
                      TestFunc(btp.gatts_add_desc, 0,
                               Perm.read | Perm.write, UUID.CCC),
                      TestFunc(btp.gatts_add_char, 0,
@@ -362,20 +366,6 @@ def test_cases_server(ptses):
                      TestFunc(btp.gatts_set_val, 0, Value.long_1),
                      TestFunc(btp.gatts_set_enc_key_size, 0, 0x0f),
                      TestFunc(btp.gatts_start_server)]
-
-    init_server_9 = [TestFunc(btp.gatts_add_svc, 0, UUID.VND16_1),
-                     TestFunc(btp.gatts_add_char, 0,
-                              Prop.read | Prop.write | Prop.notify | Prop.indicate,
-                              Perm.read | Perm.write, UUID.VND16_2),
-                     TestFunc(btp.gatts_set_val, 0, Value.eight_bytes_1),
-                     TestFunc(btp.gatts_add_desc, 0,
-                              Perm.read | Perm.write, UUID.CCC),
-                     TestFunc(btp.gatts_add_char, 0,
-                              Prop.read | Prop.write | Prop.notify | Prop.indicate,
-                              Perm.read | Perm.write, UUID.VND16_3),
-                     TestFunc(btp.gatts_set_val, 0, Value.eight_bytes_1),
-                     TestFunc(btp.gatts_add_desc, 0,
-                              Perm.read | Perm.write, UUID.CCC)]
 
     custom_test_cases = [
         ZTestCase("GATT", "GATT/SR/GAC/BV-01-C",
@@ -529,7 +519,7 @@ def test_cases_server(ptses):
                   pre_conditions_1 + init_server_2,
                   generic_wid_hdl=gatt_wid_hdl),
         ZTestCase("GATT", "GATT/SR/GAN/BV-02-C",
-                  pre_conditions_1 + init_server_9,
+                  pre_conditions_1 + init_server_2,
                   generic_wid_hdl=gatt_wid_hdl,
                   lt2="GATT/SR/GAN/BV-02-C_LT2"),
         ZTestCase("GATT", "GATT/SR/GAI/BV-01-C",


### PR DESCRIPTION
This reverts commit a72a698e7adb43d74774735d41d88c45e9cd2ff2, which caused the bot to hang on the GATT/SR/GAN/BV-02-C test case after BTP ERROR. Even after superguard timeout and performed recovery the next test cases fail too.
[GATT_SR_GAN_BV-02-C_2022_12_06_08_45_16.log](https://github.com/intel/auto-pts/files/10164324/GATT_SR_GAN_BV-02-C_2022_12_06_08_45_16.log)
