### PR TITLE
cliparser: fix btpclient_path support

### DIFF
--- a/autopts/ptsprojects/bluez/iutctl.py
+++ b/autopts/ptsprojects/bluez/iutctl.py
@@ -27,7 +27,7 @@ IUT = None
 
 # IUT log file object
 IUT_LOG_FO = None
-CLI_SUPPORT = ['btp_py', 'btpclient_path']
+CLI_SUPPORT = ['btpclient_path']
 
 
 def get_iut_cmd(btpclient_path):

--- a/cliparser.py
+++ b/cliparser.py
@@ -195,9 +195,9 @@ class CliParser(argparse.ArgumentParser):
 
         return ''
 
-    def check_args_btp_py(self, args):
+    def check_args_btpclient_path(self, args):
         if not os.path.exists(args.btpclient_path):
-            return 'btp_py mode: Path {} of btpclient.py file' \
+            return 'btpclient: Path {} of btp client ' \
                    ' does not exist!\n'.format(repr(args.btpclient_path))
 
         return ''


### PR DESCRIPTION
Drops unused 'btp_py' flag in bluez/iutclt.py.

Fixes #852

Tested with btstack/iuctl.py which is derived from bluez/iuctl.py.

