### PR TITLE
wid: Fix WID 100

### DIFF
--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -480,6 +480,7 @@ def hdl_wid_91(_: WIDParams):
 
 
 def hdl_wid_100(_: WIDParams):
+    btp.gap_set_bondable_off()
     btp.gap_pair()
     return True
 


### PR DESCRIPTION
WID 100: "Please start the Bonding Procedure in non-bondable mode:"

This WID requires non-bondable mode but PTS doesn't seem to call WID104 before that.