### PR TITLE
zephyr: Fix race in GAP/SEC/AUT/BV-27-C handling

### DIFF
--- a/autopts/ptsprojects/zephyr/gap.py
+++ b/autopts/ptsprojects/zephyr/gap.py
@@ -284,6 +284,11 @@ def test_cases(ptses):
                   cmds=pre_conditions + init_gatt_db +
                   [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
                   generic_wid_hdl=gap_wid_hdl),
+        ZTestCase("GAP", "GAP/SEC/AUT/BV-27-C",
+                  cmds=pre_conditions +
+                  [TestFunc(btp.gattc_read_rsp, store_val=False,
+                            post_wid=112)],
+                  generic_wid_hdl=gap_wid_hdl),
         ZTestCase("GAP", "GAP/SEC/CSIGN/BV-01-C",
                   cmds=pre_conditions + init_gatt_db +
                   [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],


### PR DESCRIPTION
WID 112 doesn't wait for GATT reply from PTS due to PTS replying only after WID exits. This resulted in races where test randomly failed if reply for GATT read was received after next BTP command was sent resulting in command reply service ID mismatch and test abort.