### PR TITLE
zephyr: Add support for GATT/SR/GAW/BV-14-C

### DIFF
--- a/autopts/ptsprojects/zephyr/gatt.py
+++ b/autopts/ptsprojects/zephyr/gatt.py
@@ -36,7 +36,7 @@ class Value:
     long_2 = eight_bytes_2 * 4
     long_3 = eight_bytes_2 * 7
     long_4 = one_byte_1 * 64
-    long_5 = one_byte_2 * 237
+    long_5 = one_byte_2 * 512
     long_6 = eight_bytes_1 * 10
 
 
@@ -301,6 +301,12 @@ def test_cases_server(ptses):
                               Prop.read | Prop.write,
                               Perm.read | Perm.write,
                               UUID.VND16_5),
+                     TestFunc(btp.gatts_set_val, 0, Value.long_5),
+
+                     TestFunc(btp.gatts_add_char, 0,
+                              Prop.read | Prop.write,
+                              Perm.read | Perm.write,
+                              UUID.VND16_6),
                      TestFunc(btp.gatts_set_val, 0, Value.long_6),
 
                      TestFunc(btp.gatts_start_server)


### PR DESCRIPTION
This test requires characteristic that has exactly 512 bytes of value.