### PR TITLE
bot: Add ptsgui mode

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -35,6 +35,7 @@ from autopts.client import Client, CliParser, TestCaseRunStats, init_logging, ru
 from autopts.config import AUTOPTS_ROOT_DIR, MAX_SERVER_RESTART_TIME, generate_file_paths, SERIAL_BAUDRATE
 from autopts.ptsprojects.boards import get_debugger_snr, get_free_device, get_tty, release_device
 from autopts.ptsprojects.testcase_db import DATABASE_FILE
+from autopts.types import AutoPTSMode
 
 log = logging.debug
 
@@ -84,6 +85,7 @@ class BotConfigArgs(Namespace):
 
     def __init__(self, args, **kwargs):
         super().__init__(**kwargs)
+        self.autopts_mode = args.get('autopts_mode', AutoPTSMode.AUTO_TCP_IP)
         self.iut_mode = args.get('iut_mode', None)
         self.workspace = args['workspace']
         self.project_path = args['project_path']
@@ -121,6 +123,7 @@ class BotConfigArgs(Namespace):
         self.excluded = args.get('excluded', [])
 
         self.bd_addr = args.get('bd_addr', '')
+        self.pts_addr = args.get('pts_addr', '')
         self.enable_max_logs = args.get('enable_max_logs', False)
         self.retry = args.get('retry', 0)
         self.no_retry_on_regression = args.get('no_retry_on_regression')
@@ -155,7 +158,8 @@ class BotConfigArgs(Namespace):
                     # For backward compatibility
                     iut_target['board_name'] = iut_target['board']
 
-        if self.server_args is not None:
+        if self.autopts_mode == AutoPTSMode.AUTO_CLIENT_ONLY:
+            assert(self.server_args is not None)
             from autoptsserver import SvrArgumentParser
             _server_args = SvrArgumentParser(
                 "PTS automation server").parse_args(self.server_args.split())
@@ -614,7 +618,10 @@ class BotClient(Client):
             os.path.join(AUTOPTS_ROOT_DIR, f'errata/{self.autopts_project_name}.yaml')
         ])
 
-        if self.args.copy_workspace:
+        if self.args.autopts_mode == AutoPTSMode.GUI_CLIENT_ONLY:
+            report_data['pts_logs_folder'] = ''
+            report_data['pts_xml_folder'] = ''
+        elif self.args.copy_workspace:
             report_data['pts_logs_folder'], report_data['pts_xml_folder'] = \
                 report.pull_server_logs(self.args,
                                         self.file_paths['TMP_DIR'],

--- a/autopts/bot/common_features/report.py
+++ b/autopts/bot/common_features/report.py
@@ -28,8 +28,9 @@ import yaml
 
 from autopts.bot import common
 from autopts.bot.common_features import github
-from autopts.client import PtsServer
+from autopts.client import PtsDirectClient
 from autopts.config import AUTOPTS_ROOT_DIR
+from autopts.types import AutoPTSMode
 
 log = logging.debug
 
@@ -473,9 +474,9 @@ def pull_server_logs(args, tmp_dir, xml_folder):
             except BaseException as e:
                 logging.exception(e)
 
-    if args.server_args:
+    if args.autopts_mode == AutoPTSMode.AUTO_CLIENT_ONLY:
         # Logs available locally
-        _pull_logs(PtsServer)
+        _pull_logs(PtsDirectClient)
     else:
         # Use xmlrpc proxy to pull logs
         server_addr = args.ip_addr

--- a/autopts/client.py
+++ b/autopts/client.py
@@ -36,6 +36,8 @@ import time
 import traceback
 import xml.etree.ElementTree as ElementTree
 import xmlrpc.client
+from argparse import Namespace
+from collections.abc import Callable
 from os.path import dirname
 from xmlrpc.server import SimpleXMLRPCServer
 
@@ -50,6 +52,7 @@ from autopts.ptsprojects.testcase_db import TestCaseTable
 from autopts.pybtp import btp
 from autopts.pybtp.btp import get_iut_method as get_iut
 from autopts.pybtp.types import BTPError, BTPFatalError, BTPInitError, MissingWIDError, SynchError
+from autopts.types import AutoPTSMode, PTSProxy
 from autopts.utils import (
     CounterWithFlag,
     InterruptableThread,
@@ -91,7 +94,7 @@ def logger_log(self, *args, **kwargs):
         self.original_log(*args, **kwargs)
 
 
-class PtsServerProxy(xmlrpc.client.ServerProxy):
+class PtsServerProxy(xmlrpc.client.ServerProxy, PTSProxy):
     """Client to remote autoptsserver"""
     def __init__(self, server_address, server_port):
         super().__init__(uri=f"http://{server_address}:{server_port}/",
@@ -103,36 +106,8 @@ class PtsServerProxy(xmlrpc.client.ServerProxy):
         self.callback_thread = None
         self.callback = None
 
-    @staticmethod
-    def factory_get_instance(_id, server_address, server_port,
-                             client_address, client_port, timeout):
-        proxy = proxy = PtsServerProxy(server_address, server_port)
-        result = ResultWithFlag(False)
-        print(f"{id(proxy)} Starting PTS: {proxy.info} ...")
 
-        def wait_for():
-            try:
-                proxy.ready()
-                result.set(True)
-            except BaseException:
-                log('autoptsserver not responding, retrying...')
-            # Continue waiting
-            return True
-
-        result.wait(timeout=timeout, predicate=wait_for)
-
-        log("Server methods: %s", proxy.system.listMethods())
-        proxy.callback_thread = ClientCallbackServer(client_port, f'LT{_id}-callback')
-        proxy.callback = proxy.callback_thread.callback
-        proxy.callback_thread.start()
-        proxy.register_client_callback({'xmlrpc_address': client_address, 'xmlrpc_port': client_port})
-        log("Client IP Address: %s", client_address)
-        print(f"({id(proxy)}) OK")
-
-        return proxy
-
-
-class FakeProxy:
+class FakeProxy(PTSProxy):
     """Fake PTS XML-RPC proxy client.
 
     Usefull when testing code locally and auto-pts server is not needed"""
@@ -161,42 +136,15 @@ else:
     Server = FakeProxy
 
 
-class PtsServer(Server):
+class PtsDirectClient(Server):
     """Builtin instance of autoptsserver for one process mode"""
 
     # Counter of closed autoptsservers
     finish_count = CounterWithFlag(init_count=0)
 
     def __init__(self, _args=None):
-        super().__init__(PtsServer.finish_count, _args=_args)
+        super().__init__(PtsDirectClient.finish_count, _args=_args)
         self.info = f'builtin {_args.srv_port}'
-
-    @staticmethod
-    def factory_get_instance(args, timeout):
-        proxy = PtsServer(args)
-        proxy.start()
-
-        result = ResultWithFlag(False)
-
-        def wait_for():
-            if proxy.ready():
-                result.set(True)
-                return False
-            # Continue waiting
-            return True
-
-        try:
-            result.wait(timeout=timeout, predicate=wait_for)
-            if not result.get_nowait():
-                raise Exception('Failed to start autoptsserver')
-        except BaseException:
-            proxy.terminate()
-            raise
-
-        proxy.callback = ClientCallback()
-        proxy.register_client_callback({'client_callback': proxy.callback})
-
-        return proxy
 
 
 class ClientCallback(PTSCallback):
@@ -465,9 +413,13 @@ def init_pts_thread_entry_wrapper(func):
             func(*args)
         except Exception as exc:
             logging.exception(exc)
+            if exceptions is None:
+                raise
+
             exceptions.put(exc)
         finally:
-            counter.add(1)
+            if counter is not None:
+                counter.add(1)
 
     return wrapper
 
@@ -507,43 +459,123 @@ def init_pts_thread_entry(proxy, args, exceptions, finish_count):
     proxy.enable_maximum_logging(args.enable_max_logs)
 
 
-def init_pts(args, ptses):
-    """Initialization procedure for PTS instances"""
+class PTSProxyFactory:
+    @staticmethod
+    def create(_id: int, args: Namespace) -> PTSProxy:
+        try:
+            creator = PTSProxyFactory._CREATORS[args.autopts_mode]
+        except KeyError as e:
+            raise NotImplementedError(f"Unsupported autopts_mode: {args.autopts_mode}") from e
 
-    proxy_list = ptses
+        return creator(_id, args)
+
+    @staticmethod
+    def _create_fake_proxy(_id, args):
+        return FakeProxy()
+
+    @staticmethod
+    def _create_gui_proxy(_id, args):
+        # You have to install tkinter to use this mode
+        from autopts.ptsguiproxy import PTSGUIProxy
+
+        pts_addr = args.pts_addr[_id] if isinstance(args.pts_addr, list) else args.pts_addr
+        if not pts_addr:
+            pts_addr = f"00:01:02:03:04:{_id:02X}"
+
+        return PTSGUIProxy(args, ClientCallback(), pts_addr, f'LT{_id + 1}')
+
+    @staticmethod
+    def _create_direct_client(_id, args):
+        timeout = args.max_server_restart_time
+
+        proxy = PtsDirectClient(args.server_args[_id])
+        proxy.start()
+
+        result = ResultWithFlag(False)
+
+        def wait_for():
+            if proxy.ready():
+                result.set(True)
+                return False
+            # Continue waiting
+            return True
+
+        try:
+            result.wait(timeout=timeout, predicate=wait_for)
+            if not result.get_nowait():
+                raise Exception('Failed to start autoptsserver')
+        except BaseException:
+            proxy.terminate()
+            raise
+
+        proxy.callback = ClientCallback()
+        proxy.register_client_callback({'client_callback': proxy.callback})
+
+        return proxy
+
+    @staticmethod
+    def _create_tcp_proxy(_id, args):
+        server_address = args.ip_addr[_id]
+        server_port = args.srv_port[_id]
+        client_address = args.local_addr[_id]
+        client_port = args.cli_port[_id]
+        timeout = args.max_server_restart_time
+
+        proxy = PtsServerProxy(server_address, server_port)
+        result = ResultWithFlag(False)
+        print(f"{id(proxy)} Starting PTS: {proxy.info} ...")
+
+        def wait_for():
+            try:
+                proxy.ready()
+                result.set(True)
+            except BaseException:
+                log('autoptsserver not responding, retrying...')
+            # Continue waiting
+            return True
+
+        result.wait(timeout=timeout, predicate=wait_for)
+
+        log("Server methods: %s", proxy.system.listMethods())
+        proxy.callback_thread = ClientCallbackServer(client_port, f'LT{_id + 1}-callback')
+        proxy.callback = proxy.callback_thread.callback
+        proxy.callback_thread.start()
+        proxy.register_client_callback({'xmlrpc_address': client_address, 'xmlrpc_port': client_port})
+        log("Client IP Address: %s", client_address)
+        print(f"({id(proxy)}) OK")
+
+        return proxy
+
+    PTSProxyCreator = Callable[[int, Namespace], PTSProxy]
+    _CREATORS: dict[AutoPTSMode, PTSProxyCreator] = {
+        AutoPTSMode.FAKE_PROXY: _create_fake_proxy,
+        AutoPTSMode.GUI_CLIENT_ONLY: _create_gui_proxy,
+        AutoPTSMode.AUTO_CLIENT_ONLY: _create_direct_client,
+        AutoPTSMode.AUTO_TCP_IP: _create_tcp_proxy,
+    }
+
+
+def _pts_init_from_main(proxy_list, args):
+    for proxy in proxy_list:
+        init_pts_thread_entry(proxy, args, None, None)
+
+
+def _pts_init_from_threads(proxy_list, args):
     thread_list = []
     exceptions = queue.Queue()
-    thread_count = len(args.cli_port)
     finish_count = CounterWithFlag(init_count=0)
 
-    server_count = getattr(args, 'server_count', len(args.cli_port))
-
-    # PtsServer.finish_count.clear()
-    for i in range(0, server_count):
-        if i < len(proxy_list):
-            proxy = proxy_list[i]
-        else:
-            if AUTO_PTS_LOCAL:
-                proxy = FakeProxy()
-            elif getattr(args, 'server_args', False):
-                proxy = PtsServer.factory_get_instance(args.server_args[i], args.max_server_restart_time)
-            else:
-                proxy = PtsServerProxy.factory_get_instance(
-                    i + 1, args.ip_addr[i], args.srv_port[i],
-                    args.local_addr[i], args.cli_port[i],
-                    args.max_server_restart_time)
-            proxy_list.append(proxy)
-
+    for _id, proxy in enumerate(proxy_list, 1):
         thread = InterruptableThread(target=init_pts_thread_entry,
-                                     name=f'LT{i + 1}-server-init',
+                                     name=f'LT{_id}-server-init',
                                      args=(proxy, args, exceptions, finish_count))
         thread_list.append(thread)
         thread.start()
 
     # Wait until each PTS instance is initialized.
     try:
-        finish_count.wait_for(thread_count, timeout=max(
-            180.0, server_count * args.max_server_restart_time))
+        finish_count.wait_for(len(thread_list), timeout=max(
+            180.0, len(thread_list) * args.max_server_restart_time))
     except Exception as e:
         logging.exception(e)
         raise
@@ -551,7 +583,7 @@ def init_pts(args, ptses):
         for _i, thread in enumerate(thread_list):
             if thread.is_alive():
                 thread.interrupt()
-                log(f"({id(proxy_list[i])}) init failed")
+                log(f"({id(proxy_list[_i])}) init failed")
 
     exeption_msg = ''
     for _ in range(exceptions.qsize()):
@@ -559,6 +591,32 @@ def init_pts(args, ptses):
 
     if exeption_msg:
         raise Exception(exeption_msg)
+
+
+def init_pts(args: Namespace, proxy_list: list[PTSProxy]):
+    """
+    Initialize PTS Proxy instances.
+
+    Args:
+        args: Parsed command-line arguments.
+        proxy_list: Existing PTS Proxy instances.
+
+    Returns:
+        List of initialized PTS Proxy instances.
+    """
+
+    init_logging('_' + '_'.join(str(x) for x in args.cli_port))
+    server_count = getattr(args, 'server_count', len(args.cli_port))
+
+    if len(proxy_list) < server_count:
+        for i in range(len(proxy_list), server_count):
+            proxy = PTSProxyFactory.create(_id=i, args=args)
+            proxy_list.append(proxy)
+
+    if len(proxy_list) == 1 or args.autopts_mode == AutoPTSMode.GUI_CLIENT_ONLY:
+        _pts_init_from_main(proxy_list, args)
+    else:
+        _pts_init_from_threads(proxy_list, args)
 
     return proxy_list
 
@@ -1032,7 +1090,7 @@ class LTThread(InterruptableThread):
             log_lock.release()
             self.interrupt_lock.release()
 
-    def _run_test_case(self, pts, test_case, exceptions, finish_count):
+    def _run_test_case(self, pts, test_case, exceptions, finish_count, mode):
         """Runs the test case specified by a TestCase instance."""
         log("Starting TestCase %s %s", self._run_test_case.__name__,
             test_case)
@@ -1064,7 +1122,14 @@ class LTThread(InterruptableThread):
                 raise Exception(f"Failed to start the test case {test_case.name}")
 
             def wait_if_no_step():
-                return test_case.steps_queue.empty()
+                if test_case.steps_queue.empty():
+                    if mode == AutoPTSMode.GUI_CLIENT_ONLY:
+                        # AutoPTS GUI mode
+                        pts.ask_for_wid()
+
+                    return True
+
+                return False
 
             try:
                 while not finish_count.is_set():
@@ -1144,6 +1209,10 @@ class LTThread(InterruptableThread):
             test_case.post_run(error_code)  # stop qemu and other commands
             del RUNNING_TEST_CASE[test_case.name]
 
+            if mode == AutoPTSMode.GUI_CLIENT_ONLY:
+                # AutoPTS GUI mode
+                pts.stop_mainloop()
+
             log("Done TestCase %s %s", self._run_test_case.__name__, test_case)
 
     def set_test_case_result(self, status):
@@ -1154,7 +1223,7 @@ class LTThread(InterruptableThread):
 
 @run_test_case_wrapper
 def run_test_case(ptses, test_case_instances, test_case_name, stats,
-                  session_log_dir, exceptions, timeout):
+                  session_log_dir, exceptions, timeout, mode):
     def test_case_lookup_name(name, test_case_class):
         """Return 'test_case_class' instance if found or None otherwise"""
         if test_case_instances is None:
@@ -1209,16 +1278,22 @@ def run_test_case(ptses, test_case_instances, test_case_name, stats,
     finish_count = CounterWithFlag(init_count=0)
     thread_count = 0
     thread_list = []
+    pts = None
 
     for thread_count, (test_case_lt, pts) in enumerate(zip(test_case_lts, ptses, strict=False), 1):
         thread = LTThread(
             name=f'LT{thread_count}-thread',
-            args=(pts, test_case_lt, exceptions, finish_count))
+            args=(pts, test_case_lt, exceptions, finish_count, mode))
         thread_list.append(thread)
         thread.start()
 
     superguard_timeout = False
     try:
+        if mode == AutoPTSMode.GUI_CLIENT_ONLY:
+            # AutoPTS GUI mode
+            pts.mainloop()
+            log('MAIN loop has ended')
+
         # Wait until each PTS instance has finished executing its test case
         finish_count.wait_for(thread_count, timeout=timeout)
     except TimeoutError:
@@ -1430,7 +1505,7 @@ def run_test_cases(ptses, test_case_instances, args, stats, **kwargs):
 
             status, duration = run_test_case(selected_ptses, selected_test_case_instances,
                                              test_case, stats, session_log_dir,
-                                             exceptions, args.superguard)
+                                             exceptions, args.superguard, args.autopts_mode)
 
             raise_on_global_end()
 
@@ -1704,7 +1779,7 @@ class Client:
             if getattr(pts, 'callback_thread', None):
                 pts.callback_thread.stop()
 
-            if isinstance(pts, PtsServer):
+            if isinstance(pts, PtsDirectClient):
                 pts.terminate()
 
         self.ptses.clear()

--- a/autopts/ptsguiproxy.py
+++ b/autopts/ptsguiproxy.py
@@ -1,0 +1,252 @@
+import logging
+import queue
+import tkinter as tk
+from tkinter import messagebox, ttk
+
+from autopts.ptsprojects.ptstypes import MMI_STYLE_STRING
+from autopts.types import PTSProxy
+
+log = logging.debug
+
+
+class WIDDialog:
+    def __init__(self, parent, callback):
+        self._parent = parent
+        self._callback = callback
+        self._test_case_status = None
+        self._dialog_window = None
+        self._project_name = None
+        self._test_case_name = None
+        self._mmi_entry = None
+        self._description_entry = None
+        self._selected_style = tk.StringVar()
+        self._selected_status = tk.StringVar()
+
+    def open_dialog(self, project_name, test_case_name, mmi_response, lt_name):
+        if self._dialog_window is not None:
+            return
+
+        self._project_name = project_name
+        self._test_case_name = test_case_name
+
+        self._dialog_window = tk.Toplevel(self._parent)
+        self._dialog_window.title(f"{lt_name} MMI entry dialog")
+        self._dialog_window.protocol("WM_DELETE_WINDOW", self.end_test_case)
+
+        mmi_label = tk.Label(self._dialog_window, text='MMI ID:', width=40)
+        mmi_label.pack(pady=10)
+
+        self._mmi_entry = tk.Entry(self._dialog_window, width=40)
+        self._mmi_entry.pack(pady=10)
+
+        mmi_style_label = tk.Label(self._dialog_window, text='MMI style:', width=40)
+        mmi_style_label.pack(pady=10)
+
+        style_options = list(MMI_STYLE_STRING.values())
+        self._selected_style.set(style_options[0])
+        dropdown = tk.OptionMenu(self._dialog_window, self._selected_style, *style_options)
+        dropdown.pack(pady=10)
+
+        mmi_description_label = tk.Label(self._dialog_window, text='MMI description:', width=40)
+        mmi_description_label.pack(pady=10)
+
+        self._description_entry = tk.Text(self._dialog_window, height=5, width=40)
+        self._description_entry.pack(pady=10)
+
+        submit_button = tk.Button(self._dialog_window, text="Submit MMI", command=self.on_submit,
+                                  fg='white', bg='#4287f5')
+        submit_button.pack(pady=10)
+
+        separator = ttk.Separator(self._dialog_window, orient='horizontal')
+        separator.pack(fill='x')
+
+        tc_status_label = tk.Label(self._dialog_window, text='Test case status:', width=40)
+        tc_status_label.pack(pady=10)
+
+        status_options = ['PASS', 'FAIL', 'INCONC']
+        self._selected_status.set(status_options[0])
+        status_dropdown = tk.OptionMenu(self._dialog_window, self._selected_status, *status_options)
+        status_dropdown.pack(pady=10)
+
+        end_test_case_button = tk.Button(self._dialog_window, text="End test case",
+                                         command=self.end_test_case, fg='white', bg='#d14555')
+        end_test_case_button.pack(pady=10)
+
+        close_button = tk.Button(self._dialog_window, text="Close", command=self.close_dialog)
+        close_button.pack(pady=10)
+
+        if mmi_response:
+            separator = ttk.Separator(self._dialog_window, orient='horizontal')
+            separator.pack(fill='x')
+
+            mmi_response_label = tk.Label(self._dialog_window, text='MMI response:', width=40)
+            mmi_response_label.pack(pady=10)
+
+            mmi_response_text = tk.Text(self._dialog_window, height=5, width=40)
+            mmi_response_text.pack(pady=10)
+            mmi_response_text.insert(tk.END, mmi_response)
+
+    def close_dialog(self):
+        if self._dialog_window is not None:
+            self._dialog_window.destroy()
+            self._dialog_window = None
+
+    def is_closed(self):
+        return self._dialog_window is None
+
+    def end_test_case(self):
+        self._test_case_status = self._selected_status.get()
+        self._callback.set_result('run_test_case', self._test_case_status)
+        self.close_dialog()
+
+    def on_submit(self):
+        if self._dialog_window is None:
+            return
+
+        try:
+            wid = int(self._mmi_entry.get())
+        except ValueError:
+            messagebox.showerror("Invalid MMI ID", "MMI ID must be an integer.")
+            return
+        description = self._description_entry.get("1.0", "end-1c")
+        selected_style = self._selected_style.get()
+
+        style = None
+        for key, val in MMI_STYLE_STRING.items():
+            if val == selected_style:
+                style = key
+                break
+
+        self._callback.on_implicit_send(self._project_name, wid, self._test_case_name, description, style)
+        self.close_dialog()
+
+    def get_test_case_status(self):
+        return self._test_case_status
+
+
+class PTSGUIProxy(PTSProxy):
+    root_window = None
+    task_queue = queue.Queue()
+
+    def __init__(self, args, callback, pts_addr, name):
+        self.info = "PTS GUI proxy"
+        self.name = name
+        self._pts_version = 'Unknown, GUI mode'
+        self._bd_addr = pts_addr
+        self._test_cases = self._parse_test_cases(args.test_cases)
+        self._wid_dialog = None
+        self._ask_for_wid_pending = False
+        self._project_name = None
+        self._test_case_name = None
+        self._last_mmi_response = ''
+        self.callback_thread = None
+        self.callback = callback
+        self._init_root()
+
+    def __getattr__(self, item):
+        return self._generic
+
+    def _generic(self, *args, **kwargs):
+        return True
+
+    def _init_root(self):
+        if not PTSGUIProxy.root_window:
+            root = tk.Tk()
+            PTSGUIProxy.root_window = root
+            root.title("GUI root")
+            root.attributes("-topmost", 1)
+            root.withdraw()
+            root.after(1000, PTSGUIProxy.check_queue)
+
+    def _parse_test_cases(self, test_cases):
+        parsed = {}
+        for tc in test_cases:
+            prefix = tc.split('/')[0]
+            if prefix not in parsed:
+                parsed[prefix] = []
+
+            parsed[prefix].append(tc)
+
+        return parsed
+
+    def get_version(self):
+        return self._pts_version
+
+    def bd_addr(self):
+        return self._bd_addr
+
+    def restart_pts(self):
+        self.callback.set_result('restart_pts', True)
+        return "WAIT"
+
+    def get_project_list(self):
+        return self._test_cases.keys()
+
+    def get_test_case_list(self, project):
+        return self._test_cases[project]
+
+    def get_test_case_description(self, project_name, test_case_name):
+        return ''
+
+    def list_workspace_tree(self, workspace_dir):
+        return []
+
+    def set_pixit(self, project_name, param_name, param_value):
+        log(f'Set PIXIT: {project_name} {param_name} {param_value}')
+
+    def update_pixit_param(self, project_name, param_name, param_value):
+        log(f'Update PIXIT: {project_name} {param_name} {param_value}')
+
+    def run_test_case(self, project_name, test_case_name):
+        self._project_name = project_name
+        self._test_case_name = test_case_name
+        return 'WAIT'
+
+    def set_wid_response(self, response):
+        self._last_mmi_response = response
+
+    def ask_for_wid(self):
+        if not self._ask_for_wid_pending and (self._wid_dialog is None or self._wid_dialog.is_closed()):
+            self._ask_for_wid_pending = True
+            PTSGUIProxy.task_queue.put(self._ask_for_wid)
+
+    def _ask_for_wid(self):
+        self._ask_for_wid_pending = False
+        status = None
+        if self._wid_dialog is not None and self._wid_dialog.is_closed():
+            status = self._wid_dialog.get_test_case_status()
+            self._wid_dialog = None
+
+        if status is None and self._wid_dialog is None:
+            self._wid_dialog = WIDDialog(PTSGUIProxy.root_window, self.callback)
+            self._wid_dialog.open_dialog(self._project_name, self._test_case_name,
+                                         self._last_mmi_response, self.name)
+
+    @staticmethod
+    def check_queue():
+        try:
+            if PTSGUIProxy.root_window is None:
+                return
+
+            fn = PTSGUIProxy.task_queue.get_nowait()
+        except queue.Empty:
+            pass
+        except AttributeError:
+            return
+        else:
+            fn()
+        finally:
+            if PTSGUIProxy.root_window:
+                PTSGUIProxy.root_window.after(100, PTSGUIProxy.check_queue)
+
+    def stop_mainloop(self):
+        if PTSGUIProxy.root_window:
+            PTSGUIProxy.task_queue.put(PTSGUIProxy.root_window.quit)
+
+    def mainloop(self):
+        self._init_root()
+        try:
+            if PTSGUIProxy.root_window:
+                PTSGUIProxy.root_window.mainloop()
+        finally:
+            PTSGUIProxy.root_window = None

--- a/autopts/types.py
+++ b/autopts/types.py
@@ -1,0 +1,43 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2026, Codecoup.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+import sys
+from typing import Protocol
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        def __str__(self):
+            return self.value
+
+
+class AutoPTSMode(StrEnum):
+    # The mode only for unit tests, autopts server is mocked, no PTS instance is opened.
+    FAKE_PROXY = 'fake_proxy'
+    # In this mode the PTS is opened in GUI mode and the autopts client provides
+    # the window for entering MMI/WID. The autopts server should not be running.
+    GUI_CLIENT_ONLY = 'gui_client_only'
+    # In this mode the PTS is opened in the automation mode by the autopts server.
+    # The autopts client communicates with the autopts server via TCP/IP.
+    AUTO_TCP_IP = 'auto_tcp_ip'
+    # In this mode the autopts server functionality is handled by the autopts client and
+    # the PTS is opened in the automation mode by the autopts client. Works only for Windows.
+    AUTO_CLIENT_ONLY = 'auto_client_only'
+
+
+class PTSProxy(Protocol):
+    """Interface implemented by all PTS proxy instances."""

--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -52,6 +52,7 @@ import wmi
 
 from autopts import ptscontrol
 from autopts.config import SERVER_PORT
+from autopts.types import PTSProxy
 from autopts.utils import (
     CounterWithFlag,
     active_hub_server_replug_usb,
@@ -432,7 +433,7 @@ def delete_workspaces():
     recursive(os.path.join(PROJECT_DIR, 'autopts/workspaces'), init_depth)
 
 
-class Server(threading.Thread):
+class Server(threading.Thread, PTSProxy):
     def __init__(self, finish_count, _args=None):
         init_logging(_args)
         threading.Thread.__init__(self, daemon=True)

--- a/cliparser.py
+++ b/cliparser.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from autopts.config import CLIENT_PORT, FILE_PATHS, MAX_SERVER_RESTART_TIME, SERIAL_BAUDRATE, SERVER_PORT
 from autopts.ptsprojects.boards import com_to_tty, get_debugger_snr, get_free_device, get_tty, tty_exists
 from autopts.ptsprojects.testcase_db import DATABASE_FILE
+from autopts.types import AutoPTSMode
 from autopts.utils import active_hub_server_replug_usb, get_tc_from_wid, load_wid_report, raise_on_global_end, ykush_replug_usb
 
 log = logging.debug
@@ -68,6 +69,12 @@ class CliParser(SmartDefaultsMixin, argparse.ArgumentParser):
 
         if iut_modes is None:
             iut_modes = IUT_MODES
+
+        self.add_argument("--autopts-mode", "--autopts_mode", type=str, default=AutoPTSMode.AUTO_TCP_IP,
+                          choices=[AutoPTSMode.AUTO_TCP_IP, AutoPTSMode.GUI_CLIENT_ONLY, AutoPTSMode.FAKE_PROXY,
+                                   AutoPTSMode.AUTO_CLIENT_ONLY],
+                          help="Specify AutoPTS client mode, which determines the method "
+                               "of communication with the PTS.")
 
         self.add_argument("--iut-mode", "--iut_mode", type=str, nargs='+',
                           action="extend", choices=iut_modes, default=None,
@@ -204,6 +211,7 @@ class CliParser(SmartDefaultsMixin, argparse.ArgumentParser):
                           help=argparse.SUPPRESS)
 
         self.add_argument("--pts_addr_map", default={}, help=argparse.SUPPRESS)
+        self.add_argument("--pts_addr", type=str, default='', help=argparse.SUPPRESS)
         self.add_argument("--restricted_pts_addrs", default=[], help=argparse.SUPPRESS)
 
         self.add_argument("--iut_targets", default=None, help=argparse.SUPPRESS)


### PR DESCRIPTION
The ptsgui mode allows to run a test case with PTS in GUI mode. A user has to manually enter MMI(WID) ID and its description into AutoPTS dialog and deliver the response to the PTS dialog.

Useful while debugging issues with test cases like the GAP/SEC/SEM/BV-26-C, where 2 x MMI windows appear at once in PTS GUI mode, but in PTS automation mode they arrive in random order, because the PTS automation interface can handle only one at a time,