### PR TITLE
cron: Add retry to _restart_processes

### DIFF
--- a/tools/cron/common.py
+++ b/tools/cron/common.py
@@ -578,8 +578,12 @@ def _start_processes(config, checkout_repos):
 
 
 def _restart_processes(config):
-    terminate_processes(config)
-    return _start_processes(config, checkout_repos=False)
+    while not config['cron']['cancel_job'].canceled:
+        try:
+            terminate_processes(config)
+            return _start_processes(config, checkout_repos=False)
+        except OSError:
+            log(traceback.format_exc())
 
 
 def _run_test(config):


### PR DESCRIPTION
It happens rarely, but sometimes a socket port does not get released in time:

  File "/home/codecoup/workspace/autopts/auto-pts-cron/tools/cron/common.py", line 653, in run_test
    _run_test(config)
  File "/home/codecoup/workspace/autopts/auto-pts-cron/tools/cron/common.py", line 644, in _run_test
    srv_process, bot_process = _restart_processes(config)
  File "/home/codecoup/workspace/autopts/auto-pts-cron/tools/cron/common.py", line 582, in _restart_processes
    return _start_processes(config, checkout_repos=False)
  File "/home/codecoup/workspace/autopts/auto-pts-cron/tools/cron/common.py", line 557, in _start_processes
    start_remote_autoptsserver(config, checkout_repos)
  File "/home/codecoup/workspace/autopts/auto-pts-cron/tools/cron/common.py", line 474, in start_remote_autoptsserver
    log(client.open_process(config['server_start_cmd'],
  File "/usr/lib/python3.10/xmlrpc/client.py", line 1122, in __call__
    return self.__send(self.__name, args)
    self.sock = self._create_connection(
(...)
  File "/usr/lib/python3.10/socket.py", line 833, in create_connection
    sock.connect(sa)
OSError: [Errno 113] No route to host