### PR TITLE
TBS: Remove unused counters

### DIFF
--- a/autopts/ptsprojects/stack/layers/tbs.py
+++ b/autopts/ptsprojects/stack/layers/tbs.py
@@ -21,8 +21,6 @@ from autopts.pybtp import defs
 class TBS:
     def __init__(self):
         self.event_queues = {}
-        self.wid_counter = 0
-        self.index_counter = 0
 
     def event_received(self, event_type, event_data_tuple):
         self.event_queues[event_type].append(event_data_tuple)

--- a/autopts/wid/tbs.py
+++ b/autopts/wid/tbs.py
@@ -24,9 +24,6 @@ from autopts.pybtp.types import WIDParams
 from autopts.wid import generic_wid_hdl
 
 log = logging.debug
-global wid_counter
-wid_counter = 0
-
 
 def tbs_wid_hdl(wid, description, test_case_name):
     log(f'{tbs_wid_hdl.__name__}, {wid}, {description}, {test_case_name}')


### PR DESCRIPTION
The wid_counter and index_counter values from both the class and the wid file were unused.