### PR TITLE
bot: Add no_copy parameter

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -72,6 +72,10 @@ class BotCliParser(CliParser):
         self.add_argument('--simple', action='store_true',
                           help='Skip build and flash in bot mode.', default=False)
 
+        self.add_argument('--nc', dest='copy', action='store_false',
+                          help='Do not copy workspace, open original one. '
+                               'Warning: workspace file might be modified', default=True)
+
     def add_positional_args(self):
         self.add_argument("config_path", nargs='?', default='config.py',
                           help="Path to config.py to use for testing.")
@@ -125,6 +129,7 @@ class BotConfigArgs(Namespace):
         self.no_build = args.get('no_build', False)
         self.dongle_init_retry = args.get('dongle_init_retry', 5)
         self.build_env_cmd = args.get('build_env_cmd', None)
+        self.copy = args.get('copy', True)
 
         if self.ykush or self.active_hub_server:
             self.usb_replug_available = True

--- a/autopts/client.py
+++ b/autopts/client.py
@@ -483,7 +483,7 @@ def init_pts_thread_entry(proxy, args, exceptions, finish_count):
     log("PTS BD_ADDR: %s", proxy.q_bd_addr)
 
     log("Opening workspace: %s", args.workspace)
-    proxy.open_workspace(args.workspace)
+    proxy.open_workspace(args.workspace, args.copy)
 
     if args.bd_addr:
         projects = proxy.get_project_list()

--- a/autopts/ptscontrol.py
+++ b/autopts/ptscontrol.py
@@ -671,7 +671,7 @@ class PyPTS:
             os.remove(self._temp_workspace_path)
 
     @pts_lock_wrapper(PTS_START_LOCK)
-    def open_workspace(self, workspace_path):
+    def open_workspace(self, workspace_path, copy):
         """Opens existing workspace"""
 
         log(f"open_workspace {workspace_path}")
@@ -696,23 +696,27 @@ class PyPTS:
         # Workaround CASE0044114 PTS issue
         # Do not open original workspace file that can become broken by
         # TestCase. Instead use a copy of this file
-        if self._temp_workspace_path and \
-                os.path.exists(self._temp_workspace_path):
-            os.unlink(self._temp_workspace_path)
+        if copy:
+            if self._temp_workspace_path and \
+                    os.path.exists(self._temp_workspace_path):
+                os.unlink(self._temp_workspace_path)
 
-        workspace_dir = os.path.dirname(workspace_path)
-        workspace_name = os.path.basename(workspace_path)
+            workspace_dir = os.path.dirname(workspace_path)
+            workspace_name = os.path.basename(workspace_path)
 
-        temp_workspace_dir = os.path.join(workspace_dir, "_" + self.get_bluetooth_address())
-        Path(temp_workspace_dir).mkdir(parents=False, exist_ok=True)
+            temp_workspace_dir = os.path.join(workspace_dir, "_" + self.get_bluetooth_address())
+            Path(temp_workspace_dir).mkdir(parents=False, exist_ok=True)
 
-        self._temp_workspace_path = \
-            os.path.join(temp_workspace_dir, "temp_" + workspace_name)
-        shutil.copy2(workspace_path, self._temp_workspace_path)
-        log("Using temporary workspace: %s", self._temp_workspace_path)
+            self._temp_workspace_path = \
+                os.path.join(temp_workspace_dir, "temp_" + workspace_name)
+            shutil.copy2(workspace_path, self._temp_workspace_path)
+            log("Using temporary workspace: %s", self._temp_workspace_path)
 
-        self._pts.OpenWorkspace(self._temp_workspace_path)
-        self.add_recov(self.open_workspace, workspace_path)
+            self._pts.OpenWorkspace(self._temp_workspace_path)
+        else:
+            self._pts.OpenWorkspace(workspace_path)
+
+        self.add_recov(self.open_workspace, workspace_path, copy)
         self._cache_test_cases()
 
     def _cache_test_cases(self):


### PR DESCRIPTION
This option can be used to skip creating and using copy of workspace file. This might be useful if you need to run tests in automation and later use this workspace file to generate report in PTS, or you need to repeat some test cases manually and    keep verdicts from automated test session.
