### PR TITLE
zephyr: Fix IXIT configuration after PTS update

### DIFF
--- a/autopts/ptsprojects/zephyr/l2cap.py
+++ b/autopts/ptsprojects/zephyr/l2cap.py
@@ -89,9 +89,6 @@ def test_cases(ptses):
                   "L2CAP", "TSPX_bd_addr_iut",
                   stack.gap.iut_addr_get_str())),
               TestFunc(lambda: pts.update_pixit_param(
-                  "L2CAP", "TSPX_bd_addr_iut_le",
-                  stack.gap.iut_addr_get_str())),
-              TestFunc(lambda: pts.update_pixit_param(
                   "L2CAP", "TSPX_spsm", format(le_psm, '04x'))),
               TestFunc(lambda: pts.update_pixit_param(
                   "L2CAP", "TSPX_psm_authentication_required", format(le_psm, '04x'))),
@@ -115,10 +112,6 @@ def test_cases(ptses):
                   "L2CAP", "TSPX_l2ca_cbmtu_min", format(64, '04x'))),
               TestFunc(lambda: pts.update_pixit_param(
                   "L2CAP", "TSPX_l2ca_cbmtu_max", format(256, '04x'))),
-              TestFunc(lambda: pts.update_pixit_param(
-                  "L2CAP", "TSPX_iut_address_type_random",
-                  "TRUE" if stack.gap.iut_addr_is_random()
-                  else "FALSE")),
               TestFunc(btp.set_pts_addr, pts_bd_addr, Addr.le_public)]
 
     pre_conditions = common + [TestFunc(stack.l2cap_init, le_psm, le_initial_mtu)]


### PR DESCRIPTION
There were some leftovers with updating removed IXIT values.