### PR TITLE
Fix AttributeError

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -2,6 +2,7 @@
 # auto-pts - The Bluetooth PTS Automation Framework
 #
 # Copyright (c) 2018, Intel Corporation.
+# Copyright (c) 2025, Atmosic.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms and conditions of the GNU General Public License,
@@ -71,10 +72,6 @@ class BotCliParser(CliParser):
 
         self.add_argument('--simple', action='store_true',
                           help='Skip build and flash in bot mode.', default=False)
-
-        self.add_argument('--nc', dest='copy', action='store_false',
-                          help='Do not copy workspace, open original one. '
-                               'Warning: workspace file might be modified', default=True)
 
     def add_positional_args(self):
         self.add_argument("config_path", nargs='?', default='config.py',

--- a/autopts/client.py
+++ b/autopts/client.py
@@ -5,6 +5,7 @@
 #
 # Copyright (c) 2017, Intel Corporation.
 # Copyright (c) 2024, Codecoup.
+# Copyright (c) 2025, Atmosic.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms and conditions of the GNU General Public License,
@@ -483,6 +484,7 @@ def init_pts_thread_entry(proxy, args, exceptions, finish_count):
     log("PTS BD_ADDR: %s", proxy.q_bd_addr)
 
     log("Opening workspace: %s", args.workspace)
+    log("Copy workspace: %s", args.copy)
     proxy.open_workspace(args.workspace, args.copy)
 
     if args.bd_addr:

--- a/cliparser.py
+++ b/cliparser.py
@@ -4,6 +4,7 @@
 # auto-pts - The Bluetooth PTS Automation Framework
 #
 # Copyright (c) 2017, Intel Corporation.
+# Copyright (c) 2025, Atmosic.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms and conditions of the GNU General Public License,
@@ -95,6 +96,10 @@ class CliParser(argparse.ArgumentParser):
 
         self.add_argument("--pylink_reset", action='store_true', default=False,
                           help="Use pylink reset.")
+
+        self.add_argument('--nc', dest='copy', action='store_false',
+                          help='Do not copy workspace, open original one. '
+                               'Warning: workspace file might be modified', default=True)
 
         # Hidden option to save test cases data in TestCase.db
         self.add_argument("-s", "--store", action="store_true",


### PR DESCRIPTION
Fixed the exception "Exception: 'Namespace' object has no attribute 'copy'" when running without bot.