### PR TITLE
wid: Avoid asserts in MMI handlers

### DIFF
--- a/autopts/wid/gatt.py
+++ b/autopts/wid/gatt.py
@@ -1049,7 +1049,9 @@ def hdl_wid_90(_: WIDParams):
 
     gatt.wait_notification_ev(timeout=5)
 
-    assert gatt.notification_events
+    if len(gatt.notification_events) == 0:
+        return False
+
     addr_type, addr, notif_type, _, _ = gatt.notification_events[0]
 
     return (addr_type, addr, notif_type) == (btp.pts_addr_type_get(), btp.pts_addr_get(), 1)
@@ -1127,7 +1129,9 @@ def hdl_wid_95(_: WIDParams):
 
     gatt.wait_notification_ev(timeout=5)
 
-    assert gatt.notification_events
+    if len(gatt.notification_events) == 0:
+        return False
+
     addr_type, addr, notif_type, _, _ = gatt.notification_events[0]
 
     return (addr_type, addr, notif_type) == (btp.pts_addr_type_get(), btp.pts_addr_get(), 2)

--- a/autopts/wid/mesh.py
+++ b/autopts/wid/mesh.py
@@ -1731,8 +1731,7 @@ def hdl_wid_332(_: WIDParams):
                  Tester 2 to IUT, and then send Friend Poll from IUT to Lower Tester 1.
     """
     stack = get_stack()
-    assert stack.mesh.wait_for_lpn_established(timeout=60)
-    return True
+    return stack.mesh.wait_for_lpn_established(timeout=60)
 
 
 def hdl_wid_333(_: WIDParams):
@@ -1742,9 +1741,7 @@ def hdl_wid_333(_: WIDParams):
                  Please click OK when friendship is terminated.
     """
     stack = get_stack()
-    assert stack.mesh.wait_for_lpn_terminated(timeout=60)
-
-    return True
+    return stack.mesh.wait_for_lpn_terminated(timeout=60)
 
 
 def hdl_wid_335(_: WIDParams):
@@ -2852,9 +2849,7 @@ def hdl_wid_560(_: WIDParams):
     description: Lower Tester 2 is waiting for IUT's heartbeat triggered by friendship termination.
     """
     stack = get_stack()
-    assert stack.mesh.wait_for_lpn_terminated(timeout=60)
-
-    return True
+    return stack.mesh.wait_for_lpn_terminated(timeout=60)
 
 
 def hdl_wid_561(_: WIDParams):
@@ -2863,9 +2858,7 @@ def hdl_wid_561(_: WIDParams):
     description: Lower Tester 2 is waiting for IUT's heartbeat triggered by friendship establishment.
     """
     stack = get_stack()
-    assert stack.mesh.wait_for_lpn_established(timeout=60)
-
-    return True
+    return stack.mesh.wait_for_lpn_established(timeout=60)
 
 
 def hdl_wid_562(_: WIDParams):
@@ -2885,8 +2878,7 @@ def hdl_wid_563(_: WIDParams):
                  to IUT (Low Power Node).
     """
     stack = get_stack()
-    assert stack.mesh.wait_for_lpn_established(timeout=60)
-    return True
+    return stack.mesh.wait_for_lpn_established(timeout=60)
 
 
 def hdl_wid_564(_: WIDParams):
@@ -2897,9 +2889,7 @@ def hdl_wid_564(_: WIDParams):
                  to IUT (Low Power Node).
     """
     stack = get_stack()
-    assert stack.mesh.wait_for_lpn_established(timeout=60)
-
-    return True
+    return stack.mesh.wait_for_lpn_established(timeout=60)
 
 
 def hdl_wid_600(_: WIDParams):


### PR DESCRIPTION
Return negative response instead of asserting.