### PR TITLE
bot & tools: Save WID usage report in tmp directory

### DIFF
--- a/autopts/utils.py
+++ b/autopts/utils.py
@@ -36,7 +36,7 @@ PTS_WORKSPACE_FILE_EXT = ".pqw6"
 # Global paths for wid report
 BASE_DIR = Path(__file__).parent.parent.resolve()
 LOG_DIR = BASE_DIR / "logs"
-OUTPUT_CSV_PATH = BASE_DIR / "wid_usage_report.csv"
+OUTPUT_CSV_PATH = BASE_DIR / "tmp" / "wid_usage_report.csv"
 
 # Regex patterns for log field parsing in wid report
 WID_REGEX = re.compile(r"^wid:\s*(\S+)")


### PR DESCRIPTION
Saving this file in base directory caused some problems during setting this up in weekly runs.