### PR TITLE
Zephyr: Change `CONFIG_BT_L2CAP_CLS` to `CONFIG_BT_L2CAP_CONNLESS`

### DIFF
--- a/autopts/bot/iut_config/zephyr.py
+++ b/autopts/bot/iut_config/zephyr.py
@@ -384,7 +384,7 @@ iut_config = {
             'CONFIG_BT_SMP': 'y',
             'CONFIG_BT_L2CAP_DYNAMIC_CHANNEL': 'y',
             'CONFIG_BT_PAGE_TIMEOUT': '0xFFFF',
-            'CONFIG_BT_L2CAP_CLS': 'y',
+            'CONFIG_BT_L2CAP_CONNLESS': 'y',
         },
         "test_cases": [
             'L2CAP/CLS/CLR/BV-01-C',


### PR DESCRIPTION
In Zephyr, the feature configuration of L2CAP connectionless is changed from `CONFIG_BT_L2CAP_CLS` to `CONFIG_BT_L2CAP_CONNLESS`.

Change `CONFIG_BT_L2CAP_CLS` to `CONFIG_BT_L2CAP_CONNLESS` for `br_l2cap_cls.conf`.