### PR TITLE
ptscontrol: Add enable_maximum_logging to recovery list

### DIFF
--- a/autopts/ptscontrol.py
+++ b/autopts/ptscontrol.py
@@ -979,6 +979,7 @@ class PyPTS:
         log("%s %s", self.enable_maximum_logging.__name__, enable)
         self._pts.EnableMaximumLogging(enable)
         self._pts_logger.enable_maximum_logging(enable)
+        self.add_recov(self.enable_maximum_logging, enable)
 
     def set_call_timeout(self, timeout):
         """Sets a timeout period in milliseconds for the RunTestCase() calls


### PR DESCRIPTION
If --debug-logs or enable_max_logs is used, PTS logging should be set to the debug level. After PTS recovery, however, the logging level was not restored, since the enable_maximum_logging method was not included in the recovery list.