### PR TITLE
errata: Update zephyr list

### DIFF
--- a/errata/zephyr.yaml
+++ b/errata/zephyr.yaml
@@ -4,6 +4,37 @@
 
 BAP/BSRC/SCC/BV-34-C: https://github.com/zephyrproject-rtos/zephyr/issues/92153
 
+BAP/UCL/STR/BV-539-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-580-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-581-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-582-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-560-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-561-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-562-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-563-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-540-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-583-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-584-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-585-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-541-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-586-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-587-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-588-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-564-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-565-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-566-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-567-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-542-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-589-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-590-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-591-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-543-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-544-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-545-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-549-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-550-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+BAP/UCL/STR/BV-551-C: https://github.com/zephyrproject-rtos/zephyr/issues/96012
+
 CSIP/CL/CGGIT/CHA/BV-01-C: https://github.com/zephyrproject-rtos/zephyr/issues/91813
 
 DFUM/SR/FD/BV-28-C: https://github.com/zephyrproject-rtos/zephyr/issues/92159


### PR DESCRIPTION
This lists tests that are failign due to missing support in tester for CIS establishment in QoS Configured state.