### PR TITLE
bot: common: cliparser: Fix DEBUG:root logs appearing in console

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -272,6 +272,8 @@ class BotClient(Client):
         if 'file_paths' in self.bot_config:
             generate_file_paths(self.bot_config['file_paths'])
 
+        # Remove default root handler that was created at the first logging.debug
+        logging.getLogger().handlers.clear()
         self.args, errmsg = self.arg_parser.parse(bot_config_namespace)
         self.args.retry_config = bot_config_dict.get('retry_config', None)
 
@@ -282,11 +284,6 @@ class BotClient(Client):
             self.load_backup_of_previous_run()
         else:
             self.bot_pre_cleanup()
-
-        # Remove default root handler that was created at the first logging.debug
-        logging.getLogger().handlers.clear()
-        init_logging('_' + '_'.join(str(x) for x in self.args.cli_port),
-                     self.file_paths.get('BOT_LOG_FILE', None))
 
         return errmsg
 

--- a/cliparser.py
+++ b/cliparser.py
@@ -21,7 +21,7 @@ import os
 import time
 from distutils.spawn import find_executable
 
-from autopts.config import CLIENT_PORT, MAX_SERVER_RESTART_TIME, SERIAL_BAUDRATE, SERVER_PORT
+from autopts.config import CLIENT_PORT, FILE_PATHS, MAX_SERVER_RESTART_TIME, SERIAL_BAUDRATE, SERVER_PORT
 from autopts.ptsprojects.boards import com_to_tty, get_debugger_snr, get_free_device, get_tty, tty_exists
 from autopts.ptsprojects.testcase_db import DATABASE_FILE
 from autopts.utils import active_hub_server_replug_usb, get_tc_from_wid, load_wid_report, raise_on_global_end, ykush_replug_usb
@@ -430,7 +430,8 @@ class CliParser(argparse.ArgumentParser):
         args = self.parse_args(None, arg_ns)
 
         from autopts.client import init_logging
-        init_logging('_' + '_'.join(str(x) for x in args.cli_port))
+        init_logging('_' + '_'.join(str(x) for x in args.cli_port),
+                     FILE_PATHS.get('BOT_LOG_FILE', None))
 
         if args.btproxy_bin and not is_executable(args.btproxy_bin):
             return args, f'The btproxy_bin={args.btproxy_bin} is not an executable file'


### PR DESCRIPTION
Console logs like this:
 DEBUG:root:find_tty
 DEBUG:root:Using tty_file=COM19

appeared when logging started before autoptsclient_bot_<ports>.log was initialized. We can do this earlier, since the initialization can happen in cliparser now.