### PR TITLE
iutctl: Add missing _btattach field initialization

### DIFF
--- a/autopts/ptsprojects/iutctl.py
+++ b/autopts/ptsprojects/iutctl.py
@@ -111,6 +111,8 @@ class IutCtl:
         self._rtt_logger_name = 'Logger'
         self._btmon_rtt_name = 'btmonitor'
         self._btmon = None
+        self._btattach = None
+        self._btproxy = None
         self._uart_logger = None
         self.rtscts = args.rtscts
         self._start_mode = None


### PR DESCRIPTION
In TTY mode, the _btattach field was not initialized and could cause an exception at run_recovery() if active hub was used. Fix the exception:
AttributeError: 'IutCtl' object has no attribute '_btattach'