### PR TITLE
iutctl: zaphyr: native: Move removing flash.bin to ztestcase

### DIFF
--- a/autopts/ptsprojects/zephyr/iutctl.py
+++ b/autopts/ptsprojects/zephyr/iutctl.py
@@ -37,10 +37,10 @@ class ZephyrCtl(IutCtl):
     def stop(self):
         super().stop()
 
-        if self.iut_mode == "native":
-            flash_bin = os.path.join(AUTOPTS_ROOT_DIR, 'flash.bin')
-            if os.path.exists(flash_bin):
-                os.remove(flash_bin)
+    def remove_flash_bin(self):
+        flash_bin = os.path.join(AUTOPTS_ROOT_DIR, 'flash.bin')
+        if os.path.exists(flash_bin):
+            os.remove(flash_bin)
 
 
 def get_iut():

--- a/autopts/ptsprojects/zephyr/ztestcase.py
+++ b/autopts/ptsprojects/zephyr/ztestcase.py
@@ -38,6 +38,9 @@ class ZTestCase(TestCaseLT1):
         # Await IUT ready event
         self.cmds.insert(2, TestFunc(self.zephyrctl.wait_iut_ready_event, False))
 
+        if self.zephyrctl.iut_mode == "native":
+            self.cmds.insert(0, TestFunc(self.zephyrctl.remove_flash_bin))
+
         self.cmds.append(TestFuncCleanUp(self.stack.cleanup))
 
         # Last command is to stop QEMU or HW.


### PR DESCRIPTION
The iutctl.stop method was not the best place to remove the flash.bin, because some WIDs call it in the middle of a test case. Let's remove the file before each test case in TestCase.__init__.