### PR TITLE
iutctl: Add support for btmon for iut in native mode

### DIFF
--- a/autopts/ptsprojects/iutctl.py
+++ b/autopts/ptsprojects/iutctl.py
@@ -129,7 +129,7 @@ class IutCtl:
             if self.debugger_snr:
                 self.btp_address = BTP_ADDRESS + self.debugger_snr
                 self._rtt_logger = RTTLogger(args.rtt_log_syncto) if args.rtt_log else None
-                self._btmon = BTMON() if args.btmon else None
+        self._btmon = BTMON() if args.btmon else None
 
         if self.iut_mode == "tty":
             self._start_mode = self._start_tty_mode
@@ -301,6 +301,9 @@ class IutCtl:
                 raise Exception(f"Could not find the device: VID={self.hid_vid} "
                                 f"PID={self.hid_pid} SN={self.hid_serial}")
 
+        if self._btmon:
+            self.btmon_start()
+
         native_cmd = self.get_native_cmd(kernel_image=self.kernel_image,
                                          hci=self.hci,
                                          tty_baudrate=self.tty_baudrate,
@@ -340,7 +343,7 @@ class IutCtl:
             log_file = os.path.join(self.test_case.log_dir,
                                     self.test_case.name.replace('/', '_') +
                                     '_btmon.log')
-            self._btmon.start(self._btmon_rtt_name, log_file, self.device_core, self.debugger_snr)
+            self._btmon.start(self._btmon_rtt_name, log_file, self.device_core, self.debugger_snr, self.hci)
 
     def btmon_stop(self):
         if self._btmon:
@@ -466,3 +469,6 @@ class IutCtl:
 
         if self._native:
             self._native.close()
+
+        if self._btmon:
+            self.btmon_stop()

--- a/autopts/rtt.py
+++ b/autopts/rtt.py
@@ -150,7 +150,7 @@ class BTMON:
     def is_running(self):
         return not self.rtt_reader.stop_thread.is_set()
 
-    def start(self, buffer_name, log_file, device_core, debugger_snr):
+    def start(self, buffer_name, log_file, device_core, debugger_snr, hci):
         log("%s.%s", self.__class__, self.start.__name__)
 
         log_filecwd = os.path.dirname(os.path.abspath(log_file))
@@ -201,7 +201,13 @@ class BTMON:
 
             self.rtt_reader.start(buffer_name, device_core, debugger_snr, self._on_line_read_callback, (sock,))
         else:
-            cmd = f"btmon -C 130 -J {device_core},{debugger_snr} -w {log_filename} | grep -v '^= bt:' > {plain_log_filename}"
+            if hci is not None:
+                cmd = f"btmon -C 130 -i {hci} -w {log_filename} | grep -v '^= bt:' > {plain_log_filename}"
+            else:
+                cmd = (
+                    f"btmon -C 130 -J {device_core},{debugger_snr} "
+                    f"-w {log_filename} | grep -v '^= bt:' > {plain_log_filename}"
+                )
             self.btmon_process = subprocess.Popen(cmd, cwd=log_filecwd,
                                                   shell=True,
                                                   stdout=subprocess.PIPE,

--- a/cliparser.py
+++ b/cliparser.py
@@ -212,10 +212,11 @@ class CliParser(argparse.ArgumentParser):
                                "each test case. If board is not specified DUT "
                                "will not be reset.")
 
-        self.add_argument("--btmon",
-                          help="Capture iut btsnoop logs from device over RTT"
-                          "and catch them with btmon. Requires rtt support"
-                          "on IUT.", action='store_true', default=False)
+        self.add_argument("--btmon", action='store_true', default=False,
+                          help="Capture iut btsnoop logs from device over RTT and catch them with btmon. Requires rtt "
+                               "support on IUT. When using with native linux build CAP_NET_RAW,CAP_NET_ADMIN and "
+                               "CAP_SYS_ADMIN permissions are required. "
+                               "e.g. sudo setcap cap_net_raw,cap_net_admin,cap_sys_admin+ep /usr/bin/btmon ")
 
         self.add_argument("--device_core", default='NRF52840_XXAA',
                           help="Specify the device core for JLink related features, "


### PR DESCRIPTION
Add btmon HCI logging for tests executed on native linux build. Use --btmon option to enable.
Fixes #1560