### PR TITLE
bot: add valgrind option for native builds

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -117,6 +117,7 @@ class BotConfigArgs(Namespace):
         self.hci = args.get('hci', None)
         self.test_cases = args.get('test_cases', [])
         self.excluded = args.get('excluded', [])
+        self.valgrind = args.get('valgrind', False)
 
         self.bd_addr = args.get('bd_addr', '')
         self.enable_max_logs = args.get('enable_max_logs', False)


### PR DESCRIPTION
Valgrind can be used for native build testing.