### PR TITLE
utils: Fix path resolve issue for windows running in VM.

### DIFF
--- a/autopts/utils.py
+++ b/autopts/utils.py
@@ -36,7 +36,11 @@ from autopts.config import FILE_PATHS
 PTS_WORKSPACE_FILE_EXT = ".pqw6"
 
 # Global paths for wid report
-BASE_DIR = Path(__file__).parent.parent.resolve()
+BASE_DIR = Path(__file__).parent.parent
+try:
+    BASE_DIR = BASE_DIR.resolve()
+except OSError:
+    BASE_DIR = BASE_DIR.absolute()
 LOG_DIR = BASE_DIR / "logs"
 
 # Regex patterns for log field parsing in wid report
@@ -583,7 +587,11 @@ def extract_wid_testcases_to_csv(log_dir: Path = None):
                 testcases_combined = " ".join(testcases)
                 writer.writerow([wid, testcases_combined])
 
-    print(f"WID usage report saved to: {OUTPUT_CSV_PATH.resolve()}")
+    try:
+        wid_path = OUTPUT_CSV_PATH.resolve()
+    except OSError:
+        wid_path = OUTPUT_CSV_PATH.absolute()
+    print(f"WID usage report saved to: {wid_path}")
 
 
 Sep = re.compile(r'[,\s;|]+')


### PR DESCRIPTION
For AutoPTS setup in which Windows runs in Virtual Mashine path resolve calls return currupted disk error. This might be limited to KVM based virtual machines share files over virtiofs.


Error logs:

Z:\auto-pts_server>py -3 autoptsserver.py
Traceback (most recent call last):
  File "<frozen ntpath>", line 696, in realpath
OSError: [WinError 1005] The volume does not contain a recognized file system.
Please make sure that all required file system drivers are loaded and that the volume is not corrupted: 'Z:\\auto-pts_server'
 
During handling of the above exception, another exception occurred:
 
Traceback (most recent call last):
  File "Z:\auto-pts_server\autoptsserver.py", line 53, in <module>
    from autopts import ptscontrol
  File "Z:\auto-pts_server\autopts\ptscontrol.py", line 54, in <module>
    from autopts.utils import PTS_WORKSPACE_FILE_EXT, ResultWithFlag, count_script_instances, get_own_workspaces
  File "Z:\auto-pts_server\autopts\utils.py", line 39, in <module>
    BASE_DIR = Path(__file__).parent.parent.resolve()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\user\AppData\Local\Programs\Python\Python311\Lib\pathlib.py", line 993, in resolve
    s = os.path.realpath(self, strict=strict)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen ntpath>", line 710, in realpath
  File "<frozen ntpath>", line 650, in _getfinalpathname_nonstrict
OSError: [WinError 1005] The volume does not contain a recognized file system.
Please make sure that all required file system drivers are loaded and that the volume is not corrupted: 'Z:\\auto-pts_server'