### PR TITLE
autopts: rtt: Potentially improve stability after failed RTT teardown

### DIFF
--- a/autopts/rtt.py
+++ b/autopts/rtt.py
@@ -116,8 +116,14 @@ class RTT:
             self.read_thread.join()
             self.read_thread = None
             if RTT.jlink:
-                RTT.jlink.rtt_stop()
-                RTT.jlink.close()
+                try:
+                    RTT.jlink.rtt_stop()
+                except (pylink.errors.JLinkRTTException, pylink.errors.JLinkException) as err:
+                    log(f'Failed to stop RTT, err: {err}')
+                try:
+                    RTT.jlink.close()
+                except pylink.errors.JLinkException as err:
+                    log(f'Failed to close J-Link connection, err: {err}')
                 del RTT.jlink
                 RTT.jlink = None
 


### PR DESCRIPTION
If the pylink rtt_stop() call throws an exception, the JLink DLL is never properly closed, causing setup issues for the remaining test-cases in a run. This change ensures that we at least try to close the driver before going on with the next test-case.