### PR TITLE
errata: Add note that couple CPUP tests required Laird LE PTS dongle

### DIFF
--- a/errata/common.yaml
+++ b/errata/common.yaml
@@ -2,6 +2,9 @@
 # GAP/CONN/NCON/BV-01-C: CASE00xxxxx
 # GAP/CONN/NCON/BV-02-C: CASE00xxxxx
 
+GAP/CONN/CPUP/BV-08-C: Laird PTS LE-only dongle required
+GAP/CONN/CPUP/BV-10-C: Laird PTS LE-only dongle required
+
 GATT/CL/GAS/BV-01-C: Request ID 172942
 GATT/SR/GAN/BV-01-C: ES-27410
 GATT/SR/GAI/BV-01-C: ES-27410


### PR DESCRIPTION
PTS now provides multiple options for dongles with different features supported. Lets add a note for known tests that require specific PTS dongle.