### PR TITLE
bot: add option to skip copying workspace file

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -139,7 +139,7 @@ class BotConfigArgs(Namespace):
         self.no_build = args.get('no_build', False)
         self.dongle_init_retry = args.get('dongle_init_retry', 5)
         self.build_env_cmd = args.get('build_env_cmd', None)
-        self.copy = args.get('copy', True)
+        self.copy_workspace = args.get('copy_workspace', True)
         self.wid_usage = args.get('wid_usage', False)
 
         if self.server_args is not None:
@@ -547,10 +547,11 @@ class BotClient(Client):
             os.path.join(AUTOPTS_ROOT_DIR, f'errata/{self.autopts_project_name}.yaml')
         ])
 
-        report_data['pts_logs_folder'], report_data['pts_xml_folder'] = \
-            report.pull_server_logs(self.args,
-                                    self.file_paths['TMP_DIR'],
-                                    self.file_paths['PTS_XMLS_DIR'])
+        if self.args.copy_workspace:
+            report_data['pts_logs_folder'], report_data['pts_xml_folder'] = \
+                report.pull_server_logs(self.args,
+                                        self.file_paths['TMP_DIR'],
+                                        self.file_paths['PTS_XMLS_DIR'])
 
         report.make_report_xlsx(self.file_paths['REPORT_XLSX_FILE'],
                                 report_data['tc_results'],
@@ -558,7 +559,7 @@ class BotClient(Client):
                                 report_data['regressions'],
                                 report_data['progresses'],
                                 report_data['descriptions'],
-                                report_data['pts_xml_folder'],
+                                getattr(report_data, 'pts_xml_folder', None),
                                 report_data['errata'])
 
         report.make_report_txt(self.file_paths['REPORT_TXT_FILE'],
@@ -645,13 +646,17 @@ class BotClient(Client):
             (self.file_paths['REPORT_XLSX_FILE'], f'report_{report_data["start_time_stamp"]}.xlsx'),
             self.file_paths['REPORT_README_MD_FILE'],
             report_data['database_file'],
-            report_data['pts_xml_folder'],
         ]
 
+        if 'pts_xml_folder' in report_data:
+            attachments.append(report_data['pts_xml_folder'])
+
         iut_logs_new = os.path.join(self.file_paths['REPORT_DIR'], 'iut_logs')
-        pts_logs_new = os.path.join(self.file_paths['REPORT_DIR'], 'pts_logs')
         get_deepest_dirs(self.file_paths['IUT_LOGS_DIR'], iut_logs_new, 3)
-        get_deepest_dirs(report_data['pts_logs_folder'], pts_logs_new, 3)
+
+        if 'pts_logs_folder' in report_data:
+            pts_logs_new = os.path.join(self.file_paths['REPORT_DIR'], 'pts_logs')
+            get_deepest_dirs(report_data['pts_logs_folder'], pts_logs_new, 3)
 
         self.generate_attachments(report_data, attachments)
 

--- a/autopts/bot/common_features/report.py
+++ b/autopts/bot/common_features/report.py
@@ -100,7 +100,7 @@ def make_report_xlsx(report_xlsx_path: str,
                      regressions_list: list,
                      progresses_list: list,
                      descriptions: dict,
-                     xmls: str,
+                     xmls: str | None,
                      errata: dict):
     """
     Creates xlsx file containing test cases results and summary pie chart.
@@ -115,7 +115,7 @@ def make_report_xlsx(report_xlsx_path: str,
     """
 
     try:
-        xml_list = list(os.scandir(xmls))
+        xml_list = list(os.scandir(xmls)) if xmls is not None else None
     except FileNotFoundError:
         log("No XMLs found")
         xml_list = None

--- a/autopts/client.py
+++ b/autopts/client.py
@@ -485,8 +485,8 @@ def init_pts_thread_entry(proxy, args, exceptions, finish_count):
     log("PTS BD_ADDR: %s", proxy.q_bd_addr)
 
     log("Opening workspace: %s", args.workspace)
-    log("Copy workspace: %s", args.copy)
-    proxy.open_workspace(args.workspace, args.copy)
+    log("Copy workspace: %s", args.copy_workspace)
+    proxy.open_workspace(args.workspace, args.copy_workspace)
 
     if args.bd_addr:
         projects = proxy.get_project_list()

--- a/autopts/ptscontrol.py
+++ b/autopts/ptscontrol.py
@@ -673,7 +673,7 @@ class PyPTS:
             os.remove(self._temp_workspace_path)
 
     @pts_lock_wrapper(PTS_START_LOCK)
-    def open_workspace(self, workspace_path, copy=False):
+    def open_workspace(self, workspace_path, copy_workspace=False):
         """Opens existing workspace"""
 
         log(f"open_workspace {workspace_path}")
@@ -698,7 +698,7 @@ class PyPTS:
         # Workaround CASE0044114 PTS issue
         # Do not open original workspace file that can become broken by
         # TestCase. Instead use a copy of this file
-        if copy:
+        if copy_workspace:
             if self._temp_workspace_path and \
                     os.path.exists(self._temp_workspace_path):
                 os.unlink(self._temp_workspace_path)
@@ -718,7 +718,7 @@ class PyPTS:
         else:
             self._pts.OpenWorkspace(workspace_path)
 
-        self.add_recov(self.open_workspace, workspace_path, copy)
+        self.add_recov(self.open_workspace, workspace_path, copy_workspace)
         self._cache_test_cases()
 
     def _cache_test_cases(self):

--- a/cliparser.py
+++ b/cliparser.py
@@ -126,7 +126,7 @@ class CliParser(argparse.ArgumentParser):
         self.add_argument("--pylink_reset", action='store_true', default=False,
                           help="Use pylink reset.")
 
-        self.add_argument('--nc', dest='copy', action='store_false',
+        self.add_argument('--nc', dest='copy_workspace', action='store_false',
                           help='Do not copy workspace, open original one. '
                                'Warning: workspace file might be modified', default=True)
 


### PR DESCRIPTION
Rename copy argument to copy_workspace for clarity. Set copy_workspace in your config_prj.py to false or use command line arg --nc if you don't want auto-pts to copy your .pqw6 file and keep working with original file. This will now keep log files in autopts/workspaces/your_workspace directory which makes report generation process a lot easier. You can go back and forth between auto-pts testing and manual seamlessly.