### PR TITLE
BAP: Reorder LTs and fix synch points

### DIFF
--- a/autopts/ptsprojects/zephyr/bap.py
+++ b/autopts/ptsprojects/zephyr/bap.py
@@ -239,7 +239,7 @@ def test_cases(ptses):
                                 SynchPoint("BAP/UCL/STR/BV-532-C_LT2", 20100)]),
                       TestFunc(get_stack().synch.add_synch_element,
                                [SynchPoint("BAP/UCL/STR/BV-532-C", 311),
-                                SynchPoint("BAP/UCL/STR/BV-532-C_LT2", 311)]),
+                                SynchPoint("BAP/UCL/STR/BV-532-C_LT2", 313)]),
                       # More SyncPoint will be needed, but for now Zephyr does not reach the next wid
                   ],
                   generic_wid_hdl=bap_wid_hdl,
@@ -250,8 +250,8 @@ def test_cases(ptses):
                                [SynchPoint("BAP/UCL/STR/BV-534-C", 20100),
                                 SynchPoint("BAP/UCL/STR/BV-534-C_LT2", 20100)]),
                       TestFunc(get_stack().synch.add_synch_element,
-                               [SynchPoint("BAP/UCL/STR/BV-534-C", 311),
-                                SynchPoint("BAP/UCL/STR/BV-534-C_LT2", 311)]),
+                               [SynchPoint("BAP/UCL/STR/BV-534-C", 313),
+                                SynchPoint("BAP/UCL/STR/BV-534-C_LT2", 313)]),
                       # More SyncPoint will be needed, but for now Zephyr does not reach the next wid
                   ],
                   generic_wid_hdl=bap_wid_hdl,

--- a/autopts/wid/bap.py
+++ b/autopts/wid/bap.py
@@ -1266,8 +1266,8 @@ ac_configs = {
     'BAP/UCL/STR/BV-530-C':     ([(0, 1)], 2),          # AC 9(ii)
     'BAP/UCL/STR/BV-530-C_LT2': ([(0, 1)], 2),
     'BAP/UCL/STR/BV-531-C':     ([(1, 0), (1, 1)], 1),  # AC 8(i)
-    'BAP/UCL/STR/BV-532-C':     ([(1, 1)], 2),          # AC 8(ii)
-    'BAP/UCL/STR/BV-532-C_LT2': ([(1, 0)], 2),
+    'BAP/UCL/STR/BV-532-C':     ([(1, 0)], 2),          # AC 8(ii)
+    'BAP/UCL/STR/BV-532-C_LT2': ([(1, 1)], 2),
     'BAP/UCL/STR/BV-533-C':     ([(1, 1), (1, 1)], 1),  # AC 11(i)
     'BAP/UCL/STR/BV-534-C':     ([(1, 1)], 2),          # AC 11(ii)
     'BAP/UCL/STR/BV-534-C_LT2': ([(1, 1)], 2),


### PR DESCRIPTION
- Fixes:
  - BAP/UCL/STR/BV-532-C
  - BAP/UCL/STR/BV-534-C
- Depends on https://github.com/zephyrproject-rtos/zephyr/pull/99200