### PR TITLE
zephyr: mesh: fix model rx payload length

### DIFF
--- a/autopts/pybtp/btp/mesh.py
+++ b/autopts/pybtp/btp/mesh.py
@@ -1781,7 +1781,7 @@ def mesh_model_recv_ev(mesh, data, data_len):
     if not stack.mesh.model_recv_ev_store.data:
         return
 
-    hdr_fmt = '<HHB'
+    hdr_fmt = '<HHH'
     hdr_len = struct.calcsize(hdr_fmt)
 
     (src, dst, payload_len) = struct.unpack_from(hdr_fmt, data, 0)

--- a/doc/btp_mesh_node.txt
+++ b/doc/btp_mesh_node.txt
@@ -1532,7 +1532,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       SRC (2 octets)
                                         DST (2 octets)
-                                        Payload_Len (1 octet)
+                                        Payload_Len (2 octets)
                                         Payload (variable)
 
                 This event indicates that the IUT has received an Access layer message.


### PR DESCRIPTION
Commit fixes rx model event payload length.
Since model might receive full access payload
then 1 byte length is not sufficient. It is 2 bytes now.