### PR TITLE
bot: github: Add 'west_update_env' parameter to git config

### DIFF
--- a/autopts/bot/common_features/github.py
+++ b/autopts/bot/common_features/github.py
@@ -85,7 +85,9 @@ def update_repos(project_path, git_config):
         repos_dict[repo] = repo_dict
 
         if conf.get('west_update', False):
-            bot.common.check_call(['west', 'update'], cwd=repo_path)
+            env_cmd = conf.get('west_update_env', None)
+            env_cmd = env_cmd.split() + ['&&'] if env_cmd else []
+            bot.common.check_call(env_cmd + ['west', 'update'], cwd=repo_path)
 
         if conf.get('rm_pycache', False):
             for p in pathlib.Path(repo_path).rglob('*.py[co]'):


### PR DESCRIPTION
When using a separate Python virtual environment for the project and AutoPTS, and the 'west' tool is not installed globally, the 'west update' command in update_repos fails because 'west' is not visible.

The new 'west_update_env' parameter allows specifying a Python environment to activate before running 'west update', ensuring the command works in isolated setups.

Example usage in config.py:

z['git'] = {
    'zephyr': {
        'path': f'{HOME_PATH}/zephyrproject/zephyr',
        'remote': 'origin',
        'branch': 'main',
        'stash_changes': True,
        'update_repo': True,
        'west_update': True,
        'west_update_env': 'source {HOME_PATH}/zephyrproject/.venv/bin/activate',
    },
}