### PR TITLE
Explicitly register VCS in other test suites

### DIFF
--- a/autopts/ptsprojects/zephyr/aics.py
+++ b/autopts/ptsprojects/zephyr/aics.py
@@ -71,6 +71,7 @@ def test_cases(ptses):
                       TestFunc(btp.gap_set_gendiscov),
                       TestFunc(btp.core_reg_svc_aics),
                       TestFunc(btp.core_reg_svc_vcs),
+                      TestFunc(btp.vcs_register, 1, False, 100),
                       TestFunc(btp.set_pts_addr, pts_bd_addr, Addr.le_public),
                       TestFunc(stack.aics_init),
                       TestFunc(stack.vcs_init)]

--- a/autopts/ptsprojects/zephyr/cap.py
+++ b/autopts/ptsprojects/zephyr/cap.py
@@ -116,6 +116,7 @@ def test_cases(ptses):
         TestFunc(btp.gap_set_gendiscov),
         TestFunc(btp.core_reg_svc_mics),
         TestFunc(btp.core_reg_svc_vcs),
+        TestFunc(btp.vcs_register, 1, False, 100),
         TestFunc(stack.vcs_init),
         TestFunc(btp.core_reg_svc_aics),
         TestFunc(stack.aics_init),

--- a/autopts/ptsprojects/zephyr/hap.py
+++ b/autopts/ptsprojects/zephyr/hap.py
@@ -123,6 +123,7 @@ def test_cases(ptses):
         TestFunc(btp.core_reg_svc_ascs),
         TestFunc(stack.ascs_init),
         TestFunc(btp.core_reg_svc_vcs),
+        TestFunc(btp.vcs_register, 1, False, 100),
         TestFunc(btp.core_reg_svc_cas),
         TestFunc(btp.core_reg_svc_ias),
         TestFunc(stack.ias_init),

--- a/autopts/ptsprojects/zephyr/tmap.py
+++ b/autopts/ptsprojects/zephyr/tmap.py
@@ -89,6 +89,7 @@ def test_cases(ptses):
         TestFunc(btp.core_reg_svc_tmap),
         TestFunc(btp.core_reg_svc_vcp),
         TestFunc(btp.core_reg_svc_vcs),
+        TestFunc(btp.vcs_register, 1, False, 100),
         TestFunc(btp.core_reg_svc_tbs),
         TestFunc(btp.core_reg_svc_csip),
         TestFunc(stack.ascs_init),

--- a/autopts/ptsprojects/zephyr/vocs.py
+++ b/autopts/ptsprojects/zephyr/vocs.py
@@ -69,6 +69,7 @@ def test_cases(ptses):
                       TestFunc(btp.gap_set_gendiscov),
                       TestFunc(btp.core_reg_svc_vocs),
                       TestFunc(btp.core_reg_svc_vcs),
+                      TestFunc(btp.vcs_register, 1, False, 100),
                       TestFunc(stack.vocs_init),
                       TestFunc(stack.vcs_init)]
 


### PR DESCRIPTION
After PR 1603, some test-suites that were also using the VCS broke since the VCS service is no longer implicitly registered by bttester on initialization. This adds a call for those test-suites to explicitly register VCS, which should replicate the old behaviour for those.