### PR TITLE
zephyr: BASS: Remove adv from pre_conditions

### DIFF
--- a/autopts/ptsprojects/zephyr/bass.py
+++ b/autopts/ptsprojects/zephyr/bass.py
@@ -118,8 +118,6 @@ def test_cases(ptses):
                       TestFunc(stack.ascs_init),
                       TestFunc(stack.bap_init),
                       TestFunc(lambda: stack.bap.set_broadcast_code(broadcast_code)),
-                      TestFunc(btp.gap_set_extended_advertising_on),
-                      TestFunc(lambda: btp.gap_adv_ind_on(ad=ad)),
                       TestFunc(btp.bap_broadcast_sink_setup),
                       TestFunc(lambda: set_addr(
                           stack.gap.iut_addr_get_str())),


### PR DESCRIPTION
For all BASS test we receive WID 20001 that explcitly requests us to start advertising. With the pre_conditions we ended up starting advertising twice for all BASS tests, which in some cases ended up with a race condition if we restarted it while connecting.