### PR TITLE
errata: Add erratum for BASS/SR/CP/BV-15-C

### DIFF
--- a/errata/common.yaml
+++ b/errata/common.yaml
@@ -2,6 +2,8 @@
 # GAP/CONN/NCON/BV-01-C: CASE00xxxxx
 # GAP/CONN/NCON/BV-02-C: CASE00xxxxx
 
+BASS/SR/CP/BV-15-C: https://support.bluetooth.com/hc/en-us/requests/181225
+
 GAP/CONN/CPUP/BV-08-C: Laird PTS LE-only dongle required
 GAP/CONN/CPUP/BV-10-C: Laird PTS LE-only dongle required
 


### PR DESCRIPTION
BASS/SR/CP/BV-15-C doesn't run due to a PTS firmware error on the nRF54L15.