### PR TITLE
boards: start using nrfutil instead of nrfjprog

### DIFF
--- a/autopts/ptsprojects/boards/nrf5x.py
+++ b/autopts/ptsprojects/boards/nrf5x.py
@@ -28,7 +28,7 @@ def reset_cmd(iutctl):
     Dependency: nRF5x command line tools
     """
 
-    return f'nrfjprog -r -s {iutctl.debugger_snr}'
+    return f'nrfutil device reset --reset-kind RESET_PIN --serial-number {iutctl.debugger_snr}'
 
 
 def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, project_repos=None,


### PR DESCRIPTION
nrfutil is recommended to be used used for nrf5 series and specifically with the latest nrf54 series.

nrfjprog fails to reset nrf54l devices properly and it creates unstability in between test due to not reset device causing BTP_TIMEOUT errors.