### PR TITLE
Reset Broadcast ID IXIT for other test cases

### DIFF
--- a/autopts/ptsprojects/zephyr/bap.py
+++ b/autopts/ptsprojects/zephyr/bap.py
@@ -55,6 +55,8 @@ def set_pixits(ptses):
     pts.set_pixit("BAP", "TSPX_VS_Codec_ID", "ffff")
     pts.set_pixit("BAP", "TSPX_VS_Company_ID", "ffff")
     pts.set_pixit("BAP", "TSPX_broadcast_code", BROADCAST_CODE)
+    pts.set_pixit("BAP", "TSPX_Broadcast_ID", "0")
+    pts.set_pixit("BAP", "TSPX_Broadcast_ID_2", "0")
 
     if len(ptses) < 2:
         return


### PR DESCRIPTION
Since BAP/BSRC/SCC/BV-38-C is the only test-case to use the Broadcast ID IXIT values, the other test-cases should reset this back to null. Otherwise, certain other test-cases can fail by chance if run after BAP/BSRC/SCC/BV-38-C in a run.