### PR TITLE
tools: Resolve path to workspace for PTS

### DIFF
--- a/tools/list_testcases.py
+++ b/tools/list_testcases.py
@@ -45,3 +45,5 @@ if __name__ == '__main__':
 
     for test_case_name in test_cases:
         print(test_case_name)
+
+    pts.stop_pts()


### PR DESCRIPTION
Use abspath to make workspace_path for pts.open_workspace an absolute path which is required.

fixes https://github.com/auto-pts/auto-pts/issues/1643