### PR TITLE
btp: Add helper function to encode LE Audio metadata

### DIFF
--- a/autopts/pybtp/btp/audio.py
+++ b/autopts/pybtp/btp/audio.py
@@ -1,0 +1,119 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2025, Nordic Semiconductor ASA.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+"""Common LE Audio related functions that are not specific to any profiles"""
+
+import struct
+
+from autopts.pybtp import defs
+
+
+def is_uint8(val: int) -> bool:
+    """
+    Returns True if val is a unsigned 8-bit integer
+
+    Args:
+        val (int): The int to check
+
+    Returns:
+        bool: True if val is an unsigned 8-bit integer (0x00-0xFF), False otherwise
+    """
+    return isinstance(val, int) and 0x00 <= val <= 0xFF
+
+
+def is_uint16(val: int) -> bool:
+    """
+    Returns True if val is a unsigned 16-bit integer
+
+    Args:
+        val (int): The int to check
+
+    Returns:
+        bool: True if val is an unsigned 16-bit integer (0x0000-0xFFFF), False otherwise
+    """
+    return isinstance(val, int) and 0x0000 <= val <= 0xFFFF
+
+
+def is_utf8_string(val: str, max_len: int = 254) -> bool:
+    """
+    Returns True if val is a valid UTF-8 string
+
+    By default it checks if the string fits in LTV data (max size in octets is 255 - 1 for the type)
+
+    Args:
+        val (str): The string to check
+        max_len (int): The maximum size in octets of the string (default 254)
+
+    Returns:
+        bool: True if val is a string with size <= max_len, False otherwise
+    """
+    return isinstance(val, str) and len(val.encode("utf-8")) <= max_len
+
+
+def pack_metadata(stream_context: int = None, ccid_list: list[int] = None, program_info: str = None) -> bytes:
+    """
+    Pack LE Audio metadata into LTV (Length-Type-Value) format.
+
+    Args:
+        stream_context (int, optional): Audio stream context value (0x0000 to 0xFFFF).
+            If provided, must be an unsigned 16-bit integer.
+        ccid_list (list[int], optional): List of unique Content Control IDs (0x00 to 0xFF each).
+            If provided, must be a list of unique unsigned 8-bit integers, max length 254.
+        program_info (str, optional): UTF-8 program info string (max 254 bytes).
+
+    Returns:
+        bytes: Packed metadata in LTV format.
+
+    Raises:
+        ValueError: If any parameter is invalid (wrong type, out of range, or not unique).
+
+    Example:
+        >>> pack_metadata(stream_context=0x1234, ccid_list=[1,2,3], program_info="Test")
+        b'\\x03\\x02\\x34\\x12\\x04\\x05\\x01\\x02\\x03\\x05\\x03Test'
+    """
+
+    metadata = b""
+
+    if stream_context is not None:
+        if is_uint16(stream_context):
+            metadata += struct.pack("<BBH", 3, defs.AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, stream_context)
+        else:
+            raise ValueError(f"Invalid stream_context value: {stream_context}")
+
+    if ccid_list is not None:
+        if (
+            isinstance(ccid_list, list)
+            and len(ccid_list) <= 254  # max number of CCIDs
+            and all(is_uint8(ccid) for ccid in ccid_list)
+            and len(ccid_list) == len(set(ccid_list))  # check uniqueness
+        ):
+            metadata += struct.pack(
+                f"<BB{len(ccid_list)}B",
+                1 + len(ccid_list),
+                defs.AUDIO_METADATA_CCID_LIST,
+                *ccid_list,
+            )
+        else:
+            raise ValueError(f"Invalid ccid_list value: {ccid_list}")
+
+    if program_info is not None:
+        if is_utf8_string(program_info):
+            metadata += struct.pack(
+                "<BB", 1 + len(program_info.encode("utf-8")), defs.AUDIO_METADATA_PROGRAM_INFO
+            ) + program_info.encode("utf-8")
+        else:
+            raise ValueError(f"Invalid program_info value: {program_info}")
+
+    return metadata

--- a/autopts/wid/cap.py
+++ b/autopts/wid/cap.py
@@ -2,6 +2,7 @@
 # auto-pts - The Bluetooth PTS Automation Framework
 #
 # Copyright (c) 2023, Oticon.
+# Copyright (c) 2025, Nordic Semiconductor ASA.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms and conditions of the GNU General Public License,
@@ -20,11 +21,18 @@ from argparse import Namespace
 
 from autopts.ptsprojects.stack import WildCard, get_stack
 from autopts.pybtp import btp, defs
-from autopts.pybtp.btp import lt2_addr_get, lt2_addr_type_get, lt3_addr_get, lt3_addr_type_get, pts_addr_get, pts_addr_type_get
+from autopts.pybtp.btp import (
+    lt2_addr_get,
+    lt2_addr_type_get,
+    lt3_addr_get,
+    lt3_addr_type_get,
+    pts_addr_get,
+    pts_addr_type_get,
+)
+from autopts.pybtp.btp.audio import pack_metadata
 from autopts.pybtp.btp.cap import announcements
 from autopts.pybtp.btp.gap import gap_set_uuid16_svc_data
 from autopts.pybtp.btp.pacs import pacs_set_available_contexts
-from autopts.pybtp.defs import AUDIO_METADATA_CCID_LIST, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS
 from autopts.pybtp.types import UUID, Addr, ASCSState, BAPAnnouncement, CAPAnnouncement, WIDParams
 from autopts.wid import generic_wid_hdl
 from autopts.wid.bap import (
@@ -98,44 +106,29 @@ def hdl_wid_104(_: WIDParams):
 
 wid_114_settings = {
     # test_case_name: (source_num, metadata)
-    'CAP/INI/BST/BV-01-C': (1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/BST/BV-02-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/BST/BV-03-C': (1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/BST/BV-04-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/BST/BV-05-C': (1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                               struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/BST/BV-06-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                               struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/BST/BV-07-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                               struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01)),
-    'CAP/INI/BST/BV-08-C': (1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                               struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/BST/BV-09-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                               struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/BST/BV-10-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                               struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01)),
-    'CAP/INI/BST/BV-11-C': (1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/BST/BV-12-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/BST/BV-13-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/BST/BV-14-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                               struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/BST/BV-15-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                               struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/BST/BV-16-C': (1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/BST/BV-17-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/UTB/BV-01-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/UTB/BV-02-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0004) +
-                        struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UTB/BV-03-C': (
-        2,
-        struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)
-        + struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)
-    ),
-    'CAP/INI/UTB/BV-04-C': (2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                        struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01)),
-    'CAP/INI/BTU/BV-01-C': (1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/BTU/BV-02-C': (1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                        struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
+    "CAP/INI/BST/BV-01-C": (1, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/BST/BV-02-C": (2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/BST/BV-03-C": (1, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/BST/BV-04-C": (2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/BST/BV-05-C": (1, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/BST/BV-06-C": (2, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/BST/BV-07-C": (2, pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01])),
+    "CAP/INI/BST/BV-08-C": (1, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/BST/BV-09-C": (2, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/BST/BV-10-C": (2, pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01])),
+    "CAP/INI/BST/BV-11-C": (1, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/BST/BV-12-C": (2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/BST/BV-13-C": (2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/BST/BV-14-C": (2, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/BST/BV-15-C": (2, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/BST/BV-16-C": (1, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/BST/BV-17-C": (2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/UTB/BV-01-C": (2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/UTB/BV-02-C": (2, pack_metadata(stream_context=0x0004, ccid_list=[0x00])),
+    "CAP/INI/UTB/BV-03-C": (2, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/UTB/BV-04-C": (2, pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01])),
+    "CAP/INI/BTU/BV-01-C": (1, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/BTU/BV-02-C": (1, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
 }
 
 
@@ -208,16 +201,12 @@ def hdl_wid_202(_: WIDParams):
 
 
 wid_310_settings = {
-    'CAP/INI/UST/BV-32-C': struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200),
-    'CAP/INI/UST/BV-33-C': struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200),
-    'CAP/INI/UST/BV-34-C': struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                           struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00),
-    'CAP/INI/UST/BV-35-C': struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                           struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00),
-    'CAP/INI/UST/BV-36-C': struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                           struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01),
-    'CAP/INI/UST/BV-37-C': struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                           struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01),
+    "CAP/INI/UST/BV-32-C": pack_metadata(stream_context=0x0200),
+    "CAP/INI/UST/BV-33-C": pack_metadata(stream_context=0x0200),
+    "CAP/INI/UST/BV-34-C": pack_metadata(stream_context=0x0200, ccid_list=[0x00]),
+    "CAP/INI/UST/BV-35-C": pack_metadata(stream_context=0x0200, ccid_list=[0x00]),
+    "CAP/INI/UST/BV-36-C": pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01]),
+    "CAP/INI/UST/BV-37-C": pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01]),
 }
 
 
@@ -518,99 +507,61 @@ def hdl_wid_384(_: WIDParams):
 wid_400_settings = {
     # test_case_name: (sink_num, source_num, LT_count, metadata)
     # Two Lower Testers, unidirectional
-    'CAP/INI/UST/BV-01-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/UST/BV-02-C': (0, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/UST/BV-03-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0004) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-04-C': (0, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0004) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-05-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0002) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-06-C': (0, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0002) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-07-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-08-C': (0, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-09-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0080) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-10-C': (0, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0080) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-11-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-12-C': (0, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-13-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01)),
-    'CAP/INI/UST/BV-14-C': (0, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01)),
+    "CAP/INI/UST/BV-01-C": (1, 0, 2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/UST/BV-02-C": (0, 1, 2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/UST/BV-03-C": (1, 0, 2, pack_metadata(stream_context=0x0004, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-04-C": (0, 1, 2, pack_metadata(stream_context=0x0004, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-05-C": (1, 0, 2, pack_metadata(stream_context=0x0002, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-06-C": (0, 1, 2, pack_metadata(stream_context=0x0002, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-07-C": (1, 0, 2, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-08-C": (0, 1, 2, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-09-C": (1, 0, 2, pack_metadata(stream_context=0x0080, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-10-C": (0, 1, 2, pack_metadata(stream_context=0x0080, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-11-C": (1, 0, 2, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-12-C": (0, 1, 2, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-13-C": (1, 0, 2, pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01])),
+    "CAP/INI/UST/BV-14-C": (0, 1, 2, pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01])),
     # Single LT, unidirectional
-    'CAP/INI/UST/BV-15-C': (2, 0, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/UST/BV-16-C': (0, 2, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/UST/BV-17-C': (2, 0, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0004) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-18-C': (0, 2, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0004) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-19-C': (2, 0, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0002) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-20-C': (0, 2, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0002) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-21-C': (2, 0, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-22-C': (0, 2, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-23-C': (2, 0, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0080) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-24-C': (0, 2, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0080) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-25-C': (2, 0, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-26-C': (0, 2, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-27-C': (2, 0, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01)),
-    'CAP/INI/UST/BV-28-C': (0, 2, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01)),
+    "CAP/INI/UST/BV-15-C": (2, 0, 1, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/UST/BV-16-C": (0, 2, 1, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/UST/BV-17-C": (2, 0, 1, pack_metadata(stream_context=0x0004, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-18-C": (0, 2, 1, pack_metadata(stream_context=0x0004, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-19-C": (2, 0, 1, pack_metadata(stream_context=0x0002, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-20-C": (0, 2, 1, pack_metadata(stream_context=0x0002, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-21-C": (2, 0, 1, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-22-C": (0, 2, 1, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-23-C": (2, 0, 1, pack_metadata(stream_context=0x0080, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-24-C": (0, 2, 1, pack_metadata(stream_context=0x0080, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-25-C": (2, 0, 1, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-26-C": (0, 2, 1, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-27-C": (2, 0, 1, pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01])),
+    "CAP/INI/UST/BV-28-C": (0, 2, 1, pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01])),
     # Two LTs, one CIS bidirectional, the other CIS unidirectional
-    'CAP/INI/UST/BV-29-C': (1, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0007)),
-    'CAP/INI/UST/BV-29-C_LT2': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0007)),
-    'CAP/INI/UST/BV-30-C': (1, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0007) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-30-C_LT2': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0007) +
-                                struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-31-C': (1, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0007) +
-                            struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01)),
-    'CAP/INI/UST/BV-31-C_LT2': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0007) +
-                                struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01)),
-
+    "CAP/INI/UST/BV-29-C": (1, 1, 2, pack_metadata(stream_context=0x0007)),
+    "CAP/INI/UST/BV-29-C_LT2": (1, 0, 2, pack_metadata(stream_context=0x0007)),
+    "CAP/INI/UST/BV-30-C": (1, 1, 2, pack_metadata(stream_context=0x0007, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-30-C_LT2": (1, 0, 2, pack_metadata(stream_context=0x0007, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-31-C": (1, 1, 2, pack_metadata(stream_context=0x0007, ccid_list=[0x00, 0x01])),
+    "CAP/INI/UST/BV-31-C_LT2": (1, 0, 2, pack_metadata(stream_context=0x0007, ccid_list=[0x00, 0x01])),
     # Two LTs, unidirectional
-    'CAP/INI/UST/BV-32-C': (0, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/UST/BV-33-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/UST/BV-34-C': (0, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-35-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UST/BV-36-C': (0, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01)),
-    'CAP/INI/UST/BV-37-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01)),
-    'CAP/INI/UST/BV-40-C': (0, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/UST/BV-41-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-
-    'CAP/INI/UST/BV-42-C': (1, 1, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/UST/BV-42-C_LT2': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
+    "CAP/INI/UST/BV-32-C": (0, 1, 2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/UST/BV-33-C": (1, 0, 2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/UST/BV-34-C": (0, 1, 2, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-35-C": (1, 0, 2, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/UST/BV-36-C": (0, 1, 2, pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01])),
+    "CAP/INI/UST/BV-37-C": (1, 0, 2, pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01])),
+    "CAP/INI/UST/BV-40-C": (0, 1, 2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/UST/BV-41-C": (1, 0, 2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/UST/BV-42-C": (1, 1, 2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/UST/BV-42-C_LT2": (1, 0, 2, pack_metadata(stream_context=0x0200)),
     # Two Lower Testers, unidirectional
-    'CAP/INI/UTB/BV-01-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/UTB/BV-02-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0004) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UTB/BV-03-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
-    'CAP/INI/UTB/BV-04-C': (1, 0, 2, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBBB', 3, AUDIO_METADATA_CCID_LIST, 0x00, 0x01)),
+    "CAP/INI/UTB/BV-01-C": (1, 0, 2, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/UTB/BV-02-C": (1, 0, 2, pack_metadata(stream_context=0x0004, ccid_list=[0x00])),
+    "CAP/INI/UTB/BV-03-C": (1, 0, 2, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
+    "CAP/INI/UTB/BV-04-C": (1, 0, 2, pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01])),
     # Single LT, unidirectional
-    'CAP/INI/BTU/BV-01-C': (1, 0, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'CAP/INI/BTU/BV-02-C': (1, 0, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                            struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)),
+    "CAP/INI/BTU/BV-01-C": (1, 0, 1, pack_metadata(stream_context=0x0200)),
+    "CAP/INI/BTU/BV-02-C": (1, 0, 1, pack_metadata(stream_context=0x0200, ccid_list=[0x00])),
 }
 
 
@@ -830,8 +781,7 @@ def hdl_wid_409(_: WIDParams):
        to advertise with new BASE information"""
 
     source_id = 0x00
-    metadata = struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0004) + \
-               struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00)
+    metadata = pack_metadata(stream_context=0x0004, ccid_list=[0x00])
 
     btp.cap_broadcast_adv_stop(source_id)
 
@@ -843,11 +793,9 @@ def hdl_wid_409(_: WIDParams):
 
 
 update_settings = {
-    'CAP/INI/BST/BV-13-C': struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                           struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x00),
-    'CAP/INI/BST/BV-14-C': struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200) +
-                           struct.pack('<BBB', 2, AUDIO_METADATA_CCID_LIST, 0x01),
-    'CAP/INI/BST/BV-15-C': struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200),
+    "CAP/INI/BST/BV-13-C": pack_metadata(stream_context=0x0200, ccid_list=[0x00]),
+    "CAP/INI/BST/BV-14-C": pack_metadata(stream_context=0x0200, ccid_list=[0x01]),
+    "CAP/INI/BST/BV-15-C": pack_metadata(stream_context=0x0200),
 }
 
 
@@ -1077,6 +1025,7 @@ def hdl_wid_20106(_: WIDParams):
         Please write to Client Characteristic Configuration Descriptor
         of ASE Control Point characteristic to enable notification.
     """
+
     return True
 
 

--- a/autopts/wid/hap.py
+++ b/autopts/wid/hap.py
@@ -2,6 +2,7 @@
 # auto-pts - The Bluetooth PTS Automation Framework
 #
 # Copyright (c) 2023, Oticon.
+# Copyright (c) 2025, Nordic Semiconductor ASA.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms and conditions of the GNU General Public License,
@@ -15,14 +16,13 @@
 
 import logging
 import re
-import struct
 from argparse import Namespace
 
 from autopts.ptsprojects.stack import get_stack
 from autopts.ptsprojects.testcase import MMI
 from autopts.pybtp import btp, defs
+from autopts.pybtp.btp.audio import pack_metadata
 from autopts.pybtp.btp.btp import lt2_addr_get, lt2_addr_type_get, pts_addr_get, pts_addr_type_get
-from autopts.pybtp.defs import AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS
 from autopts.pybtp.types import (
     CODEC_CONFIG_SETTINGS,
     QOS_CONFIG_SETTINGS,
@@ -399,7 +399,7 @@ def hdl_wid_482(_: WIDParams):
     default_config = create_default_config()
     default_config.codec_set_name = '24_1'
     default_config.qos_set_name = '24_1_1'
-    default_config.metadata_ltvs = struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)
+    default_config.metadata_ltvs = pack_metadata(stream_context=0x0200)
 
     (default_config.sampling_freq,
      default_config.frame_duration,

--- a/autopts/wid/tmap.py
+++ b/autopts/wid/tmap.py
@@ -2,6 +2,7 @@
 # auto-pts - The Bluetooth PTS Automation Framework
 #
 # Copyright (c) 2024, Codecoup.
+# Copyright (c) 2025, Nordic Semiconductor ASA.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms and conditions of the GNU General Public License,
@@ -15,14 +16,13 @@
 
 import logging
 import re
-import struct
 from argparse import Namespace
 
 from autopts.ptsprojects.stack import get_stack
 from autopts.ptsprojects.testcase import MMI
 from autopts.pybtp import btp, defs
+from autopts.pybtp.btp.audio import pack_metadata
 from autopts.pybtp.btp.btp import lt2_addr_get, lt2_addr_type_get, pts_addr_get, pts_addr_type_get
-from autopts.pybtp.defs import AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS
 from autopts.pybtp.types import (
     CODEC_CONFIG_SETTINGS,
     QOS_CONFIG_SETTINGS,
@@ -413,26 +413,24 @@ def hdl_wid_503(params: WIDParams):
 wid_504_settings = {
     # test_case_name: (lt count, iut as audio source: streams + channels,
     # sink locations (0 - don't care), iut as audio sink streams, metadata)
-    'TMAP/CG/VRC/BV-01-C': (1, 1, 1, 0, 1, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/VRC/BV-05-C': (1, 2, 1, 0, 1, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/VRC/BV-06-C': (1, 1, 2, 0, 1, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/VRC/BV-07-C': (1, 1, 1, 0, 1, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/VRC/BV-08-C': (1, 2, 1, 0, 2, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/VRC/BV-11-C': (1, 2, 1, 0, 1, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/VRC/BV-12-C': (1, 2, 1, 0, 2, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/ASC/BV-01-C': (1, 1, 1, 1, 1, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/ASC/BV-02-C': (1, 1, 1, 2, 1, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/ASC/BV-03-C': (1, 1, 1, 3, 1, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-
+    "TMAP/CG/VRC/BV-01-C": (1, 1, 1, 0, 1, 1, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/VRC/BV-05-C": (1, 2, 1, 0, 1, 1, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/VRC/BV-06-C": (1, 1, 2, 0, 1, 1, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/VRC/BV-07-C": (1, 1, 1, 0, 1, 1, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/VRC/BV-08-C": (1, 2, 1, 0, 2, 1, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/VRC/BV-11-C": (1, 2, 1, 0, 1, 1, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/VRC/BV-12-C": (1, 2, 1, 0, 2, 1, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/ASC/BV-01-C": (1, 1, 1, 1, 1, 1, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/ASC/BV-02-C": (1, 1, 1, 2, 1, 1, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/ASC/BV-03-C": (1, 1, 1, 3, 1, 1, pack_metadata(stream_context=0x0200)),
     # According to TMAP.TS.p1 LT1 provides audio source and
     # LT2 provides audio sink, however, PTS 8.5.3 seem to have this the other way round
-    'TMAP/CG/VRC/BV-02-C':     (2, 1, 1, 0, 0, 0, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/VRC/BV-02-C_LT2': (2, 0, 0, 0, 1, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/VRC/BV-03-C':     (2, 1, 1, 0, 0, 0, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/VRC/BV-03-C_LT2': (2, 1, 1, 0, 1, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/VRC/BV-09-C':     (2, 1, 1, 0, 1, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-    'TMAP/CG/VRC/BV-09-C_LT2': (2, 1, 1, 0, 1, 1, struct.pack('<BBH', 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, 0x0200)),
-
+    "TMAP/CG/VRC/BV-02-C": (2, 1, 1, 0, 0, 0, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/VRC/BV-02-C_LT2": (2, 0, 0, 0, 1, 1, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/VRC/BV-03-C": (2, 1, 1, 0, 0, 0, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/VRC/BV-03-C_LT2": (2, 1, 1, 0, 1, 1, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/VRC/BV-09-C": (2, 1, 1, 0, 1, 1, pack_metadata(stream_context=0x0200)),
+    "TMAP/CG/VRC/BV-09-C_LT2": (2, 1, 1, 0, 1, 1, pack_metadata(stream_context=0x0200)),
 }
 
 
@@ -616,7 +614,7 @@ def hdl_wid_506(params: WIDParams):
     # based on cap/hdl_wid_114 using fixed configuration
 
     source_num = 1
-    metadata = struct.pack("<BBH", 3, AUDIO_METADATA_STREAMING_AUDIO_CONTEXTS, Context.CONVERSATIONAL | Context.MEDIA)
+    metadata = pack_metadata(stream_context=Context.CONVERSATIONAL | Context.MEDIA)
     qos_set_name = '48_2_1'
     coding_format = 0x06
     vid = 0x0000


### PR DESCRIPTION
Added helper function to help properly encode metadata for LE Audio. For now it only contains the used metadata, but can be easily expanded with additional types as required.