### PR TITLE
cliparser: Replace distutils.find_executable with shutil.which

### DIFF
--- a/cliparser.py
+++ b/cliparser.py
@@ -18,9 +18,9 @@
 import argparse
 import logging
 import os
+import shutil
 import sys
 import time
-from distutils.spawn import find_executable
 
 from autopts.config import CLIENT_PORT, FILE_PATHS, MAX_SERVER_RESTART_TIME, SERIAL_BAUDRATE, SERVER_PORT
 from autopts.ptsprojects.boards import com_to_tty, get_debugger_snr, get_free_device, get_tty, tty_exists
@@ -364,7 +364,7 @@ class CliParser(argparse.ArgumentParser):
         if not args.qemu_bin:
             return 'QEMU IUT mode: specify qemu_bin parameter to use this mode\n'
 
-        if not find_executable(args.qemu_bin):
+        if not shutil.which(args.qemu_bin):
             return f'QEMU IUT mode: qemu_bin={args.qemu_bin}, but not found!\n'
 
         if args.kernel_image:

--- a/tools/btpclient.py
+++ b/tools/btpclient.py
@@ -22,12 +22,12 @@ import logging
 import os
 import readline
 import shlex
+import shutil
 import socket
 import struct
 import subprocess
 import sys
 import threading
-from distutils.spawn import find_executable
 
 from autopts.ptsprojects.testcase import AbstractMethodException
 from autopts.ptsprojects.zephyr.iutctl import BTP_ADDRESS, get_qemu_cmd
@@ -256,7 +256,7 @@ class StartZephyrCmd(Cmd):
             print(f"QEMU kernel image {repr(kernel_image)} not found!")
             return
 
-        if not find_executable('xterm'):
+        if not shutil.which('xterm'):
             print("xterm is needed but not found!")
             return
 


### PR DESCRIPTION
distutils was removed in Python 3.12, causing an import error. shutil.which provides equivalent functionality and is the recommended replacemen.