### PR TITLE
errata: Add erratas for GAP/SEC/AUT tests

### DIFF
--- a/errata/common.yaml
+++ b/errata/common.yaml
@@ -6,6 +6,8 @@ BASS/SR/CP/BV-15-C: https://support.bluetooth.com/hc/en-us/requests/181225
 
 GAP/CONN/CPUP/BV-08-C: Laird PTS LE-only dongle required
 GAP/CONN/CPUP/BV-10-C: Laird PTS LE-only dongle required
+GAP/SEC/AUT/BV-13-C: Request ID 182175
+GAP/SEC/AUT/BV-14-C: Request ID 182175
 
 GATT/CL/GAS/BV-01-C: Request ID 172942
 GATT/SR/GAN/BV-01-C: ES-27410


### PR DESCRIPTION
In those tests PTS is incorrectly using legacy pairing which is no longer providing MITM protection.