### PR TITLE
boards: Zephyr: Remove hci_ipc.conf references

### DIFF
--- a/autopts/ptsprojects/boards/nrf53.py
+++ b/autopts/ptsprojects/boards/nrf53.py
@@ -45,12 +45,10 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, project_repo
 
     check_call('rm -rf build/'.split(), cwd=tester_dir)
 
-    bttester_overlay = 'hci_ipc.conf'
-
+    cmd = ["west", "build", "--sysbuild", "-b", board]
     if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
-        bttester_overlay += f';{conf_file}'
+        cmd.extend(("--", f"-DEXTRA_CONF_FILE='{conf_file}'"))
 
-    cmd = ['west', 'build', '--sysbuild', '-b', board, '--', f'-DEXTRA_CONF_FILE=\'{bttester_overlay}\'']
     check_call(env_cmd + cmd, cwd=tester_dir)
     try:
         check_call(env_cmd + ['west', 'flash', '--skip-rebuild', '-i', debugger_snr], cwd=tester_dir)

--- a/autopts/ptsprojects/boards/nrf53_appcore.py
+++ b/autopts/ptsprojects/boards/nrf53_appcore.py
@@ -45,11 +45,9 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, project_repo
 
     check_call('rm -rf build/'.split(), cwd=tester_dir)
 
-    bttester_overlay = 'hci_ipc.conf'
-
+    cmd = ["west", "build", "--no-sysbuild", "-b", board]
     if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
-        bttester_overlay += f';{conf_file}'
+        cmd.extend(("--", f"-DEXTRA_CONF_FILE='{conf_file}'"))
 
-    cmd = ['west', 'build', '--no-sysbuild', '-b', board, '--', f'-DEXTRA_CONF_FILE=\'{bttester_overlay}\'']
     check_call(env_cmd + cmd, cwd=tester_dir)
     check_call(env_cmd + ['west', 'flash', '--skip-rebuild', '--recover', '-i', debugger_snr], cwd=tester_dir)

--- a/autopts/ptsprojects/boards/nrf53_audio.py
+++ b/autopts/ptsprojects/boards/nrf53_audio.py
@@ -81,8 +81,7 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, project_repo
 
     config_dir_net = os.getenv("AUTOPTS_SOURCE_DIR_NET")
     if config_dir_net is None:
-        net_core_configs = ['EXTRA_CONF_FILE=\'nrf5340_cpunet_iso-bt_ll_sw_split.conf;'
-                            '../../../tests/bluetooth/tester/hci_ipc_cpunet.conf\'']
+        net_core_configs = ["EXTRA_CONF_FILE='nrf5340_cpunet_iso-bt_ll_sw_split.conf'"]
     else:
         conf_path = os.path.join(zephyr_wd, config_dir_net, 'hci_ipc.conf')
         net_core_configs = [f'EXTRA_CONF_FILE=\'{conf_path}\'']


### PR DESCRIPTION
The hci_ipc.conf in Zephyr is just an empty file,
and will be removed.

hci_ipc_net.conf does not exist in Zephyr an attemping to apply it would result in a build error.