### PR TITLE
errata: Zephyr: Remove errata for TBS/SR/SPE/BI-05-C

### DIFF
--- a/errata/zephyr.yaml
+++ b/errata/zephyr.yaml
@@ -23,6 +23,4 @@ OTS/SR/OTD/BI-04-C: https://github.com/zephyrproject-rtos/zephyr/issues/72951
 OTS/SR/OTD/BI-05-C: https://github.com/zephyrproject-rtos/zephyr/issues/72951
 OTS/SR/SGGIT/CHA/BV-15-C: https://github.com/zephyrproject-rtos/zephyr/issues/71754
 
-TBS/SR/SPE/BI-05-C: TSE24847
-
 BASS/SR/SPE/BI-06-C: https://support.bluetooth.com/hc/en-us/requests/180743


### PR DESCRIPTION
The erratum linked was released in 2025, and should no longer be an issue.