### PR TITLE
zephyr: Fix GATT server database

### DIFF
--- a/autopts/ptsprojects/zephyr/gatt.py
+++ b/autopts/ptsprojects/zephyr/gatt.py
@@ -212,6 +212,18 @@ def test_cases_server(ptses):
                               Perm.read | Perm.write,
                               UUID.CCC),
 
+                     TestFunc(btp.gatts_add_char, 0,
+                              Prop.read | Prop.write_wo_resp,
+                              Perm.read | Perm.write,
+                              UUID.VND16_6),
+                     TestFunc(btp.gatts_set_val, 0, Value.eight_bytes_1),
+
+                    TestFunc(btp.gatts_add_char, 0,
+                              Prop.read | Prop.write_wo_resp,
+                              Perm.read_authn | Perm.write_authn,
+                              UUID.VND16_7),
+                     TestFunc(btp.gatts_set_val, 0, Value.eight_bytes_1),
+
                       TestFunc(btp.gatts_add_char, 0,
                               Prop.read | Prop.write | Prop.ext_prop,
                               Perm.read | Perm.write,


### PR DESCRIPTION
Those characteristics were removed as part of signed write cleanups but those are also used by GATT Write Without Response tests. Restore them but without signed write property.