### PR TITLE
common: Add initial support for multiple IUTs

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -113,7 +113,7 @@ class BotConfigArgs(Namespace):
         self.hid_vid = args.get('hid_vid', None)
         self.hid_pid = args.get('hid_pid', None)
         self.hid_serial = args.get('hid_serial', None)
-        self.kernel_cpu = args.get('kernel_cpu', 'qemu_cortex_m3')
+        self.kernel_cpu = args.get('kernel_cpu', None)
         self.setcap_cmd = args.get('setcap_cmd', None)
         self.hci = args.get('hci', None)
         self.test_cases = args.get('test_cases', [])
@@ -159,10 +159,10 @@ class BotConfigArgs(Namespace):
 
 
 class BotClient(Client):
-    def __init__(self, get_iut, project, name, bot_config_class=BotConfigArgs,
+    def __init__(self, init_iutctl, project, name, bot_config_class=BotConfigArgs,
                  parser_class=BotCliParser):
         # Please extend this bot client
-        super().__init__(get_iut, project, name, parser_class)
+        super().__init__(init_iutctl, project, name, parser_class)
         # Parser of the bot configuration dictionary loaded from config.py
         self.parse_config = bot_config_class
         # The bot configuration dictionary. It will be parsed and overlayed
@@ -419,7 +419,8 @@ class BotClient(Client):
                                                      stats,
                                                      config=config,
                                                      pre_test_case_fn=self._backup_tc_stats,
-                                                     file_paths=copy.deepcopy(self.file_paths))
+                                                     file_paths=copy.deepcopy(self.file_paths),
+                                                     iutctl_instances=self.iutctl_instances)
 
             except BuildAndFlashException:
                 log(f'Build and flash step failed for config {config}')
@@ -518,7 +519,8 @@ class BotClient(Client):
             self.error_txt_content += traceback.format_exc() + "\n"
             raise
         finally:
-            release_device(self.args.tty_file)
+            for iuts_args in self.args.iuts_args:
+                release_device(iuts_args.tty_file)
             report.make_error_txt(self.error_txt_content, self.file_paths['ERROR_TXT_FILE'])
 
         if self.fail_info_parser:

--- a/autopts/bot/mynewt.py
+++ b/autopts/bot/mynewt.py
@@ -23,7 +23,7 @@ from autopts import bot
 from autopts.bot.common import BuildAndFlashException
 from autopts.client import Client
 from autopts.ptsprojects.boards import get_board_type, get_build_and_flash
-from autopts.ptsprojects.mynewt.iutctl import get_iut, log
+from autopts.ptsprojects.mynewt.iutctl import init_iutctl, log
 
 PROJECT_NAME = Path(__file__).stem
 
@@ -93,7 +93,7 @@ class MynewtBotCliParser(bot.common.BotCliParser):
 class MynewtBotClient(bot.common.BotClient):
     def __init__(self):
         project = importlib.import_module('autopts.ptsprojects.mynewt')
-        super().__init__(get_iut, project, 'mynewt', MynewtBotConfigArgs,
+        super().__init__(init_iutctl, project, 'mynewt', MynewtBotConfigArgs,
                          MynewtBotCliParser)
 
     def apply_config(self, args, config, value):
@@ -151,7 +151,7 @@ class MynewtBotClient(bot.common.BotClient):
 
 class MynewtClient(Client):
     def __init__(self):
-        super().__init__(get_iut, sys.modules['autopts.ptsprojects.zephyr'], 'mynewt')
+        super().__init__(init_iutctl, sys.modules['autopts.ptsprojects.zephyr'], 'mynewt')
 
 
 BotClient = MynewtBotClient

--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -32,9 +32,9 @@ from autopts import bot
 from autopts import client as autoptsclient
 from autopts.bot.common import BotClient, BotConfigArgs, BuildAndFlashException, check_call
 from autopts.config import FILE_PATHS
-from autopts.ptsprojects.boards import get_board_type, get_build_and_flash, tty_to_com
+from autopts.ptsprojects.boards import get_build_and_flash, tty_to_com
 from autopts.ptsprojects.zephyr import ZEPHYR_PROJECT_URL
-from autopts.ptsprojects.zephyr.iutctl import get_iut, log
+from autopts.ptsprojects.zephyr.iutctl import init_iutctl, log
 
 PROJECT_NAME = Path(__file__).stem
 
@@ -142,7 +142,7 @@ class ZephyrBotCliParser(bot.common.BotCliParser):
 class ZephyrBotClient(BotClient):
     def __init__(self):
         project = importlib.import_module('autopts.ptsprojects.zephyr')
-        super().__init__(get_iut, project, 'zephyr', ZephyrBotConfigArgs,
+        super().__init__(init_iutctl, project, 'zephyr', ZephyrBotConfigArgs,
                          ZephyrBotCliParser)
         self.config_default = "prj.conf"
         self.fail_info_parser = zephyr_get_assertion_info
@@ -171,42 +171,43 @@ class ZephyrBotClient(BotClient):
         # The order is used in the -DEXTRA_CONF_FILE="<overlay1>;<...>" option.
         overlays = ';'.join(configs)
 
-        log(f"TTY path: {args.tty_file}")
+        for iut in self.iutctl_instances:
+            log(f"TTY path: {iut.tty_file}")
 
-        if args.iut_mode != 'tty':
-            iut = self.get_iut()
-            if not iut.kernel_image:
-                iut.kernel_image = os.path.join(args.project_path, args.tester_app_dir, "build/zephyr/zephyr")
-                if args.iut_mode == 'qemu':
-                    iut.kernel_image += '.elf'
-                else:
-                    iut.kernel_image += '.exe'
+            if iut.iut_mode != 'tty':
+                if not iut.kernel_image:
+                    iut.kernel_image = os.path.join(args.project_path, args.tester_app_dir, "build/zephyr/zephyr")
+                    if iut.iut_mode == 'qemu':
+                        iut.kernel_image += '.elf'
+                    else:
+                        iut.kernel_image += '.exe'
 
-        if args.no_build:
-            if args.setcap_cmd:
-                check_call(args.setcap_cmd.split())
+            if args.no_build:
+                if args.setcap_cmd:
+                    check_call(args.setcap_cmd.split())
 
-            return
+                continue
 
-        if args.iut_mode == 'tty':
-            build_and_flash = get_build_and_flash(args.board_name)
-            board_type = get_board_type(args.board_name)
+            if iut.iut_mode == 'tty':
+                build_and_flash = get_build_and_flash(iut.board.name)
+                board_type = iut.board.type
 
-            try:
-                build_and_flash(args.project_path, args.tester_app_dir, board_type, args.debugger_snr,
-                                overlays, args.project_repos, args.build_env_cmd)
+                try:
+                    build_and_flash(args.project_path, args.tester_app_dir, board_type, iut.debugger_snr,
+                                    overlays, args.project_repos, args.build_env_cmd)
 
-                flush_serial(args.tty_file, rtscts=args.rtscts, baudrate=args.tty_baudrate)
-            except BaseException as e:
-                traceback.print_exception(e)
-                self.error_txt_content += "Build and flash step failed\n"
-                raise BuildAndFlashException from e
+                    flush_serial(iut.tty_file, rtscts=iut.rtscts, baudrate=iut.tty_baudrate)
+                except BaseException as e:
+                    traceback.print_exception(e)
+                    self.error_txt_content += "Build and flash step failed\n"
+                    raise BuildAndFlashException from e
 
-            time.sleep(10)
-        else:
-            build_image(args.project_path, args.tester_app_dir, args.kernel_cpu, overlays, args.build_env_cmd)
-            if args.setcap_cmd:
-                check_call(args.setcap_cmd.split())
+                if iut == self.iutctl_instances[-1]:
+                    time.sleep(10)
+            else:
+                build_image(args.project_path, args.tester_app_dir, iut.kernel_cpu, overlays, args.build_env_cmd)
+                if args.setcap_cmd:
+                    check_call(args.setcap_cmd.split())
 
     def start(self, args=None):
         super().start(args)
@@ -238,7 +239,7 @@ class ZephyrBotClient(BotClient):
 
 class ZephyrClient(autoptsclient.Client):
     def __init__(self):
-        super().__init__(get_iut, sys.modules['autopts.ptsprojects.zephyr'], 'zephyr')
+        super().__init__(init_iutctl, sys.modules['autopts.ptsprojects.zephyr'], 'zephyr')
 
 
 BotClient = ZephyrBotClient

--- a/autopts/ptsprojects/boards/__init__.py
+++ b/autopts/ptsprojects/boards/__init__.py
@@ -42,6 +42,7 @@ class Board:
 
         self.name = board_name
         self.iutctl = iutctl
+        self.type = get_board_type(board_name)
         self.reset_cmd = self.get_reset_cmd()
 
     def reset(self):

--- a/autopts/ptsprojects/mynewt/iutctl.py
+++ b/autopts/ptsprojects/mynewt/iutctl.py
@@ -19,7 +19,6 @@ import logging
 from autopts.ptsprojects.iutctl import IutCtl
 
 log = logging.debug
-MYNEWT = None
 
 
 class MynewtCtl(IutCtl):
@@ -30,26 +29,11 @@ class MynewtCtl(IutCtl):
         self._rtt_logger_name = 'Terminal'
 
 
-def get_iut():
-    return MYNEWT
-
-
-def init(args):
+def init_iutctl(args):
     """IUT init routine
 
     tty_file -- Path to TTY file. BTP communication with HW DUT will be done
     over this TTY.
     board -- HW DUT board to use for testing.
     """
-    global MYNEWT
-
-    MYNEWT = MynewtCtl(args)
-
-
-def cleanup():
-    """IUT cleanup routine"""
-    global MYNEWT
-
-    if MYNEWT:
-        MYNEWT.stop()
-        MYNEWT = None
+    return MynewtCtl(args)

--- a/autopts/ptsprojects/mynewt/sm_wid.py
+++ b/autopts/ptsprojects/mynewt/sm_wid.py
@@ -16,9 +16,9 @@
 import logging
 import time
 
-from autopts.ptsprojects.mynewt.iutctl import get_iut
 from autopts.ptsprojects.stack import get_stack
 from autopts.pybtp import btp
+from autopts.pybtp.btp import get_iut_method as get_iut
 from autopts.pybtp.types import WIDParams
 from autopts.wid import generic_wid_hdl
 

--- a/autopts/ptsprojects/mynewt/ztestcase.py
+++ b/autopts/ptsprojects/mynewt/ztestcase.py
@@ -15,9 +15,9 @@
 
 """Test case that manages Mynewt IUT"""
 
-from autopts.ptsprojects.mynewt.iutctl import get_iut
 from autopts.ptsprojects.stack import get_stack
 from autopts.ptsprojects.testcase import TestCaseLT1, TestCaseLT2, TestFunc, TestFuncCleanUp
+from autopts.pybtp.btp import get_iut_method as get_iut
 
 
 class ZTestCase(TestCaseLT1):
@@ -29,7 +29,7 @@ class ZTestCase(TestCaseLT1):
         super().__init__(*args, ptsproject_name="mynewt", **kwargs)
 
         self.stack = get_stack()
-        self.mynewtctl = get_iut()
+        self.mynewtctl = get_iut(iutctl_id=0)
 
         # Init stack.core to be able to receive IUT ready event
         self.cmds.insert(0, TestFunc(self.stack.core_init))

--- a/autopts/ptsprojects/stack/stack.py
+++ b/autopts/ptsprojects/stack/stack.py
@@ -50,7 +50,7 @@ from autopts.ptsprojects.stack.layers.vocs import VOCS
 from autopts.ptsprojects.stack.synch import Synch
 from autopts.pybtp import common
 
-STACK = None
+_get_stack = None
 log = logging.debug
 
 
@@ -299,18 +299,13 @@ class Stack:
         # GENERATOR append 4
 
 
-def init_stack():
-    global STACK
-
-    STACK = Stack()
-    STACK.synch_init()
-
-
-def cleanup_stack():
-    global STACK
-
-    STACK = None
+def get_stack(iutctl_id=None):
+    # TODO: Refactor wid handlers so that the stack
+    # is taken from the iutctl instance
+    return _get_stack(iutctl_id)
 
 
-def get_stack():
-    return STACK
+def set_get_stack_method(get_stack_method):
+    global _get_stack
+
+    _get_stack = get_stack_method

--- a/autopts/ptsprojects/zephyr/iutctl.py
+++ b/autopts/ptsprojects/zephyr/iutctl.py
@@ -21,7 +21,6 @@ from autopts.config import AUTOPTS_ROOT_DIR
 from autopts.ptsprojects.iutctl import IutCtl
 
 log = logging.debug
-ZEPHYR = None
 
 CLI_SUPPORT = ['tty', 'hci', 'qemu']
 
@@ -43,23 +42,9 @@ class ZephyrCtl(IutCtl):
             os.remove(flash_bin)
 
 
-def get_iut():
-    return ZEPHYR
-
-
-def init(args):
+def init_iutctl(args):
     """IUT init routine
 
     args -- Argument
     """
-    global ZEPHYR
-
-    ZEPHYR = ZephyrCtl(args)
-
-
-def cleanup():
-    """IUT cleanup routine"""
-    global ZEPHYR
-    if ZEPHYR:
-        ZEPHYR.stop()
-        ZEPHYR = None
+    return ZephyrCtl(args)

--- a/autopts/ptsprojects/zephyr/sm_wid.py
+++ b/autopts/ptsprojects/zephyr/sm_wid.py
@@ -16,8 +16,8 @@
 import logging
 
 from autopts.ptsprojects.stack import get_stack
-from autopts.ptsprojects.zephyr.iutctl import get_iut
 from autopts.pybtp import btp
+from autopts.pybtp.btp import get_iut
 from autopts.wid import generic_wid_hdl
 
 log = logging.debug

--- a/autopts/wid/csip.py
+++ b/autopts/wid/csip.py
@@ -148,6 +148,19 @@ def hdl_wid_14(params: WIDParams):
     return True
 
 
+def hdl_wid_23(params: WIDParams):
+    """Please make sure there are two IUTs for this test
+       case. IUT1 and IUT2 are two instances of the same
+       implementation.
+    """
+    return True
+
+
+def hdl_wid_24(params: WIDParams):
+    """Please command IUT1 and IUT2 to update the targeted characteristic Coordinated Set Size"""
+    raise NotImplementedError()
+
+
 def hdl_wid_20001(_: WIDParams):
     """
     Please prepare IUT into a connectable mode.

--- a/autoptsclient-mynewt.py
+++ b/autoptsclient-mynewt.py
@@ -19,13 +19,13 @@
 import importlib
 
 from autopts import client as autoptsclient
-from autopts.ptsprojects.mynewt.iutctl import get_iut
+from autopts.ptsprojects.mynewt.iutctl import init_iutctl
 
 
 class MynewtClient(autoptsclient.Client):
     def __init__(self):
         project = importlib.import_module('autopts.ptsprojects.mynewt')
-        super().__init__(get_iut, project, 'mynewt')
+        super().__init__(init_iutctl, project, 'mynewt')
 
 
 def main():

--- a/autoptsclient-zephyr.py
+++ b/autoptsclient-zephyr.py
@@ -23,13 +23,13 @@
 import importlib
 
 from autopts import client as autoptsclient
-from autopts.ptsprojects.zephyr.iutctl import get_iut
+from autopts.ptsprojects.zephyr.iutctl import init_iutctl
 
 
 class ZephyrClient(autoptsclient.Client):
     def __init__(self):
         project = importlib.import_module('autopts.ptsprojects.zephyr')
-        super().__init__(get_iut, project, 'zephyr')
+        super().__init__(init_iutctl, project, 'zephyr')
 
 
 def main():

--- a/cliparser.py
+++ b/cliparser.py
@@ -21,7 +21,9 @@ import os
 import shutil
 import sys
 import time
+from itertools import zip_longest
 from pathlib import Path
+from types import SimpleNamespace
 
 from autopts.config import CLIENT_PORT, FILE_PATHS, MAX_SERVER_RESTART_TIME, SERIAL_BAUDRATE, SERVER_PORT
 from autopts.ptsprojects.boards import com_to_tty, get_debugger_snr, get_free_device, get_tty, tty_exists
@@ -39,10 +41,13 @@ class CliParser(argparse.ArgumentParser):
         if iut_modes is None:
             iut_modes = IUT_MODES
 
-        self.add_argument("--iut-mode", "--iut_mode", type=str, choices=iut_modes, default=None,
-                          help="Specify the mode of the IUT (Identity Under Test). "
-                               "If the option is not provided, mode will be inferred "
-                               "from the parameters.")
+        act = self.add_argument("--iut-mode", "--iut_mode", type=str, nargs='+',
+                                action="extend", choices=iut_modes, default=[],
+                                help="Specify the mode of the IUT (Identity Under Test). "
+                                "If the option is not provided, mode will be inferred "
+                                "from the parameters.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
 
         self.add_argument("-i", "--ip_addr", nargs="+",
                           help="IP address of the PTS automation servers. "
@@ -110,8 +115,11 @@ class CliParser(argparse.ArgumentParser):
                           "specify the ports separated by a space, "
                           "e.g. \"-C 65001 65003 65005\"")
 
-        self.add_argument("--tty-baudrate", "--tty_baudrate", type=int, default=SERIAL_BAUDRATE,
-                          help="The TTY baudrate.")
+        act = self.add_argument("--tty-baudrate", "--tty_baudrate", type=int,
+                                nargs='+', action="extend", default=[SERIAL_BAUDRATE],
+                                help="The TTY baudrate.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
 
         self.add_argument("--recovery", action='store_true', default=False,
                           help="Specify if autoptsclient should try to recover"
@@ -126,19 +134,26 @@ class CliParser(argparse.ArgumentParser):
                           help="Specify amount of time in minutes, after which"
                                " super guard will blindly trigger recovery steps.")
 
-        self.add_argument("--ykush", metavar='YKUSH_PORT',
-                          help="Specify ykush downstream port number, so on BTP TIMEOUT "
-                               "the iut device could be powered off and on.")
+        act = self.add_argument("--ykush", metavar='YKUSH_PORT', type=str,
+                                nargs="+", action="extend", default=[],
+                                help="Specify ykush downstream port number, so on BTP TIMEOUT "
+                                "the iut device could be powered off and on.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
 
-        self.add_argument("--pylink_reset", action='store_true', default=False,
-                          help="Use pylink reset.")
+        act = self.add_argument("--pylink_reset", action='store_true', default=False,
+                                help="Use pylink reset.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
 
         self.add_argument('--nc', dest='copy', action='store_false',
                           help='Do not copy workspace, open original one. '
                                'Warning: workspace file might be modified', default=True)
 
-        self.add_argument("--rtscts", dest='rtscts', action="store_true", default=False,
-                          help="Enable UART hardware flow control.")
+        act = self.add_argument("--rtscts", dest='rtscts', action="store_true", default=False,
+                                help="Enable UART hardware flow control.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
 
         # Hidden option to save test cases data in TestCase.db
         self.add_argument("-s", "--store", action="store_true",
@@ -153,15 +168,28 @@ class CliParser(argparse.ArgumentParser):
         self.add_argument("--max_server_restart_time", type=int, default=MAX_SERVER_RESTART_TIME,
                           help=argparse.SUPPRESS)
 
-        self.add_argument("--tty_alias", type=str, default='', help=argparse.SUPPRESS)
+        act = self.add_argument("--tty_alias", type=str, nargs='+', action="extend",
+                                default=[], help=argparse.SUPPRESS)
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
 
-        self.add_argument("--ykush_replug_delay", type=float, default=3, help=argparse.SUPPRESS)
+        act = self.add_argument("--ykush_replug_delay", type=float, nargs='+', action="extend",
+                                default=[3], help=argparse.SUPPRESS)
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
 
-        self.add_argument("--active-hub-server", type=str, help=argparse.SUPPRESS)
-        self.add_argument("--usb-replug-available", "--usb_replug_available", type=bool,
-                          default=False, help=argparse.SUPPRESS)
+        act = self.add_argument("--active-hub-server", type=str, help=argparse.SUPPRESS)
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
 
-        self.add_argument("--project_path", type=str, help=argparse.SUPPRESS)
+        act = self.add_argument("--usb-replug-available", "--usb_replug_available", type=bool,
+                                default=False, help=argparse.SUPPRESS)
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
+
+        act = self.add_argument("--project_path", type=str, help=argparse.SUPPRESS)
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
 
         # Path to tester application relative to project_path. Used for build and flash in bot mode. Only supported by
         # Zephyr project.
@@ -171,93 +199,164 @@ class CliParser(argparse.ArgumentParser):
         self.add_argument('--nb', dest='no_build', action='store_true',
                           help='Skip build and flash in bot mode.', default=False)
 
-        self.add_argument("--btattach-bin", "--btattach_bin", default=None,
+        act = self.add_argument("--btattach-bin", "--btattach_bin", default=None,
                           help="The path to the btattach executable, e.g. /usr/bin/btattach")
-        self.add_argument("--btattach-at-every-test-case", "--btattach_at_every_test_case",
-                          action='store_true', default=False,
-                          help="The path to the btattach executable, e.g. /usr/bin/btattach")
-        self.add_argument("--btproxy-bin", "--btproxy_bin", default=None,
-                          help="The path to the btproxy executable, e.g. /usr/bin/btproxy")
-        self.add_argument("--qemu-bin", "--qemu_bin", default=None,
-                          help="The path to the QEMU executable, e.g. /usr/bin/qemu-system-arm")
-        self.add_argument("--qemu-options", "--qemu_options", type=str, default="",
-                          help="Additional options for the qemu, e.g. -cpu cortex-m3 -machine lm3s6965evb")
-        self.add_argument("--kernel-cpu", "--kernel_cpu", default="qemu_cortex_m3",
-                          help="The type of CPU that will be used for building an image, e.g. qemu_cortex_m3")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
 
-        self.add_argument("--hci", type=int, default=None,
-                          help="Specify the number of the HCI controller")
-        self.add_argument("--hid-vid", "--hid_vid", type=str, default=None,
-                          help="Specify the VID of the USB device used as a HCI controller "
-                          "(hexadecimal string, e.g. '2fe3')")
-        self.add_argument("--hid-pid", "--hid_pid", type=str, default=None,
-                          help="Specify the PID of the USB device used as a HCI controller "
-                          "(hexadecimal string, e.g. '000b')")
-        self.add_argument("--hid-serial", "--hid_serial", type=str, default=None,
-                          help="Specify the serial number of the USB device used as a HCI controller")
-        self.add_argument("--btmgmt-bin", "--btmgmt_bin", type=str, default=None,
-                          help="The path to the btmgmt executable, e.g. /usr/bin/btmgmt")
+        act = self.add_argument("--btattach-at-every-test-case", "--btattach_at_every_test_case",
+                                action='store_true', default=False,
+                                help="The path to the btattach executable, e.g. /usr/bin/btattach")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
+
+        act = self.add_argument("--btproxy-bin", "--btproxy_bin", default=None,
+                                help="The path to the btproxy executable, e.g. /usr/bin/btproxy")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
+
+        act = self.add_argument("--qemu-bin", "--qemu_bin", default=None,
+                                help="The path to the QEMU executable, e.g. /usr/bin/qemu-system-arm")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
+
+        act = self.add_argument("--qemu-options", "--qemu_options", type=str,
+                                nargs='+', action="extend", default=[""],
+                                help="Additional options for the qemu, e.g. -cpu cortex-m3 -machine lm3s6965evb")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
+
+        act = self.add_argument("--kernel-cpu", "--kernel_cpu", type=str, nargs="+", default=[],
+                                help="The type of CPU that will be used for building an image, e.g. qemu_cortex_m3")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
+
+        act = self.add_argument("--hci", type=int, default=None,
+                                help="Specify the number of the HCI controller")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
+
+        act = self.add_argument("--hid-vid", "--hid_vid", type=str, default=None,
+                                help="Specify the VID of the USB device used as a HCI controller "
+                                "(hexadecimal string, e.g. '2fe3')")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
+
+        act = self.add_argument("--hid-pid", "--hid_pid", type=str, default=None,
+                                help="Specify the PID of the USB device used as a HCI controller "
+                                "(hexadecimal string, e.g. '000b')")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
+
+        act = self.add_argument("--hid-serial", "--hid_serial", type=str, default=None,
+                                help="Specify the serial number of the USB device used as a HCI controller")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
+
+        act = self.add_argument("--btmgmt-bin", "--btmgmt_bin", type=str, default=None,
+                                help="The path to the btmgmt executable, e.g. /usr/bin/btmgmt")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
+
         self.add_argument("--setcap-cmd", "--setcap_cmd", type=str, default=None,
                           help="Command to set HCI access permissions for zephyr.exe in native mode, "
                           "e.g. sudo /usr/sbin/setcap cap_net_raw,cap_net_admin,cap_sys_admin+ep /path/to/zephyr.exe "
                           "To allow sudo setcap without password, add to visudo a line like this: "
                           "youruser ALL=(ALL) NOPASSWD: /usr/sbin/setcap")
 
-        self.add_argument("-t", "--tty-file",
-                          help="If TTY(or COM) is specified, BTP communication "
-                               "with OS running on hardware will be done over "
-                               "this TTY. Hence, QEMU will not be used.")
+        act = self.add_argument("-t", "--tty-file", type=str, nargs='+', action="extend", default=[],
+                                help="If TTY(or COM) is specified, BTP communication "
+                                "with OS running on hardware will be done over "
+                                "this TTY. Hence, QEMU will not be used.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
 
-        self.add_argument("--net-tty-file", dest='net_tty_file', type=str, default=None,
-                          help="This can be used to log output from network core of IUT "
-                               "(if additional port is available). Value should match "
-                               "the COM/tty file port that outputs log from the network core. "
-                               "There's no indication which COM port maps to the network "
-                               "core.")
+        act = self.add_argument("--net-tty-file", dest='net_tty_file', type=str,
+                                nargs='+', action="extend", default=[],
+                                help="This can be used to log output from network core of IUT "
+                                "(if additional port is available). Value should match "
+                                "the COM/tty file port that outputs log from the network core. "
+                                "There's no indication which COM port maps to the network "
+                                "core.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
 
-        self.add_argument("-j", "--jlink", dest="debugger_snr", type=str, default=None,
-                          help="Specify jlink serial number manually.")
+        act = self.add_argument("-j", "--jlink", dest="debugger_snr", type=str,
+                                nargs='+', action="extend", default=[],
+                                help="Specify jlink serial number manually.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
 
-        self.add_argument("-b", "--board", dest='board_name', type=str, choices=board_names,
-                          help="Used DUT board. This option is used to "
-                               "select DUT reset command that is run before "
-                               "each test case. If board is not specified DUT "
-                               "will not be reset.")
+        act = self.add_argument("-b", "--board", dest='board_name', type=str,
+                                nargs='+', action="extend", default=[], choices=board_names,
+                                help="Used DUT board. This option is used to "
+                                "select DUT reset command that is run before "
+                                "each test case. If board is not specified DUT "
+                                "will not be reset.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
 
-        self.add_argument("--btmon", action='store_true', default=False,
-                          help="Capture iut btsnoop logs from device over RTT and catch them with btmon. Requires rtt "
-                               "support on IUT. When using with native linux build CAP_NET_RAW,CAP_NET_ADMIN and "
-                               "CAP_SYS_ADMIN permissions are required. "
-                               "e.g. sudo setcap cap_net_raw,cap_net_admin,cap_sys_admin+ep /usr/bin/btmon ")
+        act = self.add_argument("--btmon", action='store_true', default=False,
+                                help="Capture iut btsnoop logs from device over RTT and catch them with btmon. Requires rtt "
+                                "support on IUT. When using with native linux build CAP_NET_RAW,CAP_NET_ADMIN and "
+                                "CAP_SYS_ADMIN permissions are required. "
+                                "e.g. sudo setcap cap_net_raw,cap_net_admin,cap_sys_admin+ep /usr/bin/btmon ")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
 
-        self.add_argument("--device_core", default='NRF52840_XXAA',
-                          help="Specify the device core for JLink related features, "
-                               "e.g. BTMON or RTT logging.")
+        act = self.add_argument("--device_core", type=str, nargs='+', action="extend",
+                                default=['NRF52840_XXAA'],
+                                help="Specify the device core for JLink related features, "
+                                "e.g. BTMON or RTT logging.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
 
-        self.add_argument("--rtt-log",
-                          help="Capture iut logs from device over RTT. "
-                          "Requires rtt support on IUT.",
-                          action='store_true', default=False)
+        act = self.add_argument("--rtt-log",
+                                help="Capture iut logs from device over RTT. "
+                                "Requires rtt support on IUT.",
+                                action='store_true', default=False)
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
 
-        self.add_argument("--rtt-log-syncto",
-                          help="Specify the number of seconds that the RTT logging"
-                          "should continue after the test has finished executing.",
-                          type=float, default=0)
+        act = self.add_argument("--rtt-log-syncto",
+                                help="Specify the number of seconds that the RTT logging"
+                                "should continue after the test has finished executing.",
+                                type=float, default=0)
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
 
-        self.add_argument("--gdb",
+        act = self.add_argument("--gdb",
                           help="Skip board resets to avoid gdb server disconnection.",
                           action='store_true', default=False)
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = True
 
-        self.add_argument("--btp-tcp-ip", "--btp_tcp_ip", type=str, default='127.0.0.1',
-                          help="IP for external btp client over TCP/IP.")
-        self.add_argument("--btp-tcp-port", "--btp_tcp_port", type=int, default=None,
-                          help="Port for external btp client over TCP/IP.")
+        act = self.add_argument("--btp-tcp-ip", "--btp_tcp_ip", type=str, nargs='+',
+                                action="extend", default=['127.0.0.1'],
+                                help="IP for external btp client over TCP/IP.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
 
-        self.add_argument("--btpclient_path", type=str, default=None,
-                          help="Path to btpclient.")
+        act = self.add_argument("--btp-tcp-port", "--btp_tcp_port", type=int, nargs='+',
+                                action="extend", default=[],
+                                help="Port for external btp client over TCP/IP.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
+
+        act = self.add_argument("--btpclient-path", "--btpclient_path", type=str, nargs='+',
+                                action="extend", default=[], help="Path to btpclient.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
 
         self.add_argument("--wid_run", nargs=2, metavar=("SERVICE", "WID"),
                           help="Run testcases based on service and wid")
+
+        act = self.add_argument("--kernel-image", "--kernel_image", type=str, nargs='+',
+                                action="extend", default=[],
+                                help="OS kernel image to be used for testing,"
+                                "e.g. elf file for qemu, exe for native.")
+        act.copy_to_iutctl_args = True
+        act.use_first_as_default = False
 
         self.add_positional_args()
 
@@ -271,6 +370,48 @@ class CliParser(argparse.ArgumentParser):
         self.add_argument("kernel_image", nargs='?', default=None,
                           help="OS kernel image to be used for testing,"
                           "e.g. elf file for qemu, exe for native.")
+
+    def normalize_to_list(self, x):
+        if x is None:
+            return []
+        if isinstance(x, list):
+            return x
+        return [x]
+
+    def remodel_args(self, args):
+        """Group the args parameters for each IUT."""
+
+        # Filter out options/parameters that can be configured
+        # separately for each IUT.
+        iutctl_fields_actions = [
+            a for a in self._actions
+            if getattr(a, "copy_to_iutctl_args", False)
+        ]
+
+        lists = {
+            a.dest: self.normalize_to_list(getattr(args, a.dest))
+            for a in iutctl_fields_actions
+        }
+
+        iuts = []
+
+        for values in zip_longest(*lists.values(), fillvalue=None):
+            data = dict(zip(lists.keys(), values))
+            dev = SimpleNamespace(**data)
+
+            if iuts:
+                first = iuts[0]
+                # Some options/parameters can be common for all IUTs,
+                # so let's allow those to be provided only once.
+                for a in iutctl_fields_actions:
+                    if getattr(a, "use_first_as_default", False):
+                        name = a.dest
+                        if getattr(dev, name) is None:
+                            setattr(dev, name, getattr(first, name))
+
+            iuts.append(dev)
+
+        args.iuts_args = iuts
 
     def _replug_and_find_tty(self, args):
         log(f'{self._replug_and_find_tty.__name__}')
@@ -443,6 +584,8 @@ class CliParser(argparse.ArgumentParser):
         """
         args = self.parse_args(None, arg_ns)
 
+        self.remodel_args(args)
+
         from autopts.client import init_logging
         init_logging('_' + '_'.join(str(x) for x in args.cli_port),
                      FILE_PATHS.get('BOT_LOG_FILE', None))
@@ -453,11 +596,6 @@ class CliParser(argparse.ArgumentParser):
         if args.btattach_bin and not is_executable(args.btattach_bin):
             return args, f'The btattach_bin={args.btattach_bin} is not an executable file'
 
-        if args.ykush or args.active_hub_server:
-            args.usb_replug_available = True
-        else:
-            args.usb_replug_available = False
-
         args.superguard = 60 * args.superguard
 
         if not args.ip_addr:
@@ -466,13 +604,19 @@ class CliParser(argparse.ArgumentParser):
         if not args.local_addr:
             args.local_addr = ['127.0.0.1'] * len(args.cli_port)
 
-        args.iut_mode = self.get_iut_mode(args)
-        if sys.platform == "win32" and args.iut_mode in ['qemu', 'native']:
-            errmsg = f'The {args.iut_mode} mode is not supported under Windows!'
-            return args, errmsg
+        for iut in args.iuts_args:
+            if iut.ykush or iut.active_hub_server:
+                iut.usb_replug_available = True
+            else:
+                iut.usb_replug_available = False
 
-        check_method = getattr(self, f'check_args_{args.iut_mode}')
-        errmsg = check_method(args)
+            iut.iut_mode = self.get_iut_mode(iut)
+            if sys.platform == "win32" and iut.iut_mode in ['qemu', 'native']:
+                errmsg = f'The {iut.iut_mode} mode is not supported under Windows!'
+                return args, errmsg
+
+            check_method = getattr(self, f'check_args_{iut.iut_mode}')
+            errmsg = check_method(iut)
 
         if args.wid_run:
             self.wid_run_tcs(args)

--- a/test/mocks/external_bot.py
+++ b/test/mocks/external_bot.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from autopts import bot
 from autopts import client as autoptsclient
 from autopts.bot.common import BotClient, BotConfigArgs
-from autopts.ptsprojects.zephyr.iutctl import get_iut
+from autopts.ptsprojects.zephyr.iutctl import init_iutctl
 
 PROJECT_NAME = Path(__file__).stem
 
@@ -40,7 +40,7 @@ class ExternalBotCliParser(bot.common.BotCliParser):
 class ExternalBotClient(BotClient):
     def __init__(self):
         project = importlib.import_module('autopts.ptsprojects.zephyr')
-        super().__init__(get_iut, project, 'zephyr', ExternalBotConfigArgs,
+        super().__init__(init_iutctl, project, 'zephyr', ExternalBotConfigArgs,
                          ExternalBotCliParser)
         self.config_default = "prj.conf"
 
@@ -54,7 +54,7 @@ class ExternalBotClient(BotClient):
 
 class ExternalClient(autoptsclient.Client):
     def __init__(self):
-        super().__init__(get_iut, 'zephyr', True)
+        super().__init__(init_iutctl, 'zephyr', True)
 
 
 BotClient = ExternalBotClient


### PR DESCRIPTION
CliParser parameters such as --tty-file or --hci can now accept multiple values, allowing AutoPTS to work with multiple IUTs. For now, all IUTs must operate in the same mode, but this limitation can be easily lifted in the future.

To enable test cases that require multiple IUTs, define them as custom test cases of a project and specify the number of IUTs to be used, for example:

ZTestCase(
    "CSIP", "CSIP/SR/SP/BV-06-C",
    cmds=pre_conditions + pre_conditions_iut2,
    generic_wid_hdl=csip_wid_hdl,
    iut_count=2
)

Use set_current_iutctl_id(iutctl_id=1) to switch the active IUT context. See the example at autopts/ptsprojects/zephyr/csip.py.

Design notes and challenges:
The get_iut() and get_stack() functions are widely used across WID handlers and BTP event handlers. Ideally, these functions should accept an explicit IUT ID, but introducing this would require a major refactor to propagate the ID through the entire call chain.

Since PTS currently defines only a small number of multi-IUT test cases, and to avoid a large refactor, an interim experimental solution based on ContextVar is used.

With this approach, get_iut() and get_stack() return different references depending on the value previously set in the current execution context via set_current_iutctl_id(iutctl_id=iut_id). As a result, threads such as MainThread, LTThread-*, and BTPWorkers must manage their active IUT context so that get_iut() and get_stack() resolve to the correct instance within their call stacks.

Another difficulty is that, at least for now, some WID messages do not specify the IUT ID for which the handler should be executed. For test cases marked as multi-IUT, we therefore assume that subsequent occurrences of the same WID are to be handled for subsequent IUTs.