### PR TITLE
Zephyr: iut_config: Add br_l2cap_ext_feat.conf

### DIFF
--- a/autopts/bot/iut_config/zephyr.py
+++ b/autopts/bot/iut_config/zephyr.py
@@ -437,6 +437,18 @@ iut_config = {
             'GAP/PADV/PASE/BV-12-C',
         ]
     },
+
+    "br_l2cap_ext_feat.conf": {
+        "pre_overlay": "prj_br.conf",
+        "overlay": {
+            'CONFIG_BT_L2CAP_CONNLESS': 'y',
+        },
+        "test_cases": [
+            'L2CAP/EXF/BV-07-C',
+            'L2CAP/EXF/BV-08-C',
+            'L2CAP/FIX/BV-03-C',
+        ]
+    },
 }
 
 retry_config = {


### PR DESCRIPTION
Add new configuration for L2CAP extended features testing with BR/EDR support. This configuration enables connectionless L2CAP channels and is specifically used for the L2CAP/EXF/BV-07-C test case.

The configuration:
- Uses prj_br.conf as the base overlay
- Enables CONFIG_BT_L2CAP_CONNLESS for connectionless L2CAP support
