### PR TITLE
L2CAP: Improve WID 265 handler for L2CAP/CLS/CID/BV-01-C test case

### DIFF
--- a/autopts/wid/l2cap.py
+++ b/autopts/wid/l2cap.py
@@ -1164,9 +1164,14 @@ def hdl_wid_33(_: WIDParams):
     return True
 
 
-def hdl_wid_265(_: WIDParams):
+def hdl_wid_265(params: WIDParams):
     '''
     Please confirm the Upper Tester did receive no data.
     Click Yes if Upper Tester received no data, otherwise click No.
     '''
+    if params.test_case_name in ['L2CAP/CLS/CID/BV-01-C']:
+        l2cap = get_stack().l2cap
+        channel_ids = [channel.id for channel in l2cap.channels]
+        for cid in channel_ids:
+            _safe_l2cap_disconnect(cid)
     return True


### PR DESCRIPTION
Update hdl_wid_265 to properly handle L2CAP/CLS/CID/BV-01-C test case by disconnecting all L2CAP channels when confirming no data was received.

Changes:
- Accept WIDParams parameter instead of ignoring it
- Add test case specific handling for L2CAP/CLS/CID/BV-01-C
- Disconnect all active L2CAP channels using _safe_l2cap_disconnect

The channel disconnection is required by the test case. And with the fix, it can reduce the execution time consumption of the test case.