### PR TITLE
Bluez: Add support for external audio server

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include autopts/ptsprojects/bluez/wireplumber *.conf

--- a/autopts/ptsprojects/bluez/README.md
+++ b/autopts/ptsprojects/bluez/README.md
@@ -92,7 +92,47 @@ optional arguments:
 ./autoptsclient-bluez.py "C:\Users\tester\Documents\Profile Tuning Suite\bluez\bluez.pqw6" --btpclient_path=/home/han1/work/bluez/tools/btpclient -i 192.168.0.18 -l 192.168.0.15 -c GAP
 ```
 
+### Using PipeWire for audio
+
+By default the tests run with BlueZ in standalone mode. For audio-related profiles you can route audio through PipeWire instead.
+To do this, configure your system WirePlumber (the PipeWire session manager) instance with Bluetooth audio disabled so it does
+not claim Bluetooth devices, and start the Auto-PTS client with `--external-audio=wireplumber`:
+
+```bash
+./autoptsclient-bluez.py "C:\Users\tester\Documents\Profile Tuning Suite\bluez\bluez.pqw6" --btpclient_path=/home/han1/work/bluez/tools/btpclient -i 192.168.0.18 -l 192.168.0.15 --external-audio=wireplumber -c BAP
+```
+
+For each test case, the test harness will automatically start and stop a secondary WirePlumber instance using specific
+configurations. This test-managed WirePlumber instance is separate from your system-wide PipeWire session and handles Bluetooth
+audio for the duration of that individual test case.
+
+Note:
+
+- During development phase, Auto-PTS or PipeWire developers can run tests with a locally built (uninstalled) PipeWire by starting
+  the build-provided shell in the PipeWire source directory and running the Auto-PTS client from that shell:
+
+  ```bash
+  cd /path/to/pipewire
+  make shell
+  # inside the make-provided shell, run the client as before
+  cd /path/to/auto-pts
+  ./autoptsclient-bluez.py "C:\Users\tester\Documents\Profile Tuning Suite\bluez\bluez.pqw6" --btpclient_path=/home/han1/work/bluez/tools/btpclient -i 192.168.0.18 -l 192.168.0.15 --external-audio=wireplumber -c BAP
+  ```
+
+#### Sample WirePlumber Bluetooth disabling configuration
+For a system install place the file under `~/.config/wireplumber/wireplumber.conf.d/disable-bluetooth.conf`.
+During PipeWire development place it in the PipeWire source tree at `</path/to/pipewire>/subprojects/wireplumber/src/config/wireplumber.conf.d/disable-bluetooth.conf`.
+
+The file contents should be:
+```conf
+wireplumber.profiles = {
+  main = {
+    hardware.bluetooth = disabled
+  }
+}
+```
+
 ### Logs
 
-AutoPTS Clinet log can be found under `logs` folder.
-`btpclient` log is generated to `iut_bluez.log`
+AutoPTS Client log can be found under `logs` folder.
+`btpclient` log is generated to `iut-bluez.log`, PipeWire/WirePlumber log is generated to `iut-bluez-audio.log`.

--- a/autopts/ptsprojects/bluez/bap.py
+++ b/autopts/ptsprojects/bluez/bap.py
@@ -19,8 +19,9 @@
 from autopts.client import get_unique_name
 from autopts.ptsprojects.bluez.bap_wid import bap_wid_hdl
 from autopts.ptsprojects.bluez.btestcase import BTestCase
+from autopts.ptsprojects.bluez.iutctl import get_iut
 from autopts.ptsprojects.stack import get_stack
-from autopts.ptsprojects.testcase import TestFunc
+from autopts.ptsprojects.testcase import TestFunc, TestFuncCleanUp
 from autopts.pybtp import btp
 from autopts.pybtp.types import Addr, IOCap
 from autopts.utils import ResultWithFlag
@@ -91,10 +92,15 @@ def test_cases(ptses):
 
     stack.gap_init()
 
+    iut = get_iut()
     iut_addr = ResultWithFlag()
 
     def set_addr(addr):
         iut_addr.set(addr)
+
+    def _stop_audio():
+        iut.set_audio_profile(None)
+        iut.stop_audio()
 
     pre_conditions = [
         TestFunc(btp.core_reg_svc_gap),
@@ -115,6 +121,8 @@ def test_cases(ptses):
         TestFunc(lambda: stack.bap.set_broadcast_code(BROADCAST_CODE)),
         TestFunc(lambda: set_addr(
             stack.gap.iut_addr_get_str())),
+        TestFunc(iut.start_audio),
+        TestFuncCleanUp(_stop_audio),
         ]
 
     custom_test_cases = [

--- a/autopts/ptsprojects/bluez/bap.py
+++ b/autopts/ptsprojects/bluez/bap.py
@@ -126,6 +126,50 @@ def test_cases(ptses):
         ]
 
     custom_test_cases = [
+        BTestCase("BAP", "BAP/UCL/SCC/BV-038-C",
+                  cmds=[TestFunc(lambda: iut.set_audio_profile("low-latency"))] +
+                        pre_conditions,
+                  generic_wid_hdl=bap_wid_hdl),
+        BTestCase("BAP", "BAP/UCL/SCC/BV-042-C",
+                  cmds=[TestFunc(lambda: iut.set_audio_profile("low-latency"))] +
+                        pre_conditions,
+                  generic_wid_hdl=bap_wid_hdl),
+        BTestCase("BAP", "BAP/UCL/SCC/BV-046-C",
+                  cmds=[TestFunc(lambda: iut.set_audio_profile("low-latency"))] +
+                        pre_conditions,
+                  generic_wid_hdl=bap_wid_hdl),
+        BTestCase("BAP", "BAP/UCL/SCC/BV-048-C",
+                  cmds=[TestFunc(lambda: iut.set_audio_profile("low-latency"))] +
+                        pre_conditions,
+                  generic_wid_hdl=bap_wid_hdl),
+        BTestCase("BAP", "BAP/UCL/SCC/BV-054-C",
+                  cmds=[TestFunc(lambda: iut.set_audio_profile("low-latency"))] +
+                        pre_conditions,
+                  generic_wid_hdl=bap_wid_hdl),
+        BTestCase("BAP", "BAP/UCL/SCC/BV-058-C",
+                  cmds=[TestFunc(lambda: iut.set_audio_profile("low-latency"))] +
+                        pre_conditions,
+                  generic_wid_hdl=bap_wid_hdl),
+        BTestCase("BAP", "BAP/UCL/SCC/BV-077-C",
+                  cmds=[TestFunc(lambda: iut.set_audio_profile("high-reliability"))] +
+                        pre_conditions,
+                  generic_wid_hdl=bap_wid_hdl),
+        BTestCase("BAP", "BAP/UCL/SCC/BV-078-C",
+                  cmds=[TestFunc(lambda: iut.set_audio_profile("high-reliability"))] +
+                        pre_conditions,
+                  generic_wid_hdl=bap_wid_hdl),
+        BTestCase("BAP", "BAP/UCL/SCC/BV-080-C",
+                  cmds=[TestFunc(lambda: iut.set_audio_profile("high-reliability"))] +
+                        pre_conditions,
+                  generic_wid_hdl=bap_wid_hdl),
+        BTestCase("BAP", "BAP/UCL/SCC/BV-093-C",
+                  cmds=[TestFunc(lambda: iut.set_audio_profile("high-reliability"))] +
+                        pre_conditions,
+                  generic_wid_hdl=bap_wid_hdl),
+        BTestCase("BAP", "BAP/UCL/SCC/BV-094-C",
+                  cmds=[TestFunc(lambda: iut.set_audio_profile("high-reliability"))] +
+                        pre_conditions,
+                  generic_wid_hdl=bap_wid_hdl),
         ]
 
     test_case_name_list = pts.get_test_case_list('BAP')

--- a/autopts/ptsprojects/bluez/bap_wid.py
+++ b/autopts/ptsprojects/bluez/bap_wid.py
@@ -15,6 +15,9 @@
 
 import logging
 
+import autopts.wid.bap
+from autopts.ptsprojects.bluez.iutctl import get_iut
+from autopts.pybtp.types import WIDParams
 from autopts.wid import generic_wid_hdl
 
 log = logging.debug
@@ -23,3 +26,16 @@ log = logging.debug
 def bap_wid_hdl(wid, description, test_case_name):
     log(f'{bap_wid_hdl.__name__}, {wid}, {description}, {test_case_name}')
     return generic_wid_hdl(wid, description, test_case_name, [__name__, 'autopts.wid.bap'])
+
+
+def hdl_wid_302(params: WIDParams):
+    """
+    Please configure ASE state to CODEC configured with SINK/SOURCE ASE,
+    Freq: X KHz, Frame Duration: X ms
+    """
+
+    if get_iut().external_audio is not None:
+        logging.debug("External audio supported, skipping WID 302 handling")
+        return True
+
+    return autopts.wid.bap.hdl_wid_302(params)

--- a/autopts/ptsprojects/bluez/iutctl.py
+++ b/autopts/ptsprojects/bluez/iutctl.py
@@ -15,6 +15,7 @@
 #
 
 import logging
+import os
 import shlex
 import subprocess
 
@@ -28,6 +29,7 @@ IUT = None
 
 # IUT log file object
 IUT_LOG_FO = None
+IUT_AUDIO_LOG_FO = None
 CLI_SUPPORT = ['btpclient_path']
 
 
@@ -44,14 +46,17 @@ class IUTCtl:
 
     def __init__(self, args):
         """Constructor."""
-        log("%s.%s btpclient_path=%s", self.__class__, self.__init__.__name__,
-            args.btpclient_path)
+        log("%s.%s btpclient_path=%s external_audio=%s", self.__class__, self.__init__.__name__,
+            args.btpclient_path, args.external_audio)
 
         self.btpclient_path = args.btpclient_path[0]
+        self.external_audio = args.external_audio
         self.btp_socket = None
         self.btp_address = BTP_ADDRESS
         self.socket_srv = None
         self.iut_process = None
+        self.audio_profile = None
+        self.audio_process = None
 
         self.stack = Stack()
         self.stack.synch_init()
@@ -111,8 +116,51 @@ class IUTCtl:
             self.iut_process.wait()  # do not let zombies take over
             self.iut_process = None
 
+        self.stop_audio()
+
     def get_stack(self):
         return self.stack
+
+    def get_external_audio_support(self):
+        """Returns the type of external audio support, or None if not supported"""
+        return self.external_audio
+
+    def start_audio(self):
+        if self.external_audio != "wireplumber":
+            return
+
+        logging.debug("Starting external audio with profile: %s", self.audio_profile)
+        wp_env = os.environ.copy()
+        wp_env["WIREPLUMBER_DEBUG"] = "I,spa.bluez*:D"
+        if self.audio_profile is not None:
+            base_cfg_dir = wp_env.get("WIREPLUMBER_CONFIG_DIR", "")
+            profile_dir = os.path.join(os.path.dirname(__file__), "wireplumber/", self.audio_profile)
+            if base_cfg_dir:
+                wp_env["WIREPLUMBER_CONFIG_DIR"] = base_cfg_dir + ":" + profile_dir
+            else:
+                wp_env["WIREPLUMBER_CONFIG_DIR"] = profile_dir
+        self.audio_process = subprocess.Popen(["wireplumber", "--profile", "bluetooth"],
+                                                env=wp_env,
+                                                stdout=IUT_AUDIO_LOG_FO,
+                                                stderr=IUT_AUDIO_LOG_FO)
+        logging.debug("Starting external audio process with PID: %s", self.audio_process.pid)
+
+    def stop_audio(self):
+        if self.audio_process and self.audio_process.poll() is None:
+            logging.debug("Stopping external audio process with PID: %s", self.audio_process.pid)
+            self.audio_process.terminate()
+            try:
+                self.audio_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                logging.debug("External audio process with PID %s did not terminate in time, killing it",
+                                self.audio_process.pid)
+                self.audio_process.kill()
+                self.audio_process.wait()
+            self.audio_process = None
+        self.audio_profile = None
+
+    def set_audio_profile(self, profile):
+        self.audio_profile = profile
 
 
 def get_iut():
@@ -122,16 +170,22 @@ def get_iut():
 def init(args):
     """IUT init routine"""
     global IUT_LOG_FO
+    global IUT_AUDIO_LOG_FO
     global IUT
 
     IUT_LOG_FO = open("iut-bluez.log", "w")
+    IUT_AUDIO_LOG_FO = open("iut-bluez-audio.log", "w")
 
     IUT = IUTCtl(args)
 
 
 def cleanup():
     """IUT cleanup routine"""
-    global IUT_LOG_FO, IUT
+    global IUT_LOG_FO, IUT_AUDIO_LOG_FO, IUT
+    if IUT_AUDIO_LOG_FO:
+        IUT_AUDIO_LOG_FO.close()
+        IUT_AUDIO_LOG_FO = None
+
     if IUT_LOG_FO:
         IUT_LOG_FO.close()
         IUT_LOG_FO = None

--- a/autopts/ptsprojects/bluez/wireplumber/high-reliability/wireplumber.conf.d/high-reliability.conf
+++ b/autopts/ptsprojects/bluez/wireplumber/high-reliability/wireplumber.conf.d/high-reliability.conf
@@ -1,0 +1,15 @@
+monitor.bluez.rules = [
+  {
+    matches = [
+       {
+         ## This matches all bluetooth devices.
+         device.name = "~bluez_card.*"
+       }
+     ]
+     actions = {
+       update-props = {
+        bluez5.bap.force-target-latency = "high-reliability"
+       }
+     }
+  }
+]

--- a/autopts/ptsprojects/bluez/wireplumber/low-latency/wireplumber.conf.d/low-latency.conf
+++ b/autopts/ptsprojects/bluez/wireplumber/low-latency/wireplumber.conf.d/low-latency.conf
@@ -1,0 +1,15 @@
+monitor.bluez.rules = [
+  {
+    matches = [
+       {
+         ## This matches all bluetooth devices.
+         device.name = "~bluez_card.*"
+       }
+     ]
+     actions = {
+       update-props = {
+        bluez5.bap.force-target-latency = "low-latency"
+       }
+     }
+  }
+]

--- a/cliparser.py
+++ b/cliparser.py
@@ -314,6 +314,9 @@ class CliParser(SmartDefaultsMixin, argparse.ArgumentParser):
                           help="OS kernel image to be used for testing,"
                           "e.g. elf file for qemu, exe for native.", iut_param=True)
 
+        self.add_argument("--external-audio", type=str, default=None,
+                          help="External audio support type.")
+
         self.add_positional_args()
 
     def add_positional_args(self):

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,12 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     # package_dir={"": "src"},
-    packages=setuptools.find_packages(include=["autopts"]),
+    packages=setuptools.find_packages(include=["autopts", "autopts.*"]),
+    include_package_data=True,
+    package_data={
+        "autopts.ptsprojects.bluez": [
+            "wireplumber/*/wireplumber.conf.d/*.conf",
+        ],
+    },
     python_requires=">=3.10",
 )


### PR DESCRIPTION
This allows to run the PTS test with BlueZ standalone or with PipeWire and WirePlumber.

It also adds specific WirePlumber congifurations as some config QoS tests requests to limit properties selected by
PipeWire/WirePlumber to "low-latency" or "high-reliability".  
This can be achieved by using the "bluez5.bap.force-target-latency" property.