### PR TITLE
btp/gatt_cl: add write_long_ev

### DIFF
--- a/autopts/ptsprojects/stack/layers/gattcl.py
+++ b/autopts/ptsprojects/stack/layers/gattcl.py
@@ -13,6 +13,7 @@
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
 # more details.
 #
+
 from autopts.ptsprojects.stack.common import wait_for_event
 from autopts.ptsprojects.stack.layers import Property
 
@@ -42,6 +43,7 @@ class GattCl:
         self.dscs = []
         self.notifications = []
         self.write_status = None
+        self.write_long_completed = False
         self.event_to_await = None
 
     def set_event_to_await(self, event):
@@ -100,6 +102,27 @@ class GattCl:
 
     def wait_for_write_rsp(self, timeout=30):
         return wait_for_event(timeout, self.is_write_completed)
+
+    def is_write_long_completed(self) -> bool:
+        """
+        Checks 'write_long_completed' flag that indicates write long operation has completed.
+
+        Returns:
+            bool: True if write long operation is complete, False otherwise.
+        """
+        return self.write_long_completed
+
+    def wait_for_write_long_rsp(self, timeout: int = 30) -> bool:
+        """
+        Waits for Write Long Response event to occur.
+
+        Args:
+            timeout (int, optional): The maximum amount of time to wait in seconds.
+
+        Returns:
+            bool: True if the event occurred within the time limit, or False if the wait timed out.
+        """
+        return wait_for_event(timeout, self.is_write_long_completed)
 
     def is_verified_val_rxed(self, expected_count):
         if expected_count > 0:

--- a/autopts/pybtp/btp/gatt_cl.py
+++ b/autopts/pybtp/btp/gatt_cl.py
@@ -18,7 +18,7 @@ import binascii
 import logging
 import struct
 
-from autopts.ptsprojects.stack import GattCharacteristic, get_stack
+from autopts.ptsprojects.stack import GattCharacteristic, GattCl, get_stack
 from autopts.pybtp import defs
 from autopts.pybtp.btp.btp import (
     add_to_verify_values,
@@ -578,6 +578,31 @@ def gatt_cl_write_rsp_ev_(gatt_cl, data, data_len):
     gatt_cl.write_status = status
 
 
+def gatt_cl_write_long_rsp_ev_(gatt_cl: GattCl, data: bytes, data_len: int) -> None:
+    """
+    Handles GATT Write Long Response event
+
+    Args:
+        gatt_cl (GattCl): The instance of GattCl stack object.
+        data (bytes): The raw byte payload containing the event information
+        data_len (int): The total length of the raw data payload.
+
+    Returns:
+        None
+    """
+    logging.debug("%r", data)
+
+    fmt = '<B6sB'
+
+    addr_type, addr, status = \
+        struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
+
+    logging.debug("received addr_type=%r addr=%r status=%r", addr_type, addr, status)
+
+    gatt_cl.write_status = status
+    gatt_cl.write_long_completed = True
+
+
 def gatt_cl_notification_rxed_ev_(gatt_cl, data, data_len):
     logging.debug("%s %r", gatt_cl_notification_rxed_ev_.__name__, data)
 
@@ -613,7 +638,7 @@ GATTC_EV = {
     defs.BTP_GATTC_EV_READ_LONG_RP: gatt_cl_read_long_rsp_ev_,
     defs.BTP_GATTC_EV_READ_MULTIPLE_RP: gatt_cl_read_mult_rsp_ev_,
     defs.BTP_GATTC_EV_WRITE_RP: gatt_cl_write_rsp_ev_,
-    defs.BTP_GATTC_EV_WRITE_LONG_RP: gatt_cl_write_rsp_ev_,
+    defs.BTP_GATTC_EV_WRITE_LONG_RP: gatt_cl_write_long_rsp_ev_,
     defs.BTP_GATTC_EV_RELIABLE_WRITE_RP: gatt_cl_write_rsp_ev_,
     defs.BTP_GATTC_EV_CFG_NOTIFY_RP: gatt_cl_write_rsp_ev_,
     defs.BTP_GATTC_EV_CFG_INDICATE_RP: gatt_cl_write_rsp_ev_,
@@ -1142,7 +1167,7 @@ def gatt_cl_write_long(bd_addr_type, bd_addr, hdl, off, val, length=None):
     iutctl.btp_socket.send(*GATTC['write_long'], data=data_ba)
 
     stack = get_stack()
-    stack.gatt_cl.set_event_to_await(stack.gatt_cl.is_write_completed)
+    stack.gatt_cl.set_event_to_await(stack.gatt_cl.is_write_long_completed)
 
     gatt_cl_command_rsp_succ()
 

--- a/autopts/wid/gatt_client.py
+++ b/autopts/wid/gatt_client.py
@@ -1158,8 +1158,14 @@ def hdl_wid_82(_: WIDParams):
     Description: Verify that the Implementation Under Test (IUT) can send
     execute write request.
     """
-    # This is handled by host
-    return True
+    stack = get_stack()
+
+    execute_write_request = stack.gatt_cl.wait_for_write_long_rsp()
+    if execute_write_request:
+        # clear flag
+        stack.gatt_cl.write_long_completed = False
+        return True
+    return False
 
 
 def hdl_wid_90(params: WIDParams):


### PR DESCRIPTION
In GATT/CL/GAW tests we should verify that IUT can send execute write request. Best we can do is await specific event after write long operation is performed. This commit adds event and waiting method for write long.
Related issue: https://github.com/auto-pts/auto-pts/issues/712