### PR TITLE
l2cap: add mechanism to retrieve error code

### DIFF
--- a/autopts/ptsprojects/mynewt/l2cap.py
+++ b/autopts/ptsprojects/mynewt/l2cap.py
@@ -17,7 +17,7 @@
 
 from autopts.client import get_unique_name
 from autopts.ptsprojects.mynewt.ztestcase import ZTestCase
-from autopts.ptsprojects.stack import L2cap, get_stack
+from autopts.ptsprojects.stack import L2CapChannelStatusCode, get_stack
 from autopts.ptsprojects.testcase import TestFunc
 from autopts.pybtp import btp
 from autopts.pybtp.types import Addr
@@ -136,7 +136,7 @@ def test_cases(ptses):
 
     pre_conditions_unacceptable_parameters = common + [
         TestFunc(stack.l2cap_init, le_psm, le_initial_mtu),
-        TestFunc(btp.l2cap_le_listen, le_psm, le_initial_mtu, L2cap.unacceptable_parameters)
+        TestFunc(btp.l2cap_le_listen, le_psm, le_initial_mtu, L2CapChannelStatusCode.UNACCEPTABLE_PARAMETERS)
     ]
 
     pre_conditions_gatt = common + [

--- a/autopts/ptsprojects/stack/layers/l2cap.py
+++ b/autopts/ptsprojects/stack/layers/l2cap.py
@@ -110,6 +110,7 @@ class L2cap:
         self.channels = []
         self.hold_credits = 0
         self.num_channels = 2
+        self.conn_req_reject_reason = None
 
     def chan_lookup_id(self, chan_id):
         """ lookup L2CAP channel with specified channel ID"""
@@ -210,6 +211,22 @@ class L2cap:
             return True
 
         return wait_for_event(timeout, lambda: not self.is_connected(chan_id) and not self.is_connecting(chan_id))
+
+    def wait_for_conn_req_reject_ev(self, timeout: int = 30):
+        """
+        Waits for a L2CAP connection request to be rejected.
+
+        Args:
+            timeout (int): The maximum time to wait for the event in seconds.
+
+        Returns:
+            bool: True if the event occurred within the timeout, False otherwise.
+        """
+
+        if self.conn_req_reject_reason:
+            return True
+
+        return wait_for_event(timeout, lambda: self.conn_req_reject_reason is not None)
 
     def wait_for_connection(self, chan_id, timeout=5):
         """ Wait for channel connection """

--- a/autopts/ptsprojects/stack/layers/l2cap.py
+++ b/autopts/ptsprojects/stack/layers/l2cap.py
@@ -104,17 +104,26 @@ class L2capChan:
 
 
 class L2cap:
-    """L2CAP layer - manages L2CAP channels """
+    """
+    L2CAP layer - manages L2CAP channels.
 
-    def __init__(self, psm, initial_mtu):
-        # PSM used for testing for Client role
+    Attributes:
+        psm (int): Protocol/Service Multiplexer used for testing client role.
+        initial_mtu (int): Initial Maximum Transmission Unit.
+        channels (list[L2capChan]): List of currently active L2CAP channels.
+        hold_credits (int): Number of flow control credits currently held.
+        num_channels (int): Default or maximum number of channels.
+        conn_req_reject_reason (L2CapChannelStatusCode | None): The reason a
+            connection request was rejected, or None if no rejection occurred.
+    """
+
+    def __init__(self, psm: int, initial_mtu: int):
         self.psm = psm
         self.initial_mtu = initial_mtu
-        self.channels = []
+        self.channels: list[L2capChan] = []
         self.hold_credits = 0
         self.num_channels = 2
         self.conn_req_reject_reason: L2CapChannelStatusCode | None = None
-        """L2CapChannelStatusCode | None: The reason the L2CAP connection request was rejected."""
 
     def chan_lookup_id(self, chan_id):
         """ lookup L2CAP channel with specified channel ID"""

--- a/autopts/ptsprojects/stack/layers/l2cap.py
+++ b/autopts/ptsprojects/stack/layers/l2cap.py
@@ -14,7 +14,7 @@
 # more details.
 #
 import logging
-from enum import Enum, auto
+from enum import Enum, IntEnum, auto
 
 from autopts.ptsprojects.stack.common import wait_for_event
 
@@ -24,6 +24,20 @@ class L2capChanState(Enum):
     CONNECTING = auto()
     CONNECTED = auto()
     DISCONNECTED = auto()
+
+
+class L2CapChannelStatusCode(IntEnum):
+    SUCCESS = 0x0000
+    LE_PSM_NOT_SUPPORTED = 0x0002
+    INSUFFICIENT_RESOURCES = 0x0004
+    INSUFFICIENT_AUTHENTICATION = 0x0005
+    INSUFFICIENT_AUTHORIZATION = 0x0006
+    INSUFFICIENT_ENCRYPTION_KEY_SIZE = 0x0007
+    INSUFFICIENT_ENCRYPTION = 0x0008
+    INVALID_SOURCE_CID = 0x0009
+    SOURCE_CID_ALREADY_ALLOCATED = 0x000a
+    UNACCEPTABLE_PARAMETERS = 0x000b
+    INVALID_PARAMETERS = 0x000c
 
 
 class L2capChan:
@@ -91,17 +105,6 @@ class L2capChan:
 
 class L2cap:
     """L2CAP layer - manages L2CAP channels """
-    connection_success = 0x0000
-    unknown_le_psm = 0x0002
-    no_resources = 0x0004
-    insufficient_authen = 0x0005
-    insufficient_author = 0x0006
-    insufficient_key_sz = 0x0007
-    insufficient_enc = 0x0008
-    invalid_source_cid = 0x0009
-    source_cid_already_used = 0x000a
-    unacceptable_parameters = 0x000b
-    invalid_parameters = 0x000c
 
     def __init__(self, psm, initial_mtu):
         # PSM used for testing for Client role
@@ -110,7 +113,8 @@ class L2cap:
         self.channels = []
         self.hold_credits = 0
         self.num_channels = 2
-        self.conn_req_reject_reason = None
+        self.conn_req_reject_reason: L2CapChannelStatusCode | None = None
+        """L2CapChannelStatusCode | None: The reason the L2CAP connection request was rejected."""
 
     def chan_lookup_id(self, chan_id):
         """ lookup L2CAP channel with specified channel ID"""

--- a/autopts/pybtp/btp/l2cap.py
+++ b/autopts/pybtp/btp/l2cap.py
@@ -19,7 +19,7 @@ import binascii
 import logging
 import struct
 
-from autopts.ptsprojects.stack import get_stack
+from autopts.ptsprojects.stack import L2CapChannelStatusCode, get_stack
 from autopts.pybtp import defs
 from autopts.pybtp.btp.btp import CONTROLLER_INDEX, btp_hdr_check, pts_addr_get, pts_addr_type_get
 from autopts.pybtp.btp.btp import get_iut_method as get_iut
@@ -400,11 +400,14 @@ def l2cap_disconnected_ev(l2cap, data, data_len):
 
     hdr_fmt = '<HBHB6s'
     res, chan_id, psm, bd_addr_type, bd_addr = struct.unpack_from(hdr_fmt, data)
-    result_str = l2cap_result_str[res]
-    l2cap.disconnected(chan_id, psm, bd_addr_type, bd_addr, result_str)
+    status = L2CapChannelStatusCode(res)
+    l2cap.disconnected(chan_id, psm, bd_addr_type, bd_addr, status)
+    if status != L2CapChannelStatusCode.SUCCESS:
+        # L2CAP connection request failed
+        l2cap.conn_req_reject_reason = status
 
     logging.debug("id:%r on psm:%r, addr %r type %r, res %r",
-                  chan_id, psm, bd_addr, bd_addr_type, result_str)
+                  chan_id, psm, bd_addr, bd_addr_type, status.name)
 
 
 def l2cap_data_rcv_ev(l2cap, data, data_len):

--- a/autopts/pybtp/btp/l2cap.py
+++ b/autopts/pybtp/btp/l2cap.py
@@ -154,18 +154,6 @@ def l2cap_conn_v2(bd_addr, bd_addr_type, psm, mtu=0, num=1, ecfc=0, hold_credit=
     return chan_ids
 
 
-l2cap_result_str = {0: "Success",
-                    2: "LE_PSM not supported",
-                    4: "Insufficient Resources",
-                    5: "insufficient authentication",
-                    6: "insufficient authorization",
-                    7: "insufficient encryption key size",
-                    8: "insufficient encryption",
-                    9: "Invalid Source CID",
-                    10: "Source CID already allocated",
-                    }
-
-
 def l2cap_conn_rsp():
     logging.debug("")
 

--- a/autopts/wid/l2cap.py
+++ b/autopts/wid/l2cap.py
@@ -17,7 +17,7 @@ import logging
 import re
 import time
 
-from autopts.ptsprojects.stack import get_stack
+from autopts.ptsprojects.stack import L2CapChannelStatusCode, get_stack
 from autopts.pybtp import btp, defs
 from autopts.pybtp.types import BTPError, WIDParams
 from autopts.wid.common import _l2cap_send_forever, _safe_l2cap_disconnect
@@ -502,23 +502,51 @@ def hdl_wid_138(_: WIDParams):
 
 
 def hdl_wid_251(_: WIDParams):
-    # TODO: Fix to actually verify result of 'Insufficient Encryption' 0x0008 error
-    return get_stack().l2cap.wait_for_disconnection(0, 30)
+    """
+        Did Implementation Under Test(IUT) receive Connection refused 'Insufficient Encryption' 0x0008 error?
+    """
+    stack = get_stack()
+    stack.l2cap.wait_for_conn_req_reject_ev()
+    reason = stack.l2cap.conn_req_reject_reason
+    if reason == L2CapChannelStatusCode.INSUFFICIENT_ENCRYPTION:
+        return True
+    return False
 
 
 def hdl_wid_252(_: WIDParams):
-    # TODO: Fix to actually verify result of 'Insufficient Authentication' 0x0005 error
-    return get_stack().l2cap.wait_for_disconnection(0, 30)
+    """
+        Did Implementation Under Test(IUT) receive Connection refused 'Insufficient Authentication' 0x0005 error
+    """
+    stack = get_stack()
+    stack.l2cap.wait_for_conn_req_reject_ev()
+    reason = stack.l2cap.conn_req_reject_reason
+    if reason == L2CapChannelStatusCode.INSUFFICIENT_AUTHENTICATION:
+        return True
+    return False
 
 
 def hdl_wid_253(_: WIDParams):
-    # TODO: Fix to actually verify result of 'Insufficient Authorization' 0x0006 error
-    return get_stack().l2cap.wait_for_disconnection(0, 30)
+    """
+        Did Implementation Under Test(IUT) receive Connection refused 'Insufficient Authorization' 0x0006 error
+    """
+    stack = get_stack()
+    stack.l2cap.wait_for_conn_req_reject_ev()
+    reason = stack.l2cap.conn_req_reject_reason
+    if reason == L2CapChannelStatusCode.INSUFFICIENT_AUTHORIZATION:
+        return True
+    return False
 
 
 def hdl_wid_254(_: WIDParams):
-    # TODO: Fix to actually verify result of 'Insufficient Encryption Key Size' 0x0007 error
-    return get_stack().l2cap.wait_for_disconnection(0, 30)
+    """
+        Did Implementation Under Test(IUT) receive Connection refused 'Insufficient Encryption Key Size' 0x0007 error
+    """
+    stack = get_stack()
+    stack.l2cap.wait_for_conn_req_reject_ev()
+    reason = stack.l2cap.conn_req_reject_reason
+    if reason == L2CapChannelStatusCode.INSUFFICIENT_ENCRYPTION_KEY_SIZE:
+        return True
+    return False
 
 
 def hdl_wid_255(params: WIDParams):


### PR DESCRIPTION
As stated in L2CAP BTP docs, Opcode 0x82 - Disconected Event:

> result value is returned in the response only if remote rejected connection request

`wait_for_conn_req_reject_ev` is introduced if we specifically expect an L2CAP connection request to fail and need to obtain the status value from response. Although `class L2capChan` already has a field that is related to that (`self.disconn_reason`), if connection request has been rejected an instance of L2capChan was never created thus disconn_reason was empty.

This is needed for verification in testcases L2CAP/LE/CFC/BV-10-C, L2CAP/LE/CFC/BV-12-C, L2CAP/LE/CFC/BV-14-C, L2CAP/LE/CFC/BV-24-C

Related issue: https://github.com/auto-pts/auto-pts/issues/712