### PR TITLE
zephyr: Fix mesh_rpr_persistent_storage.conf overlay

### DIFF
--- a/autopts/bot/iut_config/zephyr.py
+++ b/autopts/bot/iut_config/zephyr.py
@@ -168,7 +168,7 @@ iut_config = {
             'MESH/SR/RPR/PDU/BI-01-C',
             'MESH/SR/RPR/PDU/BI-02-C',
             'MESH/SR/RPR/PDU/BI-03-C',
-            'MESH/NODE/CFG/COMP/BV-01-C'
+            'MESH/NODE/CFG/COMP/BV-01-C',
             'MESH/SR/RPR/LNK/BI-05-C',
             'MESH/NODE/TNPT/BV-13-C',
         ]


### PR DESCRIPTION
There was missing comma which cause two tests to not be properly included in overlay.