### PR TITLE
btp: simplify logging by removing manual function name references.

### DIFF
--- a/autopts/client.py
+++ b/autopts/client.py
@@ -81,6 +81,13 @@ AUTO_PTS_LOCAL = "AUTO_PTS_LOCAL" in os.environ
 
 def logger_log(self, *args, **kwargs):
     with log_lock:
+        # Add one frame so logs show the real caller (not logger_log).
+        # Adjust stacklevel (kwarg or 7th arg) without duplicating it.
+        if len(args) > 6:
+            args = list(args)
+            args[6] += 1
+        else:
+            kwargs['stacklevel'] = kwargs.get('stacklevel', 1) + 1
         self.original_log(*args, **kwargs)
 
 

--- a/autopts/pybtp/btp/aics.py
+++ b/autopts/pybtp/btp/aics.py
@@ -12,7 +12,7 @@ AICS = aics_btp
 
 
 def aics_command_rsp_succ(op=None):
-    logging.debug("%s", aics_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -25,7 +25,7 @@ def aics_command_rsp_succ(op=None):
 
 
 def aics_mute(bd_addr_type=None, bd_addr=None):
-    logging.debug("%s", aics_mute.__name__)
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -36,7 +36,7 @@ def aics_mute(bd_addr_type=None, bd_addr=None):
 
 
 def aics_unmute(bd_addr_type=None, bd_addr=None):
-    logging.debug("%s", aics_unmute.__name__)
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -46,7 +46,7 @@ def aics_unmute(bd_addr_type=None, bd_addr=None):
 
 
 def aics_auto_gain_set(bd_addr_type=None, bd_addr=None):
-    logging.debug("%s", aics_auto_gain_set.__name__)
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -56,7 +56,7 @@ def aics_auto_gain_set(bd_addr_type=None, bd_addr=None):
 
 
 def aics_man_gain_set(bd_addr_type=None, bd_addr=None):
-    logging.debug("%s", aics_man_gain_set.__name__)
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -66,7 +66,7 @@ def aics_man_gain_set(bd_addr_type=None, bd_addr=None):
 
 
 def aics_man_gain_only():
-    logging.debug("%s", aics_man_gain_only.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -75,7 +75,7 @@ def aics_man_gain_only():
 
 
 def aics_auto_gain_only():
-    logging.debug("%s", aics_auto_gain_only.__name__)
+    logging.debug("")
 
     data_ba = bytearray()
     iutctl = get_iut()
@@ -85,7 +85,7 @@ def aics_auto_gain_only():
 
 
 def aics_change_desc(string):
-    logging.debug("%s", aics_change_desc.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     string_len = len(string)
@@ -98,7 +98,7 @@ def aics_change_desc(string):
 
 
 def aics_state_get(bd_addr_type=None, bd_addr=None):
-    logging.debug("%s", aics_state_get.__name__)
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -109,7 +109,7 @@ def aics_state_get(bd_addr_type=None, bd_addr=None):
 
 
 def aics_status_get(bd_addr_type=None, bd_addr=None):
-    logging.debug("%s", aics_status_get.__name__)
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -120,7 +120,7 @@ def aics_status_get(bd_addr_type=None, bd_addr=None):
 
 
 def aics_type_get(bd_addr_type=None, bd_addr=None):
-    logging.debug("%s", aics_type_get.__name__)
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -131,7 +131,7 @@ def aics_type_get(bd_addr_type=None, bd_addr=None):
 
 
 def aics_gain_setting_prop_get(bd_addr_type=None, bd_addr=None):
-    logging.debug("%s", aics_gain_setting_prop_get.__name__)
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -151,7 +151,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def aics_set_gain(gain, bd_addr_type=None, bd_addr=None):
-    logging.debug("%s %r", aics_set_gain.__name__, gain)
+    logging.debug("%r", gain)
 
     iutctl = get_iut()
 
@@ -165,7 +165,7 @@ def aics_set_gain(gain, bd_addr_type=None, bd_addr=None):
 
 
 def aics_mute_disable():
-    logging.debug("%s", aics_mute_disable.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -174,7 +174,7 @@ def aics_mute_disable():
 
 
 def aics_description_get(bd_addr_type=None, bd_addr=None):
-    logging.debug("%s", aics_description_get.__name__)
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -184,7 +184,7 @@ def aics_description_get(bd_addr_type=None, bd_addr=None):
 
 
 def aics_state_ev(aics, data, data_len):
-    logging.debug('%s %r', aics_state_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbBbb'
     if len(data) < struct.calcsize(fmt):
@@ -194,14 +194,14 @@ def aics_state_ev(aics, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'Audio Input Control State: addr {addr} addr_type '
-                  f'{addr_type}, att_status {att_status}, gain {gain}, mute {mute}, mode {mode}')
+    logging.debug("Audio Input Control State: addr %r, addr_type %r, att_status %r, gain %r, mute %r, mode %r",
+                  addr, addr_type, att_status, gain, mute, mode)
 
     aics.event_received(defs.BTP_AICS_EV_STATE, (addr_type, addr, att_status, gain, mute, mode))
 
 
 def aics_gain_setting_prop_ev(aics, data, data_len):
-    logging.debug('%s %r', aics_gain_setting_prop_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbbBB'
     if len(data) < struct.calcsize(fmt):
@@ -211,16 +211,15 @@ def aics_gain_setting_prop_ev(aics, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'AICS Gain Setting Properties: addr {addr} addr_type '
-                  f'{addr_type}, units {units}, minimum {minimum}, maximum {maximum},'
-                  f' att_status {att_status}')
+    logging.debug("AICS Gain Setting Properties: addr %r, addr_type %r, units %r, minimum %r, maximum %r, att_status %r",
+                  addr, addr_type, units, minimum, maximum, att_status)
 
     aics.event_received(defs.BTP_AICS_EV_GAIN_SETTING_PROP, (addr_type, addr, units,
                                                          minimum, maximum, att_status))
 
 
 def aics_input_type_ev(aics, data, data_len):
-    logging.debug('%s %r', aics_input_type_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbb'
     if len(data) < struct.calcsize(fmt):
@@ -230,14 +229,14 @@ def aics_input_type_ev(aics, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'AICS Input type ev: addr {addr} addr_type '
-                  f'{addr_type}, input type {input_type}, att_status {att_status}')
+    logging.debug("AICS Input type ev: addr %r, addr_type %r, input type %r, att_status %r",
+                  addr, addr_type, input_type, att_status)
 
     aics.event_received(defs.BTP_AICS_EV_INPUT_TYPE, (addr_type, addr, input_type, att_status))
 
 
 def aics_status_ev(aics, data, data_len):
-    logging.debug('%s %r', aics_status_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbb'
     if len(data) < struct.calcsize(fmt):
@@ -247,14 +246,14 @@ def aics_status_ev(aics, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'AICS Status ev: addr {addr} addr_type '
-                  f'{addr_type}, status {status}, att_status {att_status}')
+    logging.debug("AICS Status ev: addr %r, addr_type %r, status %r, att_status %r",
+                  addr, addr_type, status, att_status)
 
     aics.event_received(defs.BTP_AICS_EV_STATUS, (addr_type, addr, status, att_status))
 
 
 def aics_description_ev(aics, data, data_len):
-    logging.debug('%s %r', aics_description_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sb'
 
@@ -268,14 +267,14 @@ def aics_description_ev(aics, data, data_len):
     description = struct.unpack_from(f'<{len(data) - fmt_size - 1}s', data, offset=fmt_size)
     description = binascii.hexlify(description[0]).decode('utf-8')
 
-    logging.debug(f'AICS Description ev: addr {addr} addr_type '
-                  f'{addr_type}, att_status {att_status}, description {description}')
+    logging.debug("AICS Description ev: addr %r, addr_type %r, att_status %r, description %r",
+                  addr, addr_type, att_status, description)
 
     aics.event_received(defs.BTP_AICS_EV_DESCRIPTION, (addr_type, addr, att_status, description))
 
 
 def aics_procedure_ev(aics, data, data_len):
-    logging.debug('%s %r', aics_procedure_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbb'
     if len(data) < struct.calcsize(fmt):
@@ -285,8 +284,8 @@ def aics_procedure_ev(aics, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'AICS Procedure ev: addr {addr} addr_type '
-                  f'{addr_type}, att status {att_status}, opcode {opcode}')
+    logging.debug("AICS Procedure ev: addr %r, addr_type %r, att status %r, opcode %r",
+                  addr, addr_type, att_status, opcode)
 
     aics.event_received(defs.BTP_AICS_EV_PROCEDURE, (addr_type, addr, att_status, opcode))
 

--- a/autopts/pybtp/btp/ascs.py
+++ b/autopts/pybtp/btp/ascs.py
@@ -50,7 +50,7 @@ ASCS = {
 
 
 def ascs_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", ascs_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -73,7 +73,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 def ascs_config_codec(ase_id, coding_format, vid, cid, codec_ltvs,
                       bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ascs_config_codec.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', ase_id)
@@ -94,7 +94,7 @@ def ascs_config_codec(ase_id, coding_format, vid, cid, codec_ltvs,
 
 
 def ascs_add_ase_to_cis(ase_id, cis_id, cig_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ascs_add_ase_to_cis.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', ase_id)
@@ -111,7 +111,7 @@ def ascs_config_qos(ase_id, cig_id, cis_id, sdu_interval, framing, max_sdu,
                     retransmission_number, max_transport_latency,
                     presentation_delay, bd_addr_type=None, bd_addr=None):
 
-    logging.debug(f"{ascs_config_qos.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', ase_id)
@@ -131,7 +131,7 @@ def ascs_config_qos(ase_id, cig_id, cis_id, sdu_interval, framing, max_sdu,
 
 
 def ascs_enable(ase_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ascs_enable.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', ase_id)
@@ -141,7 +141,7 @@ def ascs_enable(ase_id, bd_addr_type=None, bd_addr=None):
 
 
 def ascs_receiver_start_ready(ase_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ascs_receiver_start_ready.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', ase_id)
@@ -151,7 +151,7 @@ def ascs_receiver_start_ready(ase_id, bd_addr_type=None, bd_addr=None):
 
 
 def ascs_receiver_stop_ready(ase_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ascs_receiver_stop_ready.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', ase_id)
@@ -161,7 +161,7 @@ def ascs_receiver_stop_ready(ase_id, bd_addr_type=None, bd_addr=None):
 
 
 def ascs_disable(ase_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ascs_disable.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', ase_id)
@@ -171,7 +171,7 @@ def ascs_disable(ase_id, bd_addr_type=None, bd_addr=None):
 
 
 def ascs_release(ase_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ascs_release.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', ase_id)
@@ -181,7 +181,7 @@ def ascs_release(ase_id, bd_addr_type=None, bd_addr=None):
 
 
 def ascs_update_metadata(ase_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ascs_update_metadata.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', ase_id)
@@ -193,7 +193,7 @@ def ascs_update_metadata(ase_id, bd_addr_type=None, bd_addr=None):
 def ascs_preconfig_qos(cig_id, cis_id, sdu_interval, framing, max_sdu,
                        retransmission_number, max_transport_latency,
                        presentation_delay):
-    logging.debug(f"{ascs_config_qos.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data += struct.pack('B', cig_id)
@@ -212,7 +212,7 @@ def ascs_preconfig_qos(cig_id, cis_id, sdu_interval, framing, max_sdu,
 
 
 def ascs_ev_operation_completed_(ascs, data, data_len):
-    logging.debug('%s %r', ascs_ev_operation_completed_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sBBBB'
     header_size = struct.calcsize(fmt)
@@ -224,16 +224,15 @@ def ascs_ev_operation_completed_(ascs, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'ASE operation completed event: addr {addr} addr_type '
-                  f'{addr_type} ase_id {ase_id} opcode {opcode} '
-                  f'status {status} flags {flags}')
+    logging.debug("ASE operation completed event: addr %r, addr_type %r, ase_id %r, opcode %r, status %r, flags %r",
+                  addr, addr_type, ase_id, opcode, status, flags)
 
     ascs.event_received(defs.BTP_ASCS_EV_OPERATION_COMPLETED,
                         (addr_type, addr, ase_id, opcode, status, flags))
 
 
 def ascs_ev_characteristic_subscribed_(ascs, data, data_len):
-    logging.debug('%s %r', ascs_ev_characteristic_subscribed_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sB'
     header_size = struct.calcsize(fmt)
@@ -244,14 +243,14 @@ def ascs_ev_characteristic_subscribed_(ascs, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'ASCS characteristic with handle {handle} subscribed')
+    logging.debug("ASCS characteristic with handle %r subscribed", handle)
 
     ascs.event_received(defs.BTP_ASCS_EV_CHARACTERISTIC_SUBSCRIBED,
                         (addr_type, addr, handle))
 
 
 def ascs_ev_ase_state_changed_(ascs, data, data_len):
-    logging.debug('%s %r', ascs_ev_ase_state_changed_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sBB'
     header_size = struct.calcsize(fmt)
@@ -262,14 +261,14 @@ def ascs_ev_ase_state_changed_(ascs, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'ASE state: ase_id {ase_id}, state {state}')
+    logging.debug("ASE state: ase_id %r, state %r", ase_id, state)
 
     ascs.event_received(defs.BTP_ASCS_EV_ASE_STATE_CHANGED,
                         (addr_type, addr, ase_id, state))
 
 
 def ascs_ev_cis_connected_(ascs, data, data_len):
-    logging.debug("%s %r", ascs_ev_cis_connected_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = "<B6sBB"
     header_size = struct.calcsize(fmt)
@@ -280,13 +279,13 @@ def ascs_ev_cis_connected_(ascs, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f"CIS connected: ase_id {ase_id}, cis_id {cis_id}")
+    logging.debug("CIS connected: ase_id %r, cis_id %r", ase_id, cis_id)
 
     ascs.event_received(defs.BTP_ASCS_EV_CIS_CONNECTED, (addr_type, addr, ase_id, cis_id))
 
 
 def ascs_ev_cis_disconnected_(ascs, data, data_len):
-    logging.debug("%s %r", ascs_ev_cis_disconnected_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = "<B6sBBB"
     header_size = struct.calcsize(fmt)
@@ -297,7 +296,7 @@ def ascs_ev_cis_disconnected_(ascs, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f"CIS disconnected: ase_id {ase_id}, cis_id {cis_id}, reason {reason}")
+    logging.debug("CIS disconnected: ase_id %r, cis_id %r, reason %r", ase_id, cis_id, reason)
 
     ascs.event_received(
         defs.BTP_ASCS_EV_CIS_DISCONNECTED, (addr_type, addr, ase_id, cis_id, reason)

--- a/autopts/pybtp/btp/bap.py
+++ b/autopts/pybtp/btp/bap.py
@@ -88,7 +88,7 @@ BAP = {
 
 
 def bap_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", bap_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -110,7 +110,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def bap_discover(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{bap_discover.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
 
@@ -121,7 +121,7 @@ def bap_discover(bd_addr_type=None, bd_addr=None):
 
 
 def bap_send(ase_id, data_ba, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{bap_send.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', ase_id)
@@ -142,7 +142,7 @@ def bap_broadcast_source_setup(
         codec_ltvs, sdu_interval, framing, max_sdu, retransmission_number,
         max_transport_latency, presentation_delay):
 
-    logging.debug(f"{bap_broadcast_source_setup.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -181,7 +181,7 @@ def bap_broadcast_source_setup_v2(
         codec_ltvs, sdu_interval, framing, max_sdu, retransmission_number,
         max_transport_latency, presentation_delay):
 
-    logging.debug(f"{bap_broadcast_source_setup_v2.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -217,7 +217,7 @@ def bap_broadcast_source_setup_v2(
 
 
 def bap_broadcast_source_release(broadcast_id):
-    logging.debug(f"{bap_broadcast_source_release.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -229,7 +229,7 @@ def bap_broadcast_source_release(broadcast_id):
 
 
 def bap_broadcast_adv_start(broadcast_id):
-    logging.debug(f"{bap_broadcast_adv_start.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -240,7 +240,7 @@ def bap_broadcast_adv_start(broadcast_id):
 
 
 def bap_broadcast_adv_stop(broadcast_id):
-    logging.debug(f"{bap_broadcast_adv_stop.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -251,7 +251,7 @@ def bap_broadcast_adv_stop(broadcast_id):
 
 
 def bap_broadcast_source_start(broadcast_id):
-    logging.debug(f"{bap_broadcast_source_start.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -262,7 +262,7 @@ def bap_broadcast_source_start(broadcast_id):
 
 
 def bap_broadcast_source_stop(broadcast_id):
-    logging.debug(f"{bap_broadcast_source_stop.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -274,7 +274,7 @@ def bap_broadcast_source_stop(broadcast_id):
 
 def bap_broadcast_sink_setup():
 
-    logging.debug(f"{bap_broadcast_sink_setup.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*BAP['broadcast_sink_setup'])
@@ -283,7 +283,7 @@ def bap_broadcast_sink_setup():
 
 
 def bap_broadcast_sink_release():
-    logging.debug(f"{bap_broadcast_sink_release.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*BAP['broadcast_sink_release'])
@@ -292,7 +292,7 @@ def bap_broadcast_sink_release():
 
 
 def bap_broadcast_scan_start():
-    logging.debug(f"{bap_broadcast_scan_start.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*BAP['broadcast_scan_start'])
@@ -301,7 +301,7 @@ def bap_broadcast_scan_start():
 
 
 def bap_broadcast_scan_stop():
-    logging.debug(f"{bap_broadcast_scan_stop.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*BAP['broadcast_scan_stop'])
@@ -311,7 +311,7 @@ def bap_broadcast_scan_stop():
 
 def bap_broadcast_sink_sync(broadcast_id, advertiser_sid, skip, sync_timeout,
                             past_available, src_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{bap_broadcast_sink_sync.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -329,7 +329,7 @@ def bap_broadcast_sink_sync(broadcast_id, advertiser_sid, skip, sync_timeout,
 
 
 def bap_broadcast_sink_stop(broadcast_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{bap_broadcast_sink_stop.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -343,7 +343,7 @@ def bap_broadcast_sink_stop(broadcast_id, bd_addr_type=None, bd_addr=None):
 
 def bap_broadcast_sink_bis_sync(broadcast_id, requested_bis_sync,
                                 bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{bap_broadcast_sink_bis_sync.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -359,7 +359,7 @@ def bap_broadcast_sink_bis_sync(broadcast_id, requested_bis_sync,
 def bap_scan_delegator_add_src(broadcaster_addr_type, broadcaster_addr,
                                advertiser_sid, broadcast_id, pa_sync_state,
                                big_encryption, num_subgroups, subgroups):
-    logging.debug(f"{bap_scan_delegator_add_src.__name__}")
+    logging.debug("")
 
     if not BASSPASyncState.NOT_SYNCED <= pa_sync_state <= BASSPASyncState.NO_PAST:
         raise BTPError(f'Invalid pa_sync_state {pa_sync_state}')
@@ -388,7 +388,7 @@ def bap_scan_delegator_add_src(broadcaster_addr_type, broadcaster_addr,
 
 
 def bap_discover_scan_delegator(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{bap_discover_scan_delegator.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -400,7 +400,7 @@ def bap_discover_scan_delegator(bd_addr_type=None, bd_addr=None):
 
 
 def bap_broadcast_assistant_scan_start(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{bap_broadcast_assistant_scan_start.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -412,7 +412,7 @@ def bap_broadcast_assistant_scan_start(bd_addr_type=None, bd_addr=None):
 
 
 def bap_broadcast_assistant_scan_stop(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{bap_broadcast_assistant_scan_stop.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -427,7 +427,7 @@ def bap_add_broadcast_src(advertiser_sid, broadcast_id, pa_sync,
                           pa_interval, num_subgroups, subgroups,
                           broadcaster_addr_type, broadcaster_addr,
                           bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{bap_add_broadcast_src.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -446,7 +446,7 @@ def bap_add_broadcast_src(advertiser_sid, broadcast_id, pa_sync,
 
 
 def bap_remove_broadcast_src(src_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{bap_remove_broadcast_src.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -461,7 +461,7 @@ def bap_remove_broadcast_src(src_id, bd_addr_type=None, bd_addr=None):
 def bap_modify_broadcast_src(src_id, pa_sync, pa_interval,
                              num_subgroups, subgroups,
                              bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{bap_modify_broadcast_src.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -479,7 +479,7 @@ def bap_modify_broadcast_src(src_id, pa_sync, pa_interval,
 
 def bap_set_broadcast_code(src_id, broadcast_code,
                            bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{bap_set_broadcast_code.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -500,7 +500,7 @@ def bap_set_broadcast_code(src_id, broadcast_code,
 
 
 def bap_send_past(src_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{bap_send_past.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -513,7 +513,7 @@ def bap_send_past(src_id, bd_addr_type=None, bd_addr=None):
 
 
 def bap_ev_discovery_completed_(bap, data, data_len):
-    logging.debug('%s %r', bap_ev_discovery_completed_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sB'
     if len(data) < struct.calcsize(fmt):
@@ -523,28 +523,28 @@ def bap_ev_discovery_completed_(bap, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'BAP Discovery completed: addr {addr} addr_type '
-                  f'{addr_type} status {status}')
+    logging.debug("BAP Discovery completed: addr %r addr_type %r status %r",
+                  addr, addr_type, status)
 
     bap.event_received(defs.BTP_BAP_EV_DISCOVERY_COMPLETED, (addr_type, addr, status))
 
 
 def bap_ev_codec_cap_found_(bap, data, data_len):
-    logging.debug('%s %r', bap_ev_codec_cap_found_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sBBHBIB'
     if len(data) < struct.calcsize(fmt):
         raise BTPError('Invalid data length')
 
-    addr_type, addr, pac_dir, coding_format, frequencies, frame_durations,\
+    addr_type, addr, pac_dir, coding_format, frequencies, frame_durations, \
         octets_per_frame, channel_counts = struct.unpack_from(fmt, data)
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'Found codec capabilities: addr {addr} addr_type '
-                  f'{addr_type} pac_dir {pac_dir} coding {coding_format:#x} '
-                  f'freq {frequencies:#b} duration {frame_durations:#b} '
-                  f'frame_len {octets_per_frame:#x} channel_counts {channel_counts:#b}')
+    logging.debug("Found codec capabilities: addr %r, addr_type %r, pac_dir %r, coding %r,"
+                  "frequencies %r, duration %r, frame_len %r, channel_counts %r",
+                  addr, addr_type, pac_dir, coding_format, frequencies,
+                  frame_durations, octets_per_frame, channel_counts)
 
     bap.event_received(defs.BTP_BAP_EV_CODEC_CAP_FOUND,
                        (addr_type, addr, pac_dir, coding_format, frequencies,
@@ -552,7 +552,7 @@ def bap_ev_codec_cap_found_(bap, data, data_len):
 
 
 def bap_ev_ase_found_(bap, data, data_len):
-    logging.debug('%s %r', bap_ev_ase_found_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sBB'
     if len(data) < struct.calcsize(fmt):
@@ -562,14 +562,13 @@ def bap_ev_ase_found_(bap, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'Found ASE: addr {addr} addr_type {addr_type}'
-                  f' dir {ase_dir} ID {ase_id}')
+    logging.debug("Found ASE: addr %r addr_type %r dir %r ID %r", addr, addr_type, ase_dir, ase_id)
 
     bap.event_received(defs.BTP_BAP_EV_ASE_FOUND, (addr_type, addr, ase_dir, ase_id))
 
 
 def bap_ev_stream_received_(bap, data, data_len):
-    logging.debug('%s %r', bap_ev_stream_received_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sBB'
     fmt_len = struct.calcsize(fmt)
@@ -581,14 +580,14 @@ def bap_ev_stream_received_(bap, data, data_len):
     addr = le_bytes_to_hex_str(addr)
     iso_data = data[fmt_len:]
 
-    logging.debug(f'Stream received: addr {addr} addr_type {addr_type}'
-                  f' ID {ase_id} data {iso_data}')
+    logging.debug("Stream received: addr %r addr_type %r ID %r data %r",
+                  addr, addr_type, ase_id, iso_data)
 
     bap.event_received(defs.BTP_BAP_EV_STREAM_RECEIVED, (addr_type, addr, ase_id, iso_data))
 
 
 def bap_ev_baa_found_(bap, data, data_len):
-    logging.debug('%s %r', bap_ev_baa_found_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6s3sBH'
     fmt_len = struct.calcsize(fmt)
@@ -607,13 +606,13 @@ def bap_ev_baa_found_(bap, data, data_len):
           'advertiser_sid': advertiser_sid,
           'padv_interval': padv_interval}
 
-    logging.debug(f'Broadcast Audio Announcement received: {ev}')
+    logging.debug("Broadcast Audio Announcement received: %r", ev)
 
     bap.event_received(defs.BTP_BAP_EV_BAA_FOUND, ev)
 
 
 def bap_ev_bis_found_(bap, data, data_len):
-    logging.debug('%s %r', bap_ev_bis_found_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6s3s3sBBBHHB'
     fmt_len = struct.calcsize(fmt)
@@ -639,13 +638,13 @@ def bap_ev_bis_found_(bap, data, data_len):
           'cid': cid,
           'ltvs': ltvs}
 
-    logging.debug(f'BIS found: {ev}')
+    logging.debug("BIS found: %r", ev)
 
     bap.event_received(defs.BTP_BAP_EV_BIS_FOUND, ev)
 
 
 def bap_ev_bis_synced_received_(bap, data, data_len):
-    logging.debug('%s %r', bap_ev_bis_synced_received_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6s3sB'
     fmt_len = struct.calcsize(fmt)
@@ -662,13 +661,13 @@ def bap_ev_bis_synced_received_(bap, data, data_len):
           'broadcast_id': broadcast_id,
           'bis_id': bis_id}
 
-    logging.debug(f'BIS synced: {ev}')
+    logging.debug("BIS synced: %r", ev)
 
     bap.event_received(defs.BTP_BAP_EV_BIS_SYNCED, ev)
 
 
 def bap_ev_bis_stream_received_(bap, data, data_len):
-    logging.debug('%s %r', bap_ev_bis_stream_received_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6s3sBB'
     fmt_len = struct.calcsize(fmt)
@@ -688,13 +687,13 @@ def bap_ev_bis_stream_received_(bap, data, data_len):
           'bis_id': bis_id,
           'bid_data': bis_data}
 
-    logging.debug(f'BIS data received: {ev}')
+    logging.debug("BIS data received: %r", ev)
 
     bap.event_received(defs.BTP_BAP_EV_BIS_STREAM_RECEIVED, ev)
 
 
 def bap_ev_scan_delegator_found_(bap, data, data_len):
-    logging.debug('%s %r', bap_ev_scan_delegator_found_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6s'
     fmt_len = struct.calcsize(fmt)
@@ -708,13 +707,13 @@ def bap_ev_scan_delegator_found_(bap, data, data_len):
     ev = {'addr_type': addr_type,
           'addr': addr}
 
-    logging.debug(f'Scan Delegator found: {ev}')
+    logging.debug("Scan Delegator found: %r", ev)
 
     bap.event_received(defs.BTP_BAP_EV_SCAN_DELEGATOR_FOUND, ev)
 
 
 def bap_ev_broadcast_receive_state_(bap, data, data_len):
-    logging.debug('%s %r', bap_ev_broadcast_receive_state_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sBB6sB3sBBB'
     fmt_len = struct.calcsize(fmt)
@@ -743,13 +742,13 @@ def bap_ev_broadcast_receive_state_(bap, data, data_len):
           'subgroups': subgroups,
           }
 
-    logging.debug(f'Broadcast Receive State event: {ev}')
+    logging.debug("Broadcast Receive State event: %r", ev)
 
     bap.event_received(defs.BTP_BAP_EV_BROADCAST_RECEIVE_STATE, ev)
 
 
 def bap_ev_pa_syn_req(bap, data, data_len):
-    logging.debug('%s %r', bap_ev_pa_syn_req.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sBB3sBH'
     fmt_len = struct.calcsize(fmt)
@@ -771,7 +770,7 @@ def bap_ev_pa_syn_req(bap, data, data_len):
           'pa_interval': pa_interval,
           }
 
-    logging.debug(f'PA Sync Request event: {ev}')
+    logging.debug("PA Sync Request event: %r", ev)
 
     bap.event_received(defs.BTP_BAP_EV_PA_SYNC_REQ, ev)
 

--- a/autopts/pybtp/btp/btp.py
+++ b/autopts/pybtp/btp/btp.py
@@ -48,7 +48,7 @@ CONTROLLER_INDEX_NONE = CONTROLLER_INDEX_NONE
 
 
 def read_supp_svcs():
-    logging.debug("%s", read_supp_svcs.__name__)
+    logging.debug("")
     iutctl = get_iut()
     stack = get_stack()
 
@@ -59,7 +59,7 @@ def read_supp_svcs():
     btp_hdr_check(tuple_hdr,
                   defs.BTP_SERVICE_ID_CORE,
                   defs.BTP_CORE_CMD_READ_SUPPORTED_SERVICES)
-    logging.debug("%s received %r %r", read_supp_svcs.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     stack.supported_svcs = int.from_bytes(tuple_data[0], 'little')
@@ -444,7 +444,7 @@ def core_reg_svc_gap():
 
 
 def core_unreg_svc_gap():
-    logging.debug("%s", core_unreg_svc_gap.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*CORE['gap_unreg'])
@@ -457,7 +457,7 @@ def core_reg_svc_gatt():
 
 
 def core_unreg_svc_gatt():
-    logging.debug("%s", core_unreg_svc_gatt.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send_wait_rsp(*CORE['gatt_unreg'])
@@ -468,7 +468,7 @@ def core_reg_svc_l2cap():
 
 
 def core_unreg_svc_l2cap():
-    logging.debug("%s", core_unreg_svc_l2cap.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send_wait_rsp(*CORE['l2cap_unreg'])
@@ -479,7 +479,7 @@ def core_reg_svc_mesh():
 
 
 def core_unreg_svc_mesh():
-    logging.debug("%s", core_unreg_svc_mesh.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send_wait_rsp(*CORE['mesh_unreg'])
@@ -490,7 +490,7 @@ def core_reg_svc_mmdl():
 
 
 def core_unreg_svc_mmdl():
-    logging.debug("%s", core_unreg_svc_mmdl.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send_wait_rsp(*CORE['mmdl_unreg'])
@@ -501,7 +501,7 @@ def core_reg_svc_gatt_cl():
 
 
 def core_unreg_svc_gatt_cl():
-    logging.debug("%s", core_unreg_svc_gatt_cl.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send_wait_rsp(*CORE['gatt_cl_unreg'])
@@ -610,7 +610,7 @@ def core_reg_svc_rfcomm():
 # GENERATOR append 1
 
 def core_reg_svc_rsp_succ(service_name):
-    logging.debug("%s", core_reg_svc_rsp_succ.__name__)
+    logging.debug("")
     iutctl = get_iut()
 
     expected_frame = ((defs.BTP_SERVICE_ID_CORE,
@@ -638,7 +638,7 @@ def core_reg_svc_rsp_succ(service_name):
 
 
 def core_unreg_svc_rsp_succ():
-    logging.debug("%s", core_unreg_svc_rsp_succ.__name__)
+    logging.debug("")
     iutctl = get_iut()
 
     expected_frame = ((defs.BTP_SERVICE_ID_CORE,
@@ -659,7 +659,7 @@ def core_unreg_svc_rsp_succ():
 
 
 def core_log_message(message):
-    logging.debug("%s", core_log_message.__name__)
+    logging.debug("")
 
     data = bytearray(struct.pack('H', len(message)) + message.encode('utf-8'))
 
@@ -692,7 +692,7 @@ set_get_stack_method(_get_stack)
 
 
 def event_handler(hdr, data):
-    logging.debug("%s %r %r", event_handler.__name__, hdr, data)
+    logging.debug("%r %r", hdr, data)
     from .event_map import (
         AICS_EV,
         ASCS_EV,

--- a/autopts/pybtp/btp/cap.py
+++ b/autopts/pybtp/btp/cap.py
@@ -40,7 +40,7 @@ def announcements(adv_data):
 
 
 def cap_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", cap_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -62,7 +62,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def cap_discover(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{cap_discover.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
 
@@ -73,7 +73,7 @@ def cap_discover(bd_addr_type=None, bd_addr=None):
 
 
 def cap_unicast_audio_start(cig_id, set_type):
-    logging.debug(f"{cap_unicast_audio_start.__name__}")
+    logging.debug("")
 
     data = struct.pack('B', cig_id)
     data += struct.pack('B', set_type)
@@ -85,7 +85,7 @@ def cap_unicast_audio_start(cig_id, set_type):
 
 
 def cap_unicast_audio_update(metadata_tuple):
-    logging.debug(f"{cap_unicast_audio_update.__name__}")
+    logging.debug("")
 
     data = bytearray()
     stream_count = len(metadata_tuple)
@@ -111,7 +111,7 @@ BTP_CAP_UNICAST_AUDIO_STOP_FLAG_RELEASE = 0b00000001
 
 
 def cap_unicast_audio_stop(cig_id, release):
-    logging.debug(f"{cap_unicast_audio_stop.__name__}")
+    logging.debug("")
 
     data = struct.pack('B', cig_id)
 
@@ -128,7 +128,7 @@ def cap_unicast_audio_stop(cig_id, release):
 
 
 def cap_unicast_setup_ase(config, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{cap_unicast_setup_ase.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', config.ase_id)
@@ -164,7 +164,7 @@ def cap_unicast_setup_ase(config, bd_addr_type=None, bd_addr=None):
 
 def cap_broadcast_source_setup_stream(source_id, subgroup_id, coding_format,
                                       vid, cid, codec_ltvs, metadata_ltvs):
-    logging.debug(f"{cap_broadcast_source_setup_stream.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -192,7 +192,7 @@ def cap_broadcast_source_setup_stream(source_id, subgroup_id, coding_format,
 
 def cap_broadcast_source_setup_subgroup(source_id, subgroup_id, coding_format,
                                         vid, cid, codec_ltvs, metadata_ltvs):
-    logging.debug(f"{cap_broadcast_source_setup_subgroup.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -227,7 +227,7 @@ def cap_broadcast_source_setup(source_id, broadcast_id, sdu_interval, framing, m
                                presentation_delay, encryption, broadcast_code,
                                subgroup_codec_level):
 
-    logging.debug(f"{cap_broadcast_source_setup.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -266,7 +266,7 @@ def cap_broadcast_source_setup(source_id, broadcast_id, sdu_interval, framing, m
 
 
 def cap_broadcast_source_release(source_id):
-    logging.debug(f"{cap_broadcast_source_release.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -278,7 +278,7 @@ def cap_broadcast_source_release(source_id):
 
 
 def cap_broadcast_adv_start(source_id):
-    logging.debug(f"{cap_broadcast_adv_start.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -289,7 +289,7 @@ def cap_broadcast_adv_start(source_id):
 
 
 def cap_broadcast_adv_stop(source_id):
-    logging.debug(f"{cap_broadcast_adv_stop.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -300,7 +300,7 @@ def cap_broadcast_adv_stop(source_id):
 
 
 def cap_broadcast_source_start(source_id):
-    logging.debug(f"{cap_broadcast_source_start.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -311,7 +311,7 @@ def cap_broadcast_source_start(source_id):
 
 
 def cap_broadcast_source_stop(source_id):
-    logging.debug(f"{cap_broadcast_source_stop.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -322,7 +322,7 @@ def cap_broadcast_source_stop(source_id):
 
 
 def cap_broadcast_source_update(source_id, metadata_ltvs):
-    logging.debug(f"{cap_broadcast_source_update.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -339,7 +339,7 @@ def cap_broadcast_source_update(source_id, metadata_ltvs):
 
 
 def cap_ev_discovery_completed_(cap, data, data_len):
-    logging.debug('%s %r', cap_ev_discovery_completed_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sB'
     if len(data) < struct.calcsize(fmt):
@@ -349,14 +349,14 @@ def cap_ev_discovery_completed_(cap, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'CAP Discovery completed: addr {addr} addr_type '
-                  f'{addr_type} status {status}')
+    logging.debug("CAP Discovery completed: addr %r, addr_type %r, status %r",
+                  addr, addr_type, status)
 
     cap.event_received(defs.BTP_CAP_EV_DISCOVERY_COMPLETED, (addr_type, addr, status))
 
 
 def cap_ev_unicast_start_completed_(cap, data, data_len):
-    logging.debug('%s %r', cap_ev_unicast_start_completed_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = 'BB'
     if len(data) < struct.calcsize(fmt):
@@ -364,13 +364,13 @@ def cap_ev_unicast_start_completed_(cap, data, data_len):
 
     cig_id, status = struct.unpack_from(fmt, data)
 
-    logging.debug(f'CAP Unicast Start completed: cig_id {cig_id}, status {status}')
+    logging.debug("CAP Unicast Start completed: cig_id %r, status %r", cig_id, status)
 
     cap.event_received(defs.BTP_CAP_EV_UNICAST_START_COMPLETED, (status,))
 
 
 def cap_ev_unicast_stop_completed_(cap, data, data_len):
-    logging.debug('%s %r', cap_ev_unicast_stop_completed_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = 'BB'
     if len(data) < struct.calcsize(fmt):
@@ -378,7 +378,7 @@ def cap_ev_unicast_stop_completed_(cap, data, data_len):
 
     cig_id, status = struct.unpack_from(fmt, data)
 
-    logging.debug(f'CAP Unicast Stop completed: cig_id {cig_id}, status {status}')
+    logging.debug("CAP Unicast Stop completed: cig_id %r, status %r", cig_id, status)
 
     cap.event_received(defs.BTP_CAP_EV_UNICAST_STOP_COMPLETED, (cig_id, status))
 

--- a/autopts/pybtp/btp/cas.py
+++ b/autopts/pybtp/btp/cas.py
@@ -36,7 +36,7 @@ CAS = {
 
 
 def cas_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", cas_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -58,7 +58,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def cas_set_member_lock(lock, force, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{cas_set_member_lock.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('BB', lock, force)
@@ -70,7 +70,7 @@ def cas_set_member_lock(lock, force, bd_addr_type=None, bd_addr=None):
 
 
 def cas_get_member_rsi(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{cas_get_member_rsi.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
 

--- a/autopts/pybtp/btp/ccp.py
+++ b/autopts/pybtp/btp/ccp.py
@@ -123,7 +123,7 @@ class CallFlags(IntFlag):
 
 
 def ccp_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", ccp_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -145,7 +145,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def ccp_discover_tbs(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_discover_tbs.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
 
@@ -156,7 +156,7 @@ def ccp_discover_tbs(bd_addr_type=None, bd_addr=None):
 
 
 def ccp_accept_call(index, call_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_accept_call.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<BB', index, call_id)
@@ -168,7 +168,7 @@ def ccp_accept_call(index, call_id, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_terminate_call(index, call_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_terminate_call.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<BB', index, call_id)
@@ -180,7 +180,7 @@ def ccp_terminate_call(index, call_id, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_originate_call(index, uri, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_originate_call.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     uri += '\0'
@@ -194,7 +194,7 @@ def ccp_originate_call(index, uri, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_call_state(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_call_state.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -206,7 +206,7 @@ def ccp_read_call_state(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_bearer_name(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_bearer_name.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -218,7 +218,7 @@ def ccp_read_bearer_name(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_bearer_uci(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_bearer_uci.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -230,7 +230,7 @@ def ccp_read_bearer_uci(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_bearer_tech(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_bearer_tech.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -242,7 +242,7 @@ def ccp_read_bearer_tech(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_uri_list(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_uri_list.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -254,7 +254,7 @@ def ccp_read_uri_list(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_signal_strength(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_signal_strength.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -266,7 +266,7 @@ def ccp_read_signal_strength(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_signal_interval(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_signal_interval.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -278,7 +278,7 @@ def ccp_read_signal_interval(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_current_calls(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_current_calls.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -290,7 +290,7 @@ def ccp_read_current_calls(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_ccid(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_ccid.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -302,7 +302,7 @@ def ccp_read_ccid(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_call_uri(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_call_uri.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -314,7 +314,7 @@ def ccp_read_call_uri(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_status_flags(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_status_flags.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -326,7 +326,7 @@ def ccp_read_status_flags(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_optional_opcodes(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_optional_opcodes.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -338,7 +338,7 @@ def ccp_read_optional_opcodes(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_friendly_name(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_friendly_name.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -350,7 +350,7 @@ def ccp_read_friendly_name(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_read_remote_uri(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_read_remote_uri.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<B', index)
@@ -362,7 +362,7 @@ def ccp_read_remote_uri(index, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_set_signal_interval(index, interval, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_set_signal_interval.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<BB', index, interval)
@@ -374,7 +374,7 @@ def ccp_set_signal_interval(index, interval, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_hold_call(index, call_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_hold_call.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<BB', index, call_id)
@@ -386,7 +386,7 @@ def ccp_hold_call(index, call_id, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_retrieve_call(index, call_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_retrieve_call.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('<BB', index, call_id)
@@ -398,7 +398,7 @@ def ccp_retrieve_call(index, call_id, bd_addr_type=None, bd_addr=None):
 
 
 def ccp_join_calls(index, count, call_index: [], bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{ccp_join_calls.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data.extend(struct.pack('<B', index))
@@ -438,7 +438,7 @@ def ccp_await_event(ccp, event, timeout):
 
 
 def ccp_await_discovered(timeout=6000):
-    logging.debug(f"{ccp_await_discovered.__name__}")
+    logging.debug("")
 
     stack = get_stack()
     success = ccp_await_event(stack.ccp, defs.BTP_CCP_EV_DISCOVERED, timeout)
@@ -451,7 +451,7 @@ def ccp_await_discovered(timeout=6000):
 
 def ccp_ev_discovered(ccp, data, data_len):
     status, tbs_count, gtbs_found = struct.unpack('<IB?', data)
-    logging.debug(f"{ccp_ev_discovered.__name__} status: %u tbs count: %u gbts: %s" % (status, tbs_count, gtbs_found))
+    logging.debug("status: %u tbs count: %u gbts: %s", status, tbs_count, gtbs_found)
 
     event_dict = {
         'count': 0,
@@ -463,7 +463,7 @@ def ccp_ev_discovered(ccp, data, data_len):
 
 
 def ccp_ev_chrc_handles(ccp, data, data_len):
-    logging.debug('%s %r', ccp_ev_chrc_handles.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<HHHHHHHHHHHHHHHH'
     if len(data) < struct.calcsize(fmt):
@@ -474,15 +474,14 @@ def ccp_ev_chrc_handles(ccp, data, data_len):
         optional_opcodes, termination_reasons, incoming_call,\
         friendly_name = struct.unpack_from(fmt, data)
 
-    logging.debug(f'CCP Characteristics Handles: Bearer Provider Name {provider_name},'
-                  f' Bearer UCI Handle {bearer_uci}, Bearer Technology {bearer_technology}, '
-                  f'URI List Handle {uri_list}, Signal Strength {signal_strength},'
-                  f' Signal Interval Handle {signal_interval}, Current Calls {current_calls},'
-                  f'CCID Handle {ccid}, Status Flags {status_flags}, Bearer URI {bearer_uri}, '
-                  f'Call State {call_state}, Call Control Point {control_point}, '
-                  f'Optional Opcodes Handle {optional_opcodes},'
-                  f'Termination Reasons {termination_reasons}, Incoming Call {incoming_call},'
-                  f'Friendly Name {friendly_name}')
+    logging.debug(
+        "CCP Characteristics Handles: Bearer Provider Name %r, Bearer UCI Handle %r, Bearer Technology %r,"
+        "URI List Handle %r, Signal Strength %r, Signal Interval Handle %r, Current Calls %r,CCID Handle %r,"
+        "Status Flags %r, Bearer URI %r, Call State %r, Call Control Point %r, Optional Opcodes Handle %r,"
+        "Termination Reasons %r, Incoming Call %r,Friendly Name %r",
+        provider_name, bearer_uci, bearer_technology, uri_list, signal_strength, signal_interval, current_calls, ccid,
+        status_flags, bearer_uri, call_state, control_point, optional_opcodes, termination_reasons, incoming_call,
+        friendly_name)
 
     ccp.event_received_2(defs.BTP_CCP_EV_CHRC_HANDLES, (provider_name, bearer_uci, bearer_technology,
                                                     uri_list, signal_strength, signal_interval,
@@ -493,7 +492,7 @@ def ccp_ev_chrc_handles(ccp, data, data_len):
 
 
 def ccp_ev_chrc_val(ccp, data, data_len):
-    logging.debug('%s %r', ccp_ev_chrc_val.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbBB'
     if len(data) < struct.calcsize(fmt):
@@ -503,16 +502,15 @@ def ccp_ev_chrc_val(ccp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'CCP Characteristic Read: addr {addr} addr_type '
-                  f'{addr_type}, status {status}, Instance index {inst_index},'
-                  f' Value {value}')
+    logging.debug("CCP Characteristic Read: addr %r, addr_type %r, status %r, Instance index %r, Value %r",
+                  addr, addr_type, status, inst_index, value)
 
     ccp.event_received_2(defs.BTP_CCP_EV_CHRC_VAL, (addr_type, addr, status, inst_index,
                                                 value))
 
 
 def ccp_ev_chrc_str(ccp, data, data_len):
-    logging.debug('%s %r', ccp_ev_chrc_str.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbBB'
 
@@ -525,14 +523,14 @@ def ccp_ev_chrc_str(ccp, data, data_len):
 
     str_data = struct.unpack_from(f'<{data_len}s', data, offset=fmt_size)[0].decode('utf-8')
 
-    logging.debug(f'CCP Characteristic String data: addr {addr} addr_type '
-                  f'{addr_type}, status {status}, String Data: {str_data}')
+    logging.debug("CCP Characteristic String data: addr %r, addr_type %r, status %r, String Data: %r",
+                  addr, addr_type, status, str_data)
 
     ccp.event_received_2(defs.BTP_CCP_EV_CHRC_STR, (addr_type, addr, status, inst_index, str_data))
 
 
 def ccp_ev_cp(ccp, data, data_len):
-    logging.debug('%s %r', ccp_ev_cp.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sb'
 
@@ -543,14 +541,14 @@ def ccp_ev_cp(ccp, data, data_len):
     addr_type, addr, status = struct.unpack_from(fmt, data)
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'CCP Control Point event: addr {addr} addr_type '
-                  f'{addr_type}, status {status}')
+    logging.debug("CCP Control Point event: addr %r, addr_type %r, status %r",
+                  addr, addr_type, status)
 
     ccp.event_received_2(defs.BTP_CCP_EV_CP, (addr_type, addr, status))
 
 
 def ccp_ev_current_calls(ccp, data, data_len):
-    logging.debug('%s %r', ccp_ev_current_calls.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sb'
 
@@ -561,14 +559,14 @@ def ccp_ev_current_calls(ccp, data, data_len):
     addr_type, addr, status = struct.unpack_from(fmt, data)
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'CCP Current Calls event: addr {addr} addr_type '
-                  f'{addr_type}, status {status}')
+    logging.debug("CCP Current Calls event: addr %r, addr_type %r, status %r",
+                  addr, addr_type, status)
 
     ccp.event_received_2(defs.BTP_CCP_EV_CURRENT_CALLS, (addr_type, addr, status))
 
 
 def ccp_await_call_state(timeout=1000):
-    logging.debug(f"{ccp_await_call_state.__name__}")
+    logging.debug("")
 
     stack = get_stack()
     success = ccp_await_event(stack.ccp, defs.BTP_CCP_EV_CALL_STATES, timeout)
@@ -616,9 +614,7 @@ def ccp_ev_call_states(ccp, data, data_len):
         states_fmt += f" index:{index} {CallState(state)} flags:{ccp_fmt_flags(flags)}"
         states_fmt += " }"
 
-    logging.debug(
-        f"{ccp_ev_call_states.__name__} status: {status} index: 0x{index:02x} calls: {call_count} {states_fmt}"
-    )
+    logging.debug("status: %r, index: 0x%r, calls: %r, %r", status, index, call_count, states_fmt)
 
     ccp.event_received(defs.BTP_CCP_EV_CALL_STATES, event_dict)
 

--- a/autopts/pybtp/btp/core.py
+++ b/autopts/pybtp/btp/core.py
@@ -20,7 +20,7 @@ from autopts.pybtp import defs
 
 
 def core_iut_ready_ev(core, data, data_len):
-    logging.debug("%s", core_iut_ready_ev.__name__)
+    logging.debug("")
 
     core.event_received(defs.BTP_CORE_EV_IUT_READY, True)
 

--- a/autopts/pybtp/btp/csip.py
+++ b/autopts/pybtp/btp/csip.py
@@ -51,7 +51,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def csip_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", csip_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -64,7 +64,7 @@ def csip_command_rsp_succ(timeout=20.0):
 
 
 def csip_discover(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{csip_discover.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
 
@@ -75,7 +75,7 @@ def csip_discover(bd_addr_type=None, bd_addr=None):
 
 
 def csip_set_coordinator_lock(addr_list=None):
-    logging.debug(f"{csip_set_coordinator_lock.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -97,7 +97,7 @@ def csip_set_coordinator_lock(addr_list=None):
 
 
 def csip_set_coordinator_release(addr_list=None):
-    logging.debug(f"{csip_set_coordinator_release.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -119,7 +119,7 @@ def csip_set_coordinator_release(addr_list=None):
 
 
 def csip_start_ordered_access(flags=0x00):
-    logging.debug(f"{csip_start_ordered_access.__name__}")
+    logging.debug("")
 
     # RFU
     data = struct.pack('B', flags)
@@ -131,7 +131,7 @@ def csip_start_ordered_access(flags=0x00):
 
 
 def csip_ev_discovery_completed(csip, data, data_len):
-    logging.debug('%s %r', csip_ev_discovery_completed.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbHHHH'
     if len(data) < struct.calcsize(fmt):
@@ -141,11 +141,10 @@ def csip_ev_discovery_completed(csip, data, data_len):
         rank_handle = struct.unpack_from(fmt, data)
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'CSIP Discovery Completed: addr {addr},'
-                  f' addr_type {addr_type},'
-                  f' status {status}, Set Sirk Handle {sirk_handle},'
-                  f' Set Size Handle {size_handle}, Set Lock Handle {lock_handle},'
-                  f' Rank Handle {rank_handle}')
+    logging.debug(
+        "CSIP Discovery Completed: addr %r, addr_type %r, status %r, Set Sirk Handle %r,"
+        "Set Size Handle %r, Set Lock Handle %r, Rank Handle %r",
+        addr, addr_type, status, sirk_handle, size_handle, lock_handle, rank_handle)
 
     csip.event_received(defs.BTP_CSIP_EV_DISCOVERED, (addr_type, addr, status,
                                                   sirk_handle, size_handle,
@@ -153,7 +152,7 @@ def csip_ev_discovery_completed(csip, data, data_len):
 
 
 def csip_sirk_ev(csip, data, data_len):
-    logging.debug('%s %r', csip_sirk_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6s'
     if len(data) < struct.calcsize(fmt):
@@ -164,14 +163,13 @@ def csip_sirk_ev(csip, data, data_len):
     sirk_bytes = data[7:]
     sirk_hex = le_bytes_to_hex_str(sirk_bytes)
 
-    logging.debug(f'CSIP Sirk event: addr {addr}, addr_type {addr_type},'
-                  f' sirk {sirk_hex}')
+    logging.debug("CSIP Sirk event: addr %r, addr_type %r, sirk %r", addr, addr_type, sirk_hex)
 
     csip.event_received(defs.BTP_CSIP_EV_SIRK, (addr_type, addr, sirk_hex))
 
 
 def csip_lock_ev(csip, data, data_len):
-    logging.debug('%s %r', csip_lock_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<b'
     if len(data) < struct.calcsize(fmt):
@@ -179,7 +177,7 @@ def csip_lock_ev(csip, data, data_len):
 
     lock_val = struct.unpack_from(fmt, data)
 
-    logging.debug(f'CSIP Set Lock status {lock_val}')
+    logging.debug("CSIP Set Lock status %r", lock_val)
 
     csip.event_received(defs.BTP_CSIP_EV_LOCK, lock_val)
 

--- a/autopts/pybtp/btp/csis.py
+++ b/autopts/pybtp/btp/csis.py
@@ -45,7 +45,7 @@ CSIS = {
 
 
 def csis_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", csis_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -67,7 +67,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def csis_set_member_lock(lock, force, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{csis_set_member_lock.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('BB', lock, force)
@@ -79,7 +79,7 @@ def csis_set_member_lock(lock, force, bd_addr_type=None, bd_addr=None):
 
 
 def csis_get_member_rsi(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{csis_get_member_rsi.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
 
@@ -91,7 +91,7 @@ def csis_get_member_rsi(bd_addr_type=None, bd_addr=None):
 
 
 def csis_set_sirk_type(sirk_type):
-    logging.debug(f"{csis_set_sirk_type.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data.extend(struct.pack('<b', sirk_type))
@@ -104,7 +104,7 @@ def csis_set_sirk_type(sirk_type):
 
 
 def csis_set_sirk(sirk):
-    logging.debug(f"{csis_set_sirk.__name__}")
+    logging.debug("")
 
     data = bytearray()
     # Send SIRK as 16 bytes hex string
@@ -118,7 +118,7 @@ def csis_set_sirk(sirk):
 
 
 def csis_set_set_size(size, rank):
-    logging.debug(f"{csis_set_set_size.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data.extend(struct.pack('<BB', size, rank))

--- a/autopts/pybtp/btp/gap.py
+++ b/autopts/pybtp/btp/gap.py
@@ -174,7 +174,7 @@ GAP = {
 
 
 def gap_new_settings_ev_(gap, data, data_len):
-    logging.debug("%s %r", gap_new_settings_ev_.__name__, data)
+    logging.debug("%r", data)
 
     data_fmt = '<I'
 
@@ -184,7 +184,7 @@ def gap_new_settings_ev_(gap, data, data_len):
 
 
 def gap_device_found_ev_(gap, data, data_len):
-    logging.debug("%s %r", gap_device_found_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sBBH'
     if len(data) < struct.calcsize(fmt):
@@ -206,7 +206,7 @@ def gap_device_found_ev_(gap, data, data_len):
 
 
 def gap_connected_ev_(gap, data, data_len):
-    logging.debug("%s %r", gap_connected_ev_.__name__, data)
+    logging.debug("%r", data)
 
     hdr_fmt = '<B6sHHH'
 
@@ -219,7 +219,7 @@ def gap_connected_ev_(gap, data, data_len):
 
 
 def gap_disconnected_ev_(gap, data, data_len):
-    logging.debug("%s %r", gap_disconnected_ev_.__name__, data)
+    logging.debug("%r", data)
 
     hdr_fmt = '<B6s'
     addr_type, addr = struct.unpack_from(hdr_fmt, data)
@@ -229,7 +229,7 @@ def gap_disconnected_ev_(gap, data, data_len):
 
 
 def gap_passkey_disp_ev_(gap, data, data_len):
-    logging.debug("%s %r", gap_passkey_disp_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sI'
 
@@ -246,7 +246,7 @@ def gap_passkey_disp_ev_(gap, data, data_len):
 
 
 def gap_identity_resolved_ev_(gap, data, data_len):
-    logging.debug("%s", gap_identity_resolved_ev_.__name__)
+    logging.debug("")
 
     logging.debug("received %r", data)
 
@@ -270,7 +270,7 @@ def gap_identity_resolved_ev_(gap, data, data_len):
 
 
 def gap_conn_param_update_ev_(gap, data, data_len):
-    logging.debug("%s", gap_conn_param_update_ev_.__name__)
+    logging.debug("")
 
     logging.debug("received %r", data)
 
@@ -291,7 +291,7 @@ def gap_conn_param_update_ev_(gap, data, data_len):
 
 
 def gap_sec_level_changed_ev_(gap, data, data_len):
-    logging.debug("%s", gap_sec_level_changed_ev_.__name__)
+    logging.debug("")
 
     logging.debug("received %r", data)
 
@@ -308,7 +308,7 @@ def gap_sec_level_changed_ev_(gap, data, data_len):
 
 
 def gap_pairing_consent_ev_(gap, data, data_len):
-    logging.debug("%s", gap_pairing_consent_ev_.__name__)
+    logging.debug("")
 
     logging.debug("received %r", data)
 
@@ -324,7 +324,7 @@ def gap_pairing_consent_ev_(gap, data, data_len):
 
 def gap_pairing_failed_ev_(gap, data, data_len):
     stack = get_stack()
-    logging.debug("%s", gap_pairing_failed_ev_.__name__)
+    logging.debug("")
 
     logging.debug("received %r", data)
 
@@ -341,7 +341,7 @@ def gap_pairing_failed_ev_(gap, data, data_len):
 
 
 def gap_bond_lost_ev_(gap, data, data_len):
-    logging.debug("%s", gap_bond_lost_ev_.__name__)
+    logging.debug("")
 
     logging.debug("received %r", data)
 
@@ -357,33 +357,33 @@ def gap_bond_lost_ev_(gap, data, data_len):
 
 
 def gap_padv_sync_established_ev_(gap, data, data_len):
-    logging.debug("%s", gap_padv_sync_established_ev_.__name__)
+    logging.debug("")
     stack = get_stack()
 
     stack.gap.periodic_sync_established_rxed = True
 
 
 def gap_padv_sync_lost_ev_(gap, data, data_len):
-    logging.debug("%s", gap_padv_sync_lost_ev_.__name__)
+    logging.debug("")
     stack = get_stack()
 
     stack.gap.periodic_sync_lost_rxed = True
 
 
 def gap_padv_report_ev_(gap, data, data_len):
-    logging.debug("%s", gap_padv_report_ev_.__name__)
+    logging.debug("")
     stack = get_stack()
     stack.gap.periodic_report_rxed = True
 
 
 def gap_padv_transfer_received_ev_(gap, data, data_len):
-    logging.debug("%s", gap_padv_transfer_received_ev_.__name__)
+    logging.debug("")
     stack = get_stack()
     stack.gap.periodic_transfer_received = True
 
 
 def gap_big_sync_established_ev_(gap, data, data_len):
-    logging.debug("%s", gap_big_sync_established_ev_.__name__)
+    logging.debug("")
     stack = get_stack()
 
     fmt = '<B6sIBBIBHH'
@@ -397,7 +397,7 @@ def gap_big_sync_established_ev_(gap, data, data_len):
 
 
 def gap_big_sync_lost_ev_(gap, data, data_len):
-    logging.debug("%s", gap_big_sync_lost_ev_.__name__)
+    logging.debug("")
     stack = get_stack()
 
     stack.gap.big_sync_established = False
@@ -407,7 +407,7 @@ def gap_big_sync_lost_ev_(gap, data, data_len):
 
 
 def gap_bis_data_path_setup_ev_(gap, data, data_len):
-    logging.debug("%s", gap_bis_data_path_setup_ev_.__name__)
+    logging.debug("")
     stack = get_stack()
 
     fmt = '<B6sB'
@@ -417,7 +417,7 @@ def gap_bis_data_path_setup_ev_(gap, data, data_len):
 
 
 def gap_bis_stream_received_ev_(gap, data, data_len):
-    logging.debug("%s", gap_bis_stream_received_ev_.__name__)
+    logging.debug("")
     stack = get_stack()
 
     fmt = '<B6sBBIHB'
@@ -439,7 +439,7 @@ def gap_bis_stream_received_ev_(gap, data, data_len):
 
 
 def gap_passkey_confirm_req_ev_(gap, data, data_len):
-    logging.debug("%s", gap_passkey_confirm_req_ev_.__name__)
+    logging.debug("")
     iutctl = get_iut()
 
     fmt = '<B6sI'
@@ -457,7 +457,7 @@ def gap_passkey_confirm_req_ev_(gap, data, data_len):
 
 
 def gap_passkey_entry_req_ev_(gap, data, data_len):
-    logging.debug("%s", gap_passkey_entry_req_ev_.__name__)
+    logging.debug("")
     iutctl = get_iut()
 
     fmt = '<B6s'
@@ -471,7 +471,7 @@ def gap_passkey_entry_req_ev_(gap, data, data_len):
 
 def gap_encryption_change_ev_(gap, data, data_len):
     stack = get_stack()
-    logging.debug("%s", gap_encryption_change_ev_.__name__)
+    logging.debug("")
 
     logging.debug("enc change received %r", data)
 
@@ -488,7 +488,7 @@ def gap_encryption_change_ev_(gap, data, data_len):
 
 
 def gap_peer_car_status_ev_(gap, data, data_len):
-    logging.debug("%s", gap_peer_car_status_ev_.__name__)
+    logging.debug("")
     stack = get_stack()
     fmt = '<B6sB'
     _addr_t, _addr, _car = struct.unpack_from(fmt, data)
@@ -502,7 +502,7 @@ def gap_peer_car_status_ev_(gap, data, data_len):
 
 def gap_subrate_change_ev_(gap, data, data_len):
     stack = get_stack()
-    logging.debug("%s", gap_subrate_change_ev_.__name__)
+    logging.debug("")
 
     logging.debug("Subrate change received %r", data)
 
@@ -524,7 +524,7 @@ def gap_subrate_change_ev_(gap, data, data_len):
 
 
 def gap_padv_biginfo_ev_(gap, data, data_len):
-    logging.debug("%s %r", gap_padv_biginfo_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sHBBBHBBBHIHBBB'
     if len(data) < struct.calcsize(fmt):
@@ -573,7 +573,7 @@ GAP_EV = {
 
 
 def __gap_current_settings_update(settings):
-    logging.debug("%s %r", __gap_current_settings_update.__name__, settings)
+    logging.debug("%r", settings)
     if isinstance(settings, tuple):
         fmt = '<I'
         if len(settings[0]) != struct.calcsize(fmt):
@@ -627,7 +627,7 @@ def gap_wait_for_sec_lvl_change(level, timeout=30):
 
 
 def gap_adv_ind_on(ad=None, sd=None, duration=AdDuration.forever, own_addr_type=OwnAddrType.le_identity_address):
-    logging.debug("%s %r %r", gap_adv_ind_on.__name__, ad, sd)
+    logging.debug("%r %r", ad, sd)
 
     if ad is None:
         ad = {}
@@ -690,7 +690,7 @@ def gap_adv_ind_on(ad=None, sd=None, duration=AdDuration.forever, own_addr_type=
 
 
 def gap_adv_off():
-    logging.debug("%s", gap_adv_off.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -707,7 +707,7 @@ def gap_adv_off():
 
 
 def gap_direct_adv_on(addr, addr_type, high_duty=0, peer_rpa=0):
-    logging.debug("%s %r %r %r %r", gap_direct_adv_on.__name__, addr,
+    logging.debug("%r %r %r %r", addr,
                   addr_type, high_duty, peer_rpa)
 
     stack = get_stack()
@@ -739,7 +739,7 @@ def gap_direct_adv_on(addr, addr_type, high_duty=0, peer_rpa=0):
 
 
 def gap_conn(bd_addr=None, bd_addr_type=None, own_addr_type=OwnAddrType.le_identity_address):
-    logging.debug("%s %r %r", gap_conn.__name__, bd_addr, bd_addr_type)
+    logging.debug("%r %r", bd_addr, bd_addr_type)
     iutctl = get_iut()
 
     data_ba = bytearray()
@@ -763,7 +763,7 @@ def set_filter_accept_list(address_list=None):
         address_list -- address type and address as tuples:
             address_list = [(0, 'DB:F5:72:56:C9:EF'), (0, 'DB:F5:72:56:C9:EF')]
     """
-    logging.debug("%s %s", set_filter_accept_list.__name__, address_list)
+    logging.debug("%s", address_list)
     iutctl = get_iut()
 
     data_ba = bytearray()
@@ -792,7 +792,7 @@ def gap_rpa_conn(description, own_addr_type=OwnAddrType.le_identity_address):
     Arguments:
     description -- description provided in PTS MMI.
     """
-    logging.debug("%s %s", gap_conn.__name__, description)
+    logging.debug("%s", description)
     iutctl = get_iut()
 
     bd_addr = re.search("[a-fA-F0-9]{12}", description).group(0)
@@ -811,7 +811,7 @@ def gap_rpa_conn(description, own_addr_type=OwnAddrType.le_identity_address):
 
 
 def gap_disconn(bd_addr=None, bd_addr_type=None):
-    logging.debug("%s %r %r", gap_disconn.__name__, bd_addr, bd_addr_type)
+    logging.debug("%r %r", bd_addr, bd_addr_type)
     iutctl = get_iut()
 
     stack = get_stack()
@@ -826,7 +826,7 @@ def gap_disconn(bd_addr=None, bd_addr_type=None):
 
 
 def verify_not_connected(description):
-    logging.debug("%s", verify_not_connected.__name__)
+    logging.debug("")
     stack = get_stack()
 
     gap_wait_for_connection(5)
@@ -837,7 +837,7 @@ def verify_not_connected(description):
 
 
 def gap_set_io_cap(io_cap):
-    logging.debug("%s %r", gap_set_io_cap.__name__, io_cap)
+    logging.debug("%r", io_cap)
     iutctl = get_iut()
     stack = get_stack()
     stack.gap.io_cap = io_cap
@@ -848,7 +848,7 @@ def gap_set_io_cap(io_cap):
 
 
 def gap_pair(bd_addr=None, bd_addr_type=None):
-    logging.debug("%s %r %r", gap_pair.__name__, bd_addr, bd_addr_type)
+    logging.debug("%r %r", bd_addr, bd_addr_type)
     iutctl = get_iut()
 
     gap_wait_for_connection()
@@ -867,7 +867,7 @@ def gap_pair(bd_addr=None, bd_addr_type=None):
 
 def gap_pair_v2(bd_addr=None, bd_addr_type=None, mode=defs.BTP_GAP_CMD_PAIR_V2_MODE_ANY,
                 level=defs.BTP_GAP_CMD_PAIR_V2_LEVEL_ANY, flags=defs.BTP_GAP_CMD_PAIR_V2_FLAG_NONE):
-    logging.debug("%s %r %r %r %r %r", gap_pair_v2.__name__, bd_addr, bd_addr_type, mode, level,
+    logging.debug("%r %r %r %r %r", bd_addr, bd_addr_type, mode, level,
                   flags)
     iutctl = get_iut()
 
@@ -889,7 +889,7 @@ def gap_pair_v2(bd_addr=None, bd_addr_type=None, mode=defs.BTP_GAP_CMD_PAIR_V2_M
 
 
 def gap_unpair(bd_addr=None, bd_addr_type=None):
-    logging.debug("%s %r %r", gap_unpair.__name__, bd_addr, bd_addr_type)
+    logging.debug("%r %r", bd_addr, bd_addr_type)
     iutctl = get_iut()
 
     data_ba = bytearray()
@@ -905,7 +905,7 @@ def gap_unpair(bd_addr=None, bd_addr_type=None):
 
 
 def gap_passkey_entry_rsp(bd_addr, bd_addr_type, passkey):
-    logging.debug("%s %r %r", gap_passkey_entry_rsp.__name__, bd_addr,
+    logging.debug("%r %r", bd_addr,
                   bd_addr_type)
     iutctl = get_iut()
 
@@ -927,7 +927,7 @@ def gap_passkey_entry_rsp(bd_addr, bd_addr_type, passkey):
 
 
 def gap_passkey_confirm_rsp(bd_addr, bd_addr_type, passkey):
-    logging.debug("%s %r %r", gap_passkey_confirm_rsp.__name__, bd_addr,
+    logging.debug("%r %r", bd_addr,
                   bd_addr_type)
     iutctl = get_iut()
 
@@ -950,7 +950,7 @@ def gap_passkey_confirm_rsp(bd_addr, bd_addr_type, passkey):
 
 
 def gap_reset():
-    logging.debug("%s", gap_reset.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*GAP['reset'])
@@ -959,7 +959,7 @@ def gap_reset():
 
 
 def gap_set_conn():
-    logging.debug("%s", gap_set_conn.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -976,7 +976,7 @@ def gap_set_conn():
 
 
 def gap_set_nonconn():
-    logging.debug("%s", gap_set_nonconn.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -993,7 +993,7 @@ def gap_set_nonconn():
 
 
 def gap_set_nondiscov():
-    logging.debug("%s", gap_set_nondiscov.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -1010,7 +1010,7 @@ def gap_set_nondiscov():
 
 
 def gap_set_gendiscov():
-    logging.debug("%s", gap_set_gendiscov.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1021,7 +1021,7 @@ def gap_set_gendiscov():
 
 
 def gap_set_limdiscov():
-    logging.debug("%s", gap_set_limdiscov.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1032,7 +1032,7 @@ def gap_set_limdiscov():
 
 
 def gap_set_powered_on():
-    logging.debug("%s", gap_set_powered_on.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1043,7 +1043,7 @@ def gap_set_powered_on():
 
 
 def gap_set_powered_off():
-    logging.debug("%s", gap_set_powered_off.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1054,7 +1054,7 @@ def gap_set_powered_off():
 
 
 def gap_set_bondable_on():
-    logging.debug("%s", gap_set_bondable_on.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -1071,7 +1071,7 @@ def gap_set_bondable_on():
 
 
 def gap_set_bondable_off():
-    logging.debug("%s", gap_set_bondable_off.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -1097,7 +1097,7 @@ def gap_start_discov(transport='le', discov_type='active', mode='general'):
     mode: <general, limited, observe>
 
     """
-    logging.debug("%s", gap_start_discov.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1125,7 +1125,7 @@ def gap_start_discov(transport='le', discov_type='active', mode='general'):
 
 
 def gap_stop_discov():
-    logging.debug("%s", gap_stop_discov.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1138,7 +1138,7 @@ def gap_stop_discov():
 
 
 def gap_read_ctrl_info():
-    logging.debug("%s", gap_read_ctrl_info.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1173,7 +1173,7 @@ def gap_read_ctrl_info():
 
 
 def gap_command_rsp_succ(op=None):
-    logging.debug("%s", gap_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1187,7 +1187,7 @@ def gap_command_rsp_succ(op=None):
 
 def gap_conn_param_update(bd_addr, bd_addr_type, conn_itvl_min,
                           conn_itvl_max, conn_latency, supervision_timeout):
-    logging.debug("%s %r %r 0x%04x 0x%04x 0x%04x 0x%04x", gap_conn_param_update.__name__,
+    logging.debug("%r %r 0x%04x 0x%04x 0x%04x 0x%04x",
                   bd_addr, bd_addr_type, conn_itvl_min, conn_itvl_max, conn_latency, supervision_timeout)
     iutctl = get_iut()
 
@@ -1216,7 +1216,7 @@ def gap_conn_param_update(bd_addr, bd_addr_type, conn_itvl_min,
 
 
 def gap_oob_legacy_set_data(oob_data):
-    logging.debug("%s %r", gap_oob_legacy_set_data.__name__, oob_data)
+    logging.debug("%r", oob_data)
     iutctl = get_iut()
 
     data_ba = hex_str_to_le_bytes(oob_data)
@@ -1228,13 +1228,13 @@ def gap_oob_legacy_set_data(oob_data):
 
 
 def gap_oob_sc_get_local_data():
-    logging.debug("%s", gap_oob_sc_get_local_data.__name__)
+    logging.debug("")
     iutctl = get_iut()
 
     iutctl.btp_socket.send(*GAP['oob_sc_get_local_data'], data=bytearray())
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gap_oob_sc_get_local_data.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GAP,
@@ -1249,7 +1249,7 @@ def gap_oob_sc_get_local_data():
 
 
 def gap_oob_sc_set_remote_data(r, c):
-    logging.debug("%s %r %r", gap_oob_sc_set_remote_data.__name__, r, c)
+    logging.debug("%r %r", r, c)
     iutctl = get_iut()
 
     data_ba = bytearray()
@@ -1266,7 +1266,7 @@ def gap_oob_sc_set_remote_data(r, c):
 
 
 def gap_set_mitm_on():
-    logging.debug("%s", gap_set_mitm_on.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1276,7 +1276,7 @@ def gap_set_mitm_on():
 
 
 def gap_set_mitm_off():
-    logging.debug("%s", gap_set_mitm_off.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1286,7 +1286,7 @@ def gap_set_mitm_off():
 
 
 def gap_set_privacy_on():
-    logging.debug("%s", gap_set_privacy_on.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -1303,7 +1303,7 @@ def gap_set_privacy_on():
 
 
 def gap_set_privacy_off():
-    logging.debug("%s", gap_set_privacy_off.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -1320,7 +1320,7 @@ def gap_set_privacy_off():
 
 
 def gap_set_sc_only_on():
-    logging.debug("%s", gap_set_sc_only_on.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -1337,7 +1337,7 @@ def gap_set_sc_only_on():
 
 
 def gap_set_sc_only_off():
-    logging.debug("%s", gap_set_sc_only_off.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -1354,7 +1354,7 @@ def gap_set_sc_only_off():
 
 
 def gap_set_min_enc_key_size(enc_key_size):
-    logging.debug("%s %r", gap_set_min_enc_key_size.__name__,
+    logging.debug("%r",
                   enc_key_size)
 
     iutctl = get_iut()
@@ -1368,7 +1368,7 @@ def gap_set_min_enc_key_size(enc_key_size):
 
 
 def gap_set_sc_on():
-    logging.debug("%s", gap_set_sc_on.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -1385,7 +1385,7 @@ def gap_set_sc_on():
 
 
 def gap_set_sc_off():
-    logging.debug("%s", gap_set_sc_off.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -1402,7 +1402,7 @@ def gap_set_sc_off():
 
 
 def gap_set_extended_advertising_on():
-    logging.debug("%s", gap_set_extended_advertising_on.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -1419,7 +1419,7 @@ def gap_set_extended_advertising_on():
 
 
 def gap_set_extended_advertising_off():
-    logging.debug("%s", gap_set_sc_off.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -1453,7 +1453,7 @@ def check_discov_results(addr_type=None, addr=None, discovered=True, eir=None, u
     addr = pts_addr_get(addr)
     addr_type = pts_addr_type_get(addr_type)
 
-    logging.debug("%s %r %r %r %r", check_discov_results.__name__, addr_type,
+    logging.debug("%r %r %r %r", addr_type,
                   addr, discovered, eir)
 
     found = False
@@ -1602,7 +1602,7 @@ def create_ead_adv(payload):
 
 
 def gap_padv_configure(include_tx_power, intvl_min, intvl_max):
-    logging.debug("%s", gap_padv_configure.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data_ba = bytearray(struct.pack("<BHH", include_tx_power,
@@ -1615,7 +1615,7 @@ def gap_padv_configure(include_tx_power, intvl_min, intvl_max):
 
 
 def gap_padv_start(flags=0):
-    logging.debug("%s", gap_padv_start.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data_ba = bytearray(struct.pack('<B', flags))
@@ -1627,7 +1627,7 @@ def gap_padv_start(flags=0):
 
 
 def gap_padv_set_data(data):
-    logging.debug("%s", gap_padv_set_data.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1643,7 +1643,7 @@ def gap_padv_set_data(data):
 
 def gap_padv_create_sync(adv_sid, skip, sync_to, flags,
                          addr_type=None, addr=None):
-    logging.debug("%s", gap_padv_create_sync.__name__)
+    logging.debug("")
 
     if not addr_type or not addr:
         addr_type = pts_addr_type_get(None)
@@ -1661,7 +1661,7 @@ def gap_padv_create_sync(adv_sid, skip, sync_to, flags,
 
 
 def gap_padv_sync_transfer_set_info(svc_data, addr_type=None, addr=None):
-    logging.debug("%s", gap_padv_sync_transfer_set_info.__name__)
+    logging.debug("")
 
     if not addr_type or not addr:
         addr_type = pts_addr_type_get(None)
@@ -1678,7 +1678,7 @@ def gap_padv_sync_transfer_set_info(svc_data, addr_type=None, addr=None):
 
 
 def gap_padv_sync_transfer_start(svc_data, addr_type=None, addr=None):
-    logging.debug("%s", gap_padv_sync_transfer_start.__name__)
+    logging.debug("")
 
     if not addr_type or not addr:
         addr_type = pts_addr_type_get(None)
@@ -1695,7 +1695,7 @@ def gap_padv_sync_transfer_start(svc_data, addr_type=None, addr=None):
 
 
 def gap_padv_sync_transfer_recv(skip, sync_timeout, flags, addr_type=None, addr=None):
-    logging.debug("%s", gap_padv_sync_transfer_recv.__name__)
+    logging.debug("")
 
     if not addr_type or not addr:
         addr_type = pts_addr_type_get(None)
@@ -1712,7 +1712,7 @@ def gap_padv_sync_transfer_recv(skip, sync_timeout, flags, addr_type=None, addr=
 
 def gap_subrate_request(bd_addr, bd_addr_type, subrate_min, subrate_max,
                         conn_latency, cont_num, supervision_timeout):
-    logging.debug("%s", gap_subrate_request.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1742,7 +1742,7 @@ def gap_subrate_request(bd_addr, bd_addr_type, subrate_min, subrate_max,
 
 def gap_big_create_sync(adv_sid, num_bis, bis_bitfield, sync_timeout, broadcast_code=None, mse=0x00,
                         addr_type=None, addr=None):
-    logging.debug("%s", gap_big_create_sync.__name__)
+    logging.debug("")
 
     addr_type = pts_addr_type_get(addr_type)
     addr = addr_str_to_le_bytes(pts_addr_get(addr))
@@ -1774,7 +1774,7 @@ def gap_create_big(bis_id, num_bis, interval, latency, broadcast_code=None,
                    packing=defs.BTP_GAP_CMD_CREATE_BIG_PACKING_SEQUENTIAL,
                    framing=defs.BTP_GAP_CMD_CREATE_BIG_FRAMING_UNFRAMED,
                    rtn=2, phy=defs.BTP_GAP_CMD_CREATE_BIG_PHY_2M):
-    logging.debug("%s", gap_create_big.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1799,7 +1799,7 @@ def gap_create_big(bis_id, num_bis, interval, latency, broadcast_code=None,
 
 
 def gap_bis_broadcast(bis_id, val, val_mtp=None):
-    logging.debug("%s", gap_bis_broadcast.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1819,7 +1819,7 @@ def gap_bis_broadcast(bis_id, val, val_mtp=None):
 
 
 def gap_set_broadcast_code(broadcast_code):
-    logging.debug("%s %r", gap_set_broadcast_code.__name__, broadcast_code)
+    logging.debug("%r", broadcast_code)
     stack = get_stack()
     stack.gap.big_broadcast_code = broadcast_code
 

--- a/autopts/pybtp/btp/gatt.py
+++ b/autopts/pybtp/btp/gatt.py
@@ -118,7 +118,7 @@ GATTC = {
 
 def gatt_attr_value_changed_ev_(gatt, data, data_len):
     (handle, value) = gatts_dec_attr_value_changed_ev_data(data)
-    logging.debug("%s %r %r", gatt_attr_value_changed_ev_.__name__,
+    logging.debug("%r %r",
                   handle, value)
 
     gatt.attr_value_set(handle, binascii.hexlify(value[0]))
@@ -127,7 +127,7 @@ def gatt_attr_value_changed_ev_(gatt, data, data_len):
 
 def gatt_notification_ev_(gatt, data, data_len):
     (addr_type, addr, notification_type, handle, value) = gattc_dec_notification_ev_data(data)
-    logging.debug("%s %r %r %r %r %r", gatt_notification_ev_.__name__,
+    logging.debug("%r %r %r %r %r",
                   addr_type, addr, notification_type, handle, value)
 
     gatt.notification_ev_recv(addr_type, addr, notification_type, handle, value)
@@ -140,7 +140,7 @@ GATT_EV = {
 
 
 def gatts_add_svc(svc_type, uuid):
-    logging.debug("%s %r %r", gatts_add_svc.__name__, svc_type, uuid)
+    logging.debug("%r %r", svc_type, uuid)
 
     iutctl = get_iut()
 
@@ -157,7 +157,7 @@ def gatts_add_svc(svc_type, uuid):
 
 
 def gatts_add_inc_svc(hdl):
-    logging.debug("%s %r", gatts_add_inc_svc.__name__, hdl)
+    logging.debug("%r", hdl)
 
     iutctl = get_iut()
 
@@ -174,7 +174,7 @@ def gatts_add_inc_svc(hdl):
 
 
 def gatts_add_char(hdl, prop, perm, uuid):
-    logging.debug("%s %r %r %r %r", gatts_add_char.__name__, hdl, prop, perm,
+    logging.debug("%r %r %r %r", hdl, prop, perm,
                   uuid)
 
     iutctl = get_iut()
@@ -206,7 +206,7 @@ def gatts_add_char(hdl, prop, perm, uuid):
 
 
 def gatts_set_val(hdl, val):
-    logging.debug("%s %r %r ", gatts_set_val.__name__, hdl, val)
+    logging.debug("%r %r ", hdl, val)
 
     iutctl = get_iut()
 
@@ -233,7 +233,7 @@ def gatts_set_val(hdl, val):
 
 
 def gatts_add_desc(hdl, perm, uuid):
-    logging.debug("%s %r %r %r", gatts_add_desc.__name__, hdl, perm, uuid)
+    logging.debug("%r %r %r", hdl, perm, uuid)
 
     iutctl = get_iut()
 
@@ -260,7 +260,7 @@ def gatts_add_desc(hdl, perm, uuid):
 
 
 def gatts_change_database(start_hdl, end_hdl, vis):
-    logging.debug("%s %r %r %r", gatts_change_database.__name__, start_hdl, end_hdl, vis)
+    logging.debug("%r %r %r", start_hdl, end_hdl, vis)
 
     iutctl = get_iut()
 
@@ -283,7 +283,7 @@ def gatts_change_database(start_hdl, end_hdl, vis):
 
 
 def gatts_notify_mult(bd_addr_type, bd_addr, cnt, handles):
-    logging.debug("%s %r %r", gatts_notify_mult.__name__, cnt, handles)
+    logging.debug("%r %r", cnt, handles)
 
     iutctl = get_iut()
 
@@ -303,7 +303,7 @@ def gatts_notify_mult(bd_addr_type, bd_addr, cnt, handles):
 
 
 def gatts_start_server():
-    logging.debug("%s", gatts_start_server.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*GATTS['start_server'])
@@ -312,7 +312,7 @@ def gatts_start_server():
 
 
 def gatts_get_handle_from_uuid(uuid):
-    logging.debug("%s %r", gatts_get_handle_from_uuid.__name__, uuid)
+    logging.debug("%r", uuid)
 
     iutctl = get_iut()
     data_ba = bytearray()
@@ -336,7 +336,7 @@ def gatts_get_handle_from_uuid(uuid):
 
 
 def remove_handle_from_db(hdl):
-    logging.debug("%s %r", remove_handle_from_db.__name__, hdl)
+    logging.debug("%r", hdl)
 
     iutctl = get_iut()
 
@@ -353,7 +353,7 @@ def remove_handle_from_db(hdl):
 
 
 def gatts_set_enc_key_size(hdl, enc_key_size):
-    logging.debug("%s %r %r", gatts_set_enc_key_size.__name__,
+    logging.debug("%r %r",
                   hdl, enc_key_size)
 
     iutctl = get_iut()
@@ -408,7 +408,7 @@ def gatts_dec_attr_value_changed_ev_data(frame):
 
 
 def gatts_attr_value_changed_ev():
-    logging.debug("%s", gatts_attr_value_changed_ev.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -418,14 +418,14 @@ def gatts_attr_value_changed_ev():
                   defs.BTP_GATT_EV_ATTR_VALUE_CHANGED)
 
     (handle, data) = gatts_dec_attr_value_changed_ev_data(tuple_data[0])
-    logging.debug("%s %r %r", gatts_attr_value_changed_ev.__name__,
+    logging.debug("%r %r",
                   handle, data)
 
     return handle, data
 
 
 def dec_gatts_get_attrs_rp(data, data_len):
-    logging.debug("%s %r %r", dec_gatts_get_attrs_rp.__name__, data, data_len)
+    logging.debug("%r %r", data, data_len)
 
     hdr = '<B'
     hdr_len = struct.calcsize(hdr)
@@ -459,7 +459,7 @@ def dec_gatts_get_attrs_rp(data, data_len):
 
 
 def gatts_get_attrs(start_handle=0x0001, end_handle=0xffff, type_uuid=None):
-    logging.debug("%s %r %r %r", gatts_get_attrs.__name__, start_handle,
+    logging.debug("%r %r %r", start_handle,
                   end_handle, type_uuid)
 
     iutctl = get_iut()
@@ -497,7 +497,7 @@ def gatts_get_attrs(start_handle=0x0001, end_handle=0xffff, type_uuid=None):
 
 
 def gatts_get_attr_val(bd_addr_type, bd_addr, handle):
-    logging.debug("%s %r", gatts_get_attr_val.__name__, handle)
+    logging.debug("%r", handle)
 
     iutctl = get_iut()
 
@@ -529,7 +529,7 @@ def gatts_get_attr_val(bd_addr_type, bd_addr, handle):
 
 
 def gattc_exchange_mtu(bd_addr_type, bd_addr):
-    logging.debug("%s %r %r", gattc_exchange_mtu.__name__, bd_addr_type,
+    logging.debug("%r %r", bd_addr_type,
                   bd_addr)
     iutctl = get_iut()
 
@@ -547,7 +547,7 @@ def gattc_exchange_mtu(bd_addr_type, bd_addr):
 
 
 def gattc_disc_all_prim(bd_addr_type, bd_addr):
-    logging.debug("%s %r %r", gattc_disc_all_prim.__name__, bd_addr_type,
+    logging.debug("%r %r", bd_addr_type,
                   bd_addr)
     iutctl = get_iut()
 
@@ -564,7 +564,7 @@ def gattc_disc_all_prim(bd_addr_type, bd_addr):
 
 
 def gattc_disc_prim_uuid(bd_addr_type, bd_addr, uuid):
-    logging.debug("%s %r %r %r", gattc_disc_prim_uuid.__name__, bd_addr_type,
+    logging.debug("%r %r %r", bd_addr_type,
                   bd_addr, uuid)
     iutctl = get_iut()
 
@@ -584,7 +584,7 @@ def gattc_disc_prim_uuid(bd_addr_type, bd_addr, uuid):
 
 
 def _gattc_find_included_req(bd_addr_type, bd_addr, start_hdl, end_hdl):
-    logging.debug("%s %r %r %r %r", _gattc_find_included_req.__name__,
+    logging.debug("%r %r %r %r",
                   bd_addr_type, bd_addr, start_hdl, end_hdl)
     iutctl = get_iut()
 
@@ -612,14 +612,14 @@ def _gattc_find_included_rsp():
     iutctl = get_iut()
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_find_included_rsp.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
                   defs.BTP_GATT_CMD_FIND_INCLUDED)
 
     incls_list = gatt_dec_disc_rsp(tuple_data[0], "include")
-    logging.debug("%s %r", gattc_find_included_rsp.__name__, incls_list)
+    logging.debug("%r", incls_list)
 
     for incl in incls_list:
         att_handle = f"{incl[0][0]:04X}"
@@ -636,7 +636,7 @@ def _gattc_find_included_rsp():
 
 
 def gattc_find_included(bd_addr_type, bd_addr, start_hdl=None, end_hdl=None):
-    logging.debug("%s %r %r %r %r", gattc_find_included.__name__,
+    logging.debug("%r %r %r %r",
                   bd_addr_type, bd_addr, start_hdl, end_hdl)
     gap_wait_for_connection()
 
@@ -663,8 +663,8 @@ def gattc_disc_all_chrc_find_attrs_rsp(exp_chars, store_attrs=False):
     iutctl = get_iut()
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r",
-                  gattc_disc_all_chrc_find_attrs_rsp.__name__, tuple_hdr,
+    logging.debug("received %r %r",
+                  tuple_hdr,
                   tuple_data)
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
                   defs.BTP_GATT_CMD_DISC_ALL_CHRC)
@@ -696,7 +696,7 @@ def gattc_disc_all_chrc_find_attrs_rsp(exp_chars, store_attrs=False):
 
 
 def gattc_disc_all_chrc(bd_addr_type, bd_addr, start_hdl, stop_hdl, svc=None):
-    logging.debug("%s %r %r %r %r %r", gattc_disc_all_chrc.__name__,
+    logging.debug("%r %r %r %r %r",
                   bd_addr_type, bd_addr, start_hdl, stop_hdl, svc)
     iutctl = get_iut()
 
@@ -742,7 +742,7 @@ def gattc_disc_all_chrc(bd_addr_type, bd_addr, start_hdl, stop_hdl, svc=None):
 
 
 def gattc_disc_chrc_uuid(bd_addr_type, bd_addr, start_hdl, stop_hdl, uuid):
-    logging.debug("%s %r %r %r %r %r", gattc_disc_chrc_uuid.__name__,
+    logging.debug("%r %r %r %r %r",
                   bd_addr_type, bd_addr, start_hdl, stop_hdl, uuid)
     iutctl = get_iut()
 
@@ -773,7 +773,7 @@ def gattc_disc_chrc_uuid(bd_addr_type, bd_addr, start_hdl, stop_hdl, uuid):
 
 
 def gattc_disc_all_desc(bd_addr_type, bd_addr, start_hdl, stop_hdl):
-    logging.debug("%s %r %r %r %r", gattc_disc_all_desc.__name__,
+    logging.debug("%r %r %r %r",
                   bd_addr_type, bd_addr, start_hdl, stop_hdl)
     iutctl = get_iut()
 
@@ -800,7 +800,7 @@ def gattc_disc_all_desc(bd_addr_type, bd_addr, start_hdl, stop_hdl):
 
 
 def gattc_read_char_val(bd_addr_type, bd_addr, char):
-    logging.debug("%s %r %r %r", gattc_read_char_val.__name__, bd_addr_type,
+    logging.debug("%r %r %r", bd_addr_type,
                   bd_addr, char)
 
     char_nb = char[1]
@@ -823,7 +823,7 @@ def gattc_read_char_val(bd_addr_type, bd_addr, char):
 
 
 def gattc_read(bd_addr_type, bd_addr, hdl):
-    logging.debug("%s %r %r %r", gattc_read.__name__, bd_addr_type, bd_addr,
+    logging.debug("%r %r %r", bd_addr_type, bd_addr,
                   hdl)
     iutctl = get_iut()
 
@@ -844,7 +844,7 @@ def gattc_read(bd_addr_type, bd_addr, hdl):
 
 
 def gattc_read_uuid(bd_addr_type, bd_addr, start_hdl, end_hdl, uuid):
-    logging.debug("%s %r %r %r %r %r", gattc_read_uuid.__name__, bd_addr_type,
+    logging.debug("%r %r %r %r %r", bd_addr_type,
                   bd_addr, start_hdl, end_hdl, uuid)
     iutctl = get_iut()
 
@@ -875,7 +875,7 @@ def gattc_read_uuid(bd_addr_type, bd_addr, start_hdl, end_hdl, uuid):
 
 
 def gattc_read_long(bd_addr_type, bd_addr, hdl, off, modif_off=None):
-    logging.debug("%s %r %r %r %r %r", gattc_read_long.__name__, bd_addr_type,
+    logging.debug("%r %r %r %r %r", bd_addr_type,
                   bd_addr, hdl, off, modif_off)
     iutctl = get_iut()
 
@@ -919,7 +919,7 @@ def _create_read_multiple_req(bd_addr_type, bd_addr, *hdls):
 
 
 def gattc_read_multiple(bd_addr_type, bd_addr, *hdls):
-    logging.debug("%s %r %r %r", gattc_read_multiple.__name__, bd_addr_type,
+    logging.debug("%r %r %r", bd_addr_type,
                   bd_addr, hdls)
     iutctl = get_iut()
 
@@ -930,7 +930,7 @@ def gattc_read_multiple(bd_addr_type, bd_addr, *hdls):
 
 
 def gattc_read_multiple_var(bd_addr_type, bd_addr, *hdls):
-    logging.debug("%s %r %r %r", gattc_read_multiple_var.__name__, bd_addr_type,
+    logging.debug("%r %r %r", bd_addr_type,
                   bd_addr, hdls)
     iutctl = get_iut()
 
@@ -941,7 +941,7 @@ def gattc_read_multiple_var(bd_addr_type, bd_addr, *hdls):
 
 
 def gattc_write_without_rsp(bd_addr_type, bd_addr, hdl, val, val_mtp=None):
-    logging.debug("%s %r %r %r %r %r", gattc_write_without_rsp.__name__,
+    logging.debug("%r %r %r %r %r",
                   bd_addr_type, bd_addr, hdl, val, val_mtp)
     iutctl = get_iut()
 
@@ -972,7 +972,7 @@ def gattc_write_without_rsp(bd_addr_type, bd_addr, hdl, val, val_mtp=None):
 
 
 def gattc_signed_write(bd_addr_type, bd_addr, hdl, val, val_mtp=None):
-    logging.debug("%s %r %r %r %r %r", gattc_signed_write.__name__,
+    logging.debug("%r %r %r %r %r",
                   bd_addr_type, bd_addr, hdl, val, val_mtp)
     iutctl = get_iut()
 
@@ -1008,7 +1008,7 @@ def gattc_signed_write(bd_addr_type, bd_addr, hdl, val, val_mtp=None):
 
 
 def gattc_write(bd_addr_type, bd_addr, hdl, val, val_mtp=None):
-    logging.debug("%s %r %r %r %r %r", gattc_write.__name__, bd_addr_type,
+    logging.debug("%r %r %r %r %r", bd_addr_type,
                   bd_addr, hdl, val, val_mtp)
     iutctl = get_iut()
 
@@ -1042,7 +1042,7 @@ def gattc_write(bd_addr_type, bd_addr, hdl, val, val_mtp=None):
 
 
 def gattc_write_long(bd_addr_type, bd_addr, hdl, off, val, length=None):
-    logging.debug("%s %r %r %r %r %r", gattc_write_long.__name__,
+    logging.debug("%r %r %r %r %r",
                   bd_addr_type, hdl, off, val, length)
     gap_wait_for_connection()
 
@@ -1075,7 +1075,7 @@ def gattc_write_long(bd_addr_type, bd_addr, hdl, off, val, length=None):
 
 
 def gattc_write_reliable(bd_addr_type, bd_addr, hdl, off, val, val_mtp=None):
-    logging.debug("%s %r %r %r %r %r", gattc_write_reliable.__name__,
+    logging.debug("%r %r %r %r %r",
                   bd_addr_type, bd_addr, hdl, val, val_mtp)
     iutctl = get_iut()
 
@@ -1107,7 +1107,7 @@ def gattc_write_reliable(bd_addr_type, bd_addr, hdl, off, val, val_mtp=None):
 
 
 def gattc_cfg_notify(bd_addr_type, bd_addr, enable, ccc_hdl):
-    logging.debug("%s %r %r, %r, %r", gattc_cfg_notify.__name__, bd_addr_type,
+    logging.debug("%r %r, %r, %r", bd_addr_type,
                   bd_addr, enable, ccc_hdl)
     gap_wait_for_connection()
 
@@ -1128,7 +1128,7 @@ def gattc_cfg_notify(bd_addr_type, bd_addr, enable, ccc_hdl):
     iutctl.btp_socket.send(*GATTC['cfg_notify'], data=data_ba)
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_cfg_notify.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
@@ -1136,7 +1136,7 @@ def gattc_cfg_notify(bd_addr_type, bd_addr, enable, ccc_hdl):
 
 
 def gattc_cfg_indicate(bd_addr_type, bd_addr, enable, ccc_hdl):
-    logging.debug("%s %r %r, %r, %r", gattc_cfg_indicate.__name__,
+    logging.debug("%r %r, %r, %r",
                   bd_addr_type, bd_addr, enable, ccc_hdl)
     gap_wait_for_connection()
 
@@ -1157,7 +1157,7 @@ def gattc_cfg_indicate(bd_addr_type, bd_addr, enable, ccc_hdl):
     iutctl.btp_socket.send(*GATTC['cfg_indicate'], data=data_ba)
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_cfg_indicate.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
@@ -1165,7 +1165,7 @@ def gattc_cfg_indicate(bd_addr_type, bd_addr, enable, ccc_hdl):
 
 
 def gattc_notification_ev(bd_addr, bd_addr_type, ev_type):
-    logging.debug("%s %r %r %r", gattc_notification_ev.__name__, bd_addr,
+    logging.debug("%r %r %r", bd_addr,
                   bd_addr_type, ev_type)
     iutctl = get_iut()
 
@@ -1187,7 +1187,7 @@ def gattc_notification_ev(bd_addr, bd_addr_type, ev_type):
 
 
 def gatt_command_rsp_succ():
-    logging.debug("%s", gatt_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1376,8 +1376,8 @@ def gattc_disc_prim_uuid_find_attrs_rsp(exp_svcs, store_attrs=False):
     iutctl = get_iut()
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r",
-                  gattc_disc_prim_uuid_find_attrs_rsp.__name__, tuple_hdr,
+    logging.debug("received %r %r",
+                  tuple_hdr,
                   tuple_data)
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
                   defs.BTP_GATT_CMD_DISC_PRIM_UUID)
@@ -1407,19 +1407,19 @@ def gattc_disc_prim_uuid_find_attrs_rsp(exp_svcs, store_attrs=False):
 
 
 def gattc_disc_all_prim_rsp(store_rsp=False):
-    logging.debug("%s", gattc_disc_all_prim_rsp.__name__)
+    logging.debug("")
     iutctl = get_iut()
     attrs = []
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_disc_all_prim_rsp.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
                   defs.BTP_GATT_CMD_DISC_ALL_PRIM)
 
     svcs_list = gatt_dec_disc_rsp(tuple_data[0], "service")
-    logging.debug("%s %r", gattc_disc_all_prim_rsp.__name__, svcs_list)
+    logging.debug("%r", svcs_list)
 
     for svc in svcs_list:
         (start_hdl, end_hdl, uuid) = svc
@@ -1450,14 +1450,14 @@ def gattc_disc_prim_uuid_rsp(store_rsp=False):
     svcs = []
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_disc_prim_uuid_rsp.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
                   defs.BTP_GATT_CMD_DISC_PRIM_UUID)
 
     svcs_list = gatt_dec_disc_rsp(tuple_data[0], "service")
-    logging.debug("%s %r", gattc_disc_prim_uuid_rsp.__name__, svcs_list)
+    logging.debug("%r", svcs_list)
 
     for svc in svcs_list:
         (start_hdl, end_hdl, uuid) = svc
@@ -1499,14 +1499,14 @@ def gattc_find_included_rsp(store_rsp=False):
     iutctl = get_iut()
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_find_included_rsp.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
                   defs.BTP_GATT_CMD_FIND_INCLUDED)
 
     incls_tuple = gatt_dec_disc_rsp(tuple_data[0], "include")
-    logging.debug("%s %r", gattc_find_included_rsp.__name__, incls_tuple)
+    logging.debug("%r", incls_tuple)
 
     if store_rsp:
         clear_verify_values()
@@ -1530,14 +1530,14 @@ def gattc_disc_all_chrc_rsp(store_rsp=False):
     attrs = []
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_disc_all_chrc_rsp.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
                   defs.BTP_GATT_CMD_DISC_ALL_CHRC)
 
     chrcs_list = gatt_dec_disc_rsp(tuple_data[0], "characteristic")
-    logging.debug("%s %r", gattc_disc_all_chrc_rsp.__name__, chrcs_list)
+    logging.debug("%r", chrcs_list)
 
     for chrc in chrcs_list:
         (handle, value_handle, prop, uuid) = chrc
@@ -1564,14 +1564,14 @@ def gattc_disc_chrc_uuid_rsp(store_rsp=False):
     chrcs = []
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_disc_chrc_uuid_rsp.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
                   defs.BTP_GATT_CMD_DISC_CHRC_UUID)
 
     chrcs_list = gatt_dec_disc_rsp(tuple_data[0], "characteristic")
-    logging.debug("%s %r", gattc_disc_chrc_uuid_rsp.__name__, chrcs_list)
+    logging.debug("%r", chrcs_list)
 
     for chrc in chrcs_list:
         (handle, value_handle, prop, uuid) = chrc
@@ -1606,14 +1606,14 @@ def gattc_disc_all_desc_rsp(store_rsp=False):
     descs = []
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_disc_all_desc_rsp.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
                   defs.BTP_GATT_CMD_DISC_ALL_DESC)
 
     descs_list = gatt_dec_disc_rsp(tuple_data[0], "descriptor")
-    logging.debug("%s %r", gattc_disc_all_desc_rsp.__name__, descs_list)
+    logging.debug("%r", descs_list)
 
     for desc in descs_list:
         (handle, uuid) = desc
@@ -1644,13 +1644,13 @@ def gattc_read_rsp(store_rsp=False, store_val=False, timeout=None):
         tuple_hdr, tuple_data = iutctl.btp_socket.read(timeout)
     else:
         tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_read_rsp.__name__, tuple_hdr,
+    logging.debug("received %r %r", tuple_hdr,
                   tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT, defs.BTP_GATT_CMD_READ)
 
     rsp, value = gatt_dec_read_rsp(tuple_data[0])
-    logging.debug("%s %r %r", gattc_read_rsp.__name__, rsp, value)
+    logging.debug("%r %r", rsp, value)
 
     if store_rsp or store_val:
         clear_verify_values()
@@ -1668,13 +1668,13 @@ def gattc_read_uuid_rsp(store_rsp=False, store_val=False):
     iutctl = get_iut()
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_read_uuid_rsp.__name__, tuple_hdr,
+    logging.debug("received %r %r", tuple_hdr,
                   tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT, defs.BTP_GATT_CMD_READ_UUID)
 
     rsp, char_values = gatt_dec_read_uuid_rsp(tuple_data[0])
-    logging.debug("%s %r %r", gattc_read_uuid_rsp.__name__, rsp, char_values)
+    logging.debug("%r %r", rsp, char_values)
 
     if store_rsp or store_val:
         clear_verify_values()
@@ -1695,13 +1695,13 @@ def gattc_read_long_rsp(store_rsp=False, store_val=False):
     iutctl = get_iut()
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_read_long_rsp.__name__, tuple_hdr,
+    logging.debug("received %r %r", tuple_hdr,
                   tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT, defs.BTP_GATT_CMD_READ_LONG)
 
     rsp, value = gatt_dec_read_rsp(tuple_data[0])
-    logging.debug("%s %r %r", gattc_read_long_rsp.__name__, rsp, value)
+    logging.debug("%r %r", rsp, value)
 
     if store_rsp or store_val:
         clear_verify_values()
@@ -1717,14 +1717,14 @@ def gattc_read_multiple_rsp(store_val=False, store_rsp=False):
     iutctl = get_iut()
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_read_multiple_rsp.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
                   defs.BTP_GATT_CMD_READ_MULTIPLE)
 
     rsp, values = gatt_dec_read_rsp(tuple_data[0])
-    logging.debug("%s %r %r", gattc_read_multiple_rsp.__name__, rsp, values)
+    logging.debug("%r %r", rsp, values)
 
     if store_rsp or store_val:
         clear_verify_values()
@@ -1740,14 +1740,14 @@ def gattc_read_multiple_var_rsp(store_val=False, store_rsp=False):
     iutctl = get_iut()
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_read_multiple_var_rsp.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
                   defs.BTP_GATT_CMD_READ_MULTIPLE_VAR)
 
     rsp, values = gatt_dec_read_rsp(tuple_data[0])
-    logging.debug("%s %r %r", gattc_read_multiple_var_rsp.__name__, rsp, values)
+    logging.debug("%r %r", rsp, values)
 
     if store_rsp or store_val:
         clear_verify_values()
@@ -1766,13 +1766,13 @@ def gattc_write_rsp(store_rsp=False, timeout=None):
         tuple_hdr, tuple_data = iutctl.btp_socket.read(timeout)
     else:
         tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_write_rsp.__name__, tuple_hdr,
+    logging.debug("received %r %r", tuple_hdr,
                   tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT, defs.BTP_GATT_CMD_WRITE)
 
     rsp = gatt_dec_write_rsp(tuple_data[0])
-    logging.debug("%s %r", gattc_write_rsp.__name__, rsp)
+    logging.debug("%r", rsp)
 
     if store_rsp:
         clear_verify_values()
@@ -1783,14 +1783,14 @@ def gattc_write_long_rsp(store_rsp=False):
     iutctl = get_iut()
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_write_long_rsp.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
                   defs.BTP_GATT_CMD_WRITE_LONG)
 
     rsp = gatt_dec_write_rsp(tuple_data[0])
-    logging.debug("%s %r", gattc_write_long_rsp.__name__, rsp)
+    logging.debug("%r", rsp)
 
     if store_rsp:
         clear_verify_values()
@@ -1801,14 +1801,14 @@ def gattc_write_reliable_rsp(store_rsp=False):
     iutctl = get_iut()
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read()
-    logging.debug("%s received %r %r", gattc_write_reliable_rsp.__name__,
+    logging.debug("received %r %r",
                   tuple_hdr, tuple_data)
 
     btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_GATT,
                   defs.BTP_GATT_CMD_WRITE_RELIABLE)
 
     rsp = gatt_dec_write_rsp(tuple_data[0])
-    logging.debug("%s %r", gattc_write_long_rsp.__name__, rsp)
+    logging.debug("%r", rsp)
 
     if store_rsp:
         clear_verify_values()
@@ -1816,7 +1816,7 @@ def gattc_write_reliable_rsp(store_rsp=False):
 
 
 def eatt_conn(bd_addr, bd_addr_type, num=1):
-    logging.debug("%s %r %r", eatt_conn.__name__, bd_addr, bd_addr_type)
+    logging.debug("%r %r", bd_addr, bd_addr_type)
     iutctl = get_iut()
     gap_wait_for_connection()
 

--- a/autopts/pybtp/btp/gatt_cl.py
+++ b/autopts/pybtp/btp/gatt_cl.py
@@ -36,7 +36,7 @@ GATTC = gatt_cl
 
 
 def gatt_cl_mtu_exchanged_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_mtu_exchanged_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sB'
 
@@ -172,14 +172,13 @@ att_rsp_str = {0: "",
 
 
 def gatt_cl_disc_all_prim_rsp_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_disc_all_prim_rsp_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sBB'
 
     addr_type, addr, status, svc_cnt = \
         struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
-    logging.debug("%s received addr_type=%r addr=%r status=%r svc_cnt=%r",
-                  gatt_cl_disc_all_prim_rsp_ev_.__name__,
+    logging.debug("received addr_type=%r addr=%r status=%r svc_cnt=%r",
                   addr_type, addr, status, svc_cnt)
 
     svcs_data = data[struct.calcsize(fmt) - 1:]
@@ -193,7 +192,7 @@ def gatt_cl_disc_all_prim_rsp_ev_(gatt_cl, data, data_len):
 
     svcs = gatt_cl_dec_disc_rsp(svcs_data, 'service')
 
-    logging.debug("%s %r", gatt_cl_disc_all_prim_rsp_ev_.__name__, svcs)
+    logging.debug("%r", svcs)
 
     for svc in svcs:
         start_handle = f"{svc[0]:04X}"
@@ -206,14 +205,13 @@ def gatt_cl_disc_all_prim_rsp_ev_(gatt_cl, data, data_len):
 
 
 def gatt_cl_disc_prim_uuid_rsp_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_disc_prim_uuid_rsp_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sBB'
 
     addr_type, addr, status, svc_cnt = \
         struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
-    logging.debug("%s received addr_type=%r addr=%r status=%r svc_cnt=%r",
-                  gatt_cl_disc_prim_uuid_rsp_ev_.__name__,
+    logging.debug("received addr_type=%r addr=%r status=%r svc_cnt=%r",
                   addr_type, addr, status, svc_cnt)
 
     # svcs_data contains service count and services - adjust data offset
@@ -229,7 +227,7 @@ def gatt_cl_disc_prim_uuid_rsp_ev_(gatt_cl, data, data_len):
 
     svcs = gatt_cl_dec_disc_rsp(svcs_data, 'service')
 
-    logging.debug("%s %r", gatt_cl_disc_prim_uuid_rsp_ev_.__name__, svcs)
+    logging.debug("%r", svcs)
 
     for svc in svcs:
         start_handle = f"{svc[0]:04X}"
@@ -244,14 +242,13 @@ def gatt_cl_disc_prim_uuid_rsp_ev_(gatt_cl, data, data_len):
 
 
 def gatt_cl_find_incld_rsp_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_find_incld_rsp_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sBB'
 
     addr_type, addr, status, svc_cnt = \
         struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
-    logging.debug("%s received addr_type=%r addr=%r status=%r svc_cnt=%r",
-                  gatt_cl_find_incld_rsp_ev_.__name__,
+    logging.debug("received addr_type=%r addr=%r status=%r svc_cnt=%r",
                   addr_type, addr, status, svc_cnt)
 
     svcs_data = data[struct.calcsize(fmt) - 1:]
@@ -264,7 +261,7 @@ def gatt_cl_find_incld_rsp_ev_(gatt_cl, data, data_len):
         return
     incl_tuples = gatt_cl_dec_disc_rsp(svcs_data, 'include')
 
-    logging.debug("%s %r", gatt_cl_find_incld_rsp_ev_.__name__, incl_tuples)
+    logging.debug("%r", incl_tuples)
 
     for incl in incl_tuples:
         att_handle = f"{incl[0][0]:04X}"
@@ -279,15 +276,14 @@ def gatt_cl_find_incld_rsp_ev_(gatt_cl, data, data_len):
 
 
 def gatt_cl_disc_all_chrc_rsp_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_disc_all_chrc_rsp_ev_.__name__, data)
+    logging.debug("%r", data)
     attrs = []
 
     fmt = '<B6sBB'
 
     addr_type, addr, status, char_cnt = \
         struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
-    logging.debug("%s received addr_type=%r addr=%r status=%r char_cnt=%r",
-                  gatt_cl_disc_all_chrc_rsp_ev_.__name__,
+    logging.debug("received addr_type=%r addr=%r status=%r char_cnt=%r",
                   addr_type, addr, status, char_cnt)
 
     svcs_data = data[struct.calcsize(fmt) - 1:]
@@ -301,7 +297,7 @@ def gatt_cl_disc_all_chrc_rsp_ev_(gatt_cl, data, data_len):
 
     chrcs = gatt_cl_dec_disc_rsp(svcs_data, 'characteristic')
 
-    logging.debug("%s %r", gatt_cl_disc_all_chrc_rsp_ev_.__name__, chrcs)
+    logging.debug("%r", chrcs)
 
     for chrc in chrcs:
         (handle, value_handle, prop, uuid) = chrc
@@ -317,15 +313,14 @@ def gatt_cl_disc_all_chrc_rsp_ev_(gatt_cl, data, data_len):
 
 
 def gatt_cl_disc_chrc_uuid_rsp_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_disc_chrc_uuid_rsp_ev_.__name__, data)
+    logging.debug("%r", data)
     attrs = []
 
     fmt = '<B6sBB'
 
     addr_type, addr, status, char_cnt = \
         struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
-    logging.debug("%s received addr_type=%r addr=%r status=%r char_cnt=%r",
-                  gatt_cl_disc_chrc_uuid_rsp_ev_.__name__,
+    logging.debug("received addr_type=%r addr=%r status=%r char_cnt=%r",
                   addr_type, addr, status, char_cnt)
 
     svcs_data = data[struct.calcsize(fmt) - 1:]
@@ -339,7 +334,7 @@ def gatt_cl_disc_chrc_uuid_rsp_ev_(gatt_cl, data, data_len):
 
     chrcs = gatt_cl_dec_disc_rsp(svcs_data, 'characteristic')
 
-    logging.debug("%s %r", gatt_cl_disc_chrc_uuid_rsp_ev_.__name__, chrcs)
+    logging.debug("%r", chrcs)
 
     for chrc in chrcs:
         (handle, value_handle, prop, uuid) = chrc
@@ -355,14 +350,13 @@ def gatt_cl_disc_chrc_uuid_rsp_ev_(gatt_cl, data, data_len):
 
 
 def gatt_cl_disc_all_desc_rsp_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_disc_all_desc_rsp_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sBB'
 
     addr_type, addr, status, char_cnt = \
         struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
-    logging.debug("%s received addr_type=%r addr=%r status=%r char_cnt=%r",
-                  gatt_cl_disc_all_desc_rsp_ev_.__name__,
+    logging.debug("received addr_type=%r addr=%r status=%r char_cnt=%r",
                   addr_type, addr, status, char_cnt)
 
     svcs_data = data[struct.calcsize(fmt) - 1:]
@@ -376,7 +370,7 @@ def gatt_cl_disc_all_desc_rsp_ev_(gatt_cl, data, data_len):
 
     descs = gatt_cl_dec_disc_rsp(svcs_data, 'descriptor')
 
-    logging.debug("%s %r", gatt_cl_disc_all_desc_rsp_ev_.__name__, descs)
+    logging.debug("%r", descs)
 
     gatt_cl.dscs = []
     gatt_cl.dscs_cnt = char_cnt
@@ -388,14 +382,13 @@ def gatt_cl_disc_all_desc_rsp_ev_(gatt_cl, data, data_len):
 
 
 def gatt_cl_read_rsp_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_read_rsp_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sBH'
 
     addr_type, addr, status, data_length = \
         struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
-    logging.debug("%s received addr_type=%r addr=%r status=%r data_len=%r",
-                  gatt_cl_read_rsp_ev_.__name__,
+    logging.debug("received addr_type=%r addr=%r status=%r data_len=%r",
                   addr_type, addr, status, data_length)
 
     clear_verify_values()
@@ -408,7 +401,7 @@ def gatt_cl_read_rsp_ev_(gatt_cl, data, data_len):
 
     (value,) = struct.unpack_from(f"{data_length}s", rp_data)
 
-    logging.debug("%s %r %r", gatt_cl_read_rsp_ev_.__name__, status, value)
+    logging.debug("%r %r", status, value)
 
     add_to_verify_values(att_rsp_str[status])
 
@@ -418,15 +411,14 @@ def gatt_cl_read_rsp_ev_(gatt_cl, data, data_len):
 
 
 def gatt_cl_read_uuid_rsp_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_read_uuid_rsp_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sBHB'
 
     addr_type, addr, status, data_length, value_length = \
         struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
-    logging.debug("%s received addr_type=%r addr=%r status=%r data_len=%r,"
+    logging.debug("received addr_type=%r addr=%r status=%r data_len=%r,"
                   "value_len=%r",
-                  gatt_cl_read_uuid_rsp_ev_.__name__,
                   addr_type, addr, status, data_length, value_length)
 
     if status != 0:
@@ -445,8 +437,7 @@ def gatt_cl_read_uuid_rsp_ev_(gatt_cl, data, data_len):
         clear_verify_values()
         for _x in range(chrc_count):
             handle, value = struct.unpack_from(data_fmt, tuple_data, offset)
-            logging.debug("%s %r %r",
-                          gatt_cl_read_uuid_rsp_ev_.__name__,
+            logging.debug("%r %r",
                           handle, value)
             offset += tuple_len
             attrs_to_save.append((handle, binascii.hexlify(value).upper()))
@@ -461,8 +452,7 @@ def gatt_cl_read_uuid_rsp_ev_(gatt_cl, data, data_len):
                 # verify_values doesn't match read_uuid_rp, let's clear it
                 clear_verify_values()
         handle, value = struct.unpack_from(data_fmt, tuple_data)
-        logging.debug("%s %r %r",
-                      gatt_cl_read_uuid_rsp_ev_.__name__,
+        logging.debug("%r %r",
                       handle, value)
         add_to_verify_values((handle, binascii.hexlify(value).upper()))
 
@@ -470,21 +460,20 @@ def gatt_cl_read_uuid_rsp_ev_(gatt_cl, data, data_len):
 
 
 def gatt_cl_read_long_rsp_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_read_long_rsp_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sBH'
 
     addr_type, addr, status, data_length = \
         struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
-    logging.debug("%s received addr_type=%r addr=%r status=%r data_len=%r",
-                  gatt_cl_read_long_rsp_ev_.__name__,
+    logging.debug("received addr_type=%r addr=%r status=%r data_len=%r",
                   addr_type, addr, status, data_length)
 
     rp_data = data[struct.calcsize(fmt):]
 
     (value,) = struct.unpack_from(f"{data_length}s", rp_data)
 
-    logging.debug("%s %r %r", gatt_cl_read_long_rsp_ev_.__name__, status, value)
+    logging.debug("%r %r", status, value)
 
     clear_verify_values()
 
@@ -496,14 +485,13 @@ def gatt_cl_read_long_rsp_ev_(gatt_cl, data, data_len):
 
 
 def gatt_cl_read_mult_rsp_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_read_mult_rsp_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sBH'
 
     addr_type, addr, status, data_length = \
         struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
-    logging.debug("%s received addr_type=%r addr=%r status=%r data_len=%r",
-                  gatt_cl_read_mult_rsp_ev_.__name__,
+    logging.debug("received addr_type=%r addr=%r status=%r data_len=%r",
                   addr_type, addr, status, data_length)
 
     if status != 0:
@@ -518,7 +506,7 @@ def gatt_cl_read_mult_rsp_ev_(gatt_cl, data, data_len):
 
     (value,) = struct.unpack_from(f"{data_length}s", rp_data)
 
-    logging.debug("%s %r %r", gatt_cl_read_mult_rsp_ev_.__name__, status, value)
+    logging.debug("%r %r", status, value)
 
     if (len(get_verify_values()) > 0 and not
         (isinstance(get_verify_values()[0][0], str) and
@@ -532,14 +520,13 @@ def gatt_cl_read_mult_rsp_ev_(gatt_cl, data, data_len):
 
 
 def gatt_cl_read_mult_var_rsp_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_read_mult_var_rsp_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sBH'
 
     addr_type, addr, status, data_length = \
         struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
-    logging.debug("%s received addr_type=%r addr=%r status=%r data_len=%r",
-                  gatt_cl_read_mult_var_rsp_ev_.__name__,
+    logging.debug("received addr_type=%r addr=%r status=%r data_len=%r",
                   addr_type, addr, status, data_length)
 
     rp_data = data[struct.calcsize(fmt):]
@@ -552,7 +539,7 @@ def gatt_cl_read_mult_var_rsp_ev_(gatt_cl, data, data_len):
 
     (value,) = struct.unpack_from(f"{data_length}s", rp_data)
 
-    logging.debug("%s %r %r", gatt_cl_read_mult_rsp_ev_.__name__, status, value)
+    logging.debug("%r %r", status, value)
 
     if (len(get_verify_values()) > 0 and not
     (isinstance(get_verify_values()[0][0], str) and
@@ -566,28 +553,26 @@ def gatt_cl_read_mult_var_rsp_ev_(gatt_cl, data, data_len):
 
 
 def gatt_cl_write_rsp_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_write_rsp_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sB'
 
     addr_type, addr, status = \
         struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
-    logging.debug("%s received addr_type=%r addr=%r status=%r",
-                  gatt_cl_write_rsp_ev_.__name__,
+    logging.debug("received addr_type=%r addr=%r status=%r",
                   addr_type, addr, status)
     gatt_cl.write_status = status
 
 
 def gatt_cl_notification_rxed_ev_(gatt_cl, data, data_len):
-    logging.debug("%s %r", gatt_cl_notification_rxed_ev_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sBHH'
 
     addr_type, addr, value_type, handle, data_length = \
         struct.unpack_from(fmt, data[:struct.calcsize(fmt)])
-    logging.debug("%s received addr_type=%r addr=%r"
+    logging.debug("received addr_type=%r addr=%r"
                   "value_type=%r handle=%r data_length=%r",
-                  gatt_cl_notification_rxed_ev_.__name__,
                   addr_type, addr, value_type, handle, data_length)
 
     if data_length == 0:
@@ -623,7 +608,7 @@ GATTC_EV = {
 
 
 def gatt_cl_command_rsp_succ():
-    logging.debug("%s", gatt_cl_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -634,7 +619,7 @@ def gatt_cl_command_rsp_succ():
 
 
 def gatt_cl_exchange_mtu(bd_addr_type, bd_addr):
-    logging.debug("%s %r %r", gatt_cl_exchange_mtu.__name__, bd_addr_type,
+    logging.debug("%r %r", bd_addr_type,
                   bd_addr)
     iutctl = get_iut()
 
@@ -652,7 +637,7 @@ def gatt_cl_exchange_mtu(bd_addr_type, bd_addr):
 
 
 def gatt_cl_disc_all_prim(bd_addr_type, bd_addr):
-    logging.debug("%s %r %r", gatt_cl_disc_all_prim.__name__, bd_addr_type,
+    logging.debug("%r %r", bd_addr_type,
                   bd_addr)
     stack = get_stack()
     stack.gatt_cl.prim_svcs_cnt = None
@@ -675,7 +660,7 @@ def gatt_cl_disc_all_prim(bd_addr_type, bd_addr):
 
 
 def gatt_cl_disc_prim_uuid(bd_addr_type, bd_addr, uuid):
-    logging.debug("%s %r %r %r", gatt_cl_disc_prim_uuid.__name__, bd_addr_type,
+    logging.debug("%r %r %r", bd_addr_type,
                   bd_addr, uuid)
     stack = get_stack()
     stack.gatt_cl.prim_svcs_cnt = None
@@ -701,7 +686,7 @@ def gatt_cl_disc_prim_uuid(bd_addr_type, bd_addr, uuid):
 
 
 def gatt_cl_find_included(bd_addr_type, bd_addr, start_hdl, end_hdl):
-    logging.debug("%s %r %r %r %r", gatt_cl_find_included.__name__,
+    logging.debug("%r %r %r %r",
                   bd_addr_type, bd_addr, start_hdl, end_hdl)
     stack = get_stack()
     stack.gatt_cl.incl_svcs_cnt = None
@@ -734,7 +719,7 @@ def gatt_cl_find_included(bd_addr_type, bd_addr, start_hdl, end_hdl):
 
 
 def gatt_cl_disc_all_chrc(bd_addr_type, bd_addr, start_hdl, stop_hdl, svc=None):
-    logging.debug("%s %r %r %r %r %r", gatt_cl_disc_all_chrc.__name__,
+    logging.debug("%r %r %r %r %r",
                   bd_addr_type, bd_addr, start_hdl, stop_hdl, svc)
     stack = get_stack()
     stack.gatt_cl.chrcs_cnt = None
@@ -786,7 +771,7 @@ def gatt_cl_disc_all_chrc(bd_addr_type, bd_addr, start_hdl, stop_hdl, svc=None):
 
 
 def gatt_cl_disc_chrc_uuid(bd_addr_type, bd_addr, start_hdl, stop_hdl, uuid):
-    logging.debug("%s %r %r %r %r %r", gatt_cl_disc_chrc_uuid.__name__,
+    logging.debug("%r %r %r %r %r",
                   bd_addr_type, bd_addr, start_hdl, stop_hdl, uuid)
     iutctl = get_iut()
     stack = get_stack()
@@ -822,7 +807,7 @@ def gatt_cl_disc_chrc_uuid(bd_addr_type, bd_addr, start_hdl, stop_hdl, uuid):
 
 
 def gatt_cl_disc_all_desc(bd_addr_type, bd_addr, start_hdl, stop_hdl):
-    logging.debug("%s %r %r %r %r", gatt_cl_disc_all_desc.__name__,
+    logging.debug("%r %r %r %r",
                   bd_addr_type, bd_addr, start_hdl, stop_hdl)
     stack = get_stack()
     stack.gatt_cl.dscs_cnt = None
@@ -855,7 +840,7 @@ def gatt_cl_disc_all_desc(bd_addr_type, bd_addr, start_hdl, stop_hdl):
 
 
 def gatt_cl_read(bd_addr_type, bd_addr, hdl):
-    logging.debug("%s %r %r %r", gatt_cl_read.__name__, bd_addr_type, bd_addr,
+    logging.debug("%r %r %r", bd_addr_type, bd_addr,
                   hdl)
     iutctl = get_iut()
 
@@ -881,7 +866,7 @@ def gatt_cl_read(bd_addr_type, bd_addr, hdl):
 
 
 def gatt_cl_read_uuid(bd_addr_type, bd_addr, start_hdl, end_hdl, uuid):
-    logging.debug("%s %r %r %r %r %r", gatt_cl_read_uuid.__name__, bd_addr_type,
+    logging.debug("%r %r %r %r %r", bd_addr_type,
                   bd_addr, start_hdl, end_hdl, uuid)
     iutctl = get_iut()
 
@@ -917,7 +902,7 @@ def gatt_cl_read_uuid(bd_addr_type, bd_addr, start_hdl, end_hdl, uuid):
 
 
 def gatt_cl_read_long(bd_addr_type, bd_addr, hdl, off, modif_off=None):
-    logging.debug("%s %r %r %r %r %r", gatt_cl_read_long.__name__, bd_addr_type,
+    logging.debug("%r %r %r %r %r", bd_addr_type,
                   bd_addr, hdl, off, modif_off)
     iutctl = get_iut()
 
@@ -950,7 +935,7 @@ def gatt_cl_read_long(bd_addr_type, bd_addr, hdl, off, modif_off=None):
 
 
 def gatt_cl_read_multiple(bd_addr_type, bd_addr, *hdls):
-    logging.debug("%s %r %r %r", gatt_cl_read_multiple.__name__, bd_addr_type,
+    logging.debug("%r %r %r", bd_addr_type,
                   bd_addr, hdls)
     iutctl = get_iut()
 
@@ -978,7 +963,7 @@ def gatt_cl_read_multiple(bd_addr_type, bd_addr, *hdls):
 
 
 def gatt_cl_read_multiple_var(bd_addr_type, bd_addr, *hdls):
-    logging.debug("%s %r %r %r", gatt_cl_read_multiple_var.__name__, bd_addr_type,
+    logging.debug("%r %r %r", bd_addr_type,
                   bd_addr, hdls)
     iutctl = get_iut()
 
@@ -1006,7 +991,7 @@ def gatt_cl_read_multiple_var(bd_addr_type, bd_addr, *hdls):
 
 
 def gatt_cl_write_without_rsp(bd_addr_type, bd_addr, hdl, val, val_mtp=None):
-    logging.debug("%s %r %r %r %r %r", gatt_cl_write_without_rsp.__name__,
+    logging.debug("%r %r %r %r %r",
                   bd_addr_type, bd_addr, hdl, val, val_mtp)
     iutctl = get_iut()
 
@@ -1037,7 +1022,7 @@ def gatt_cl_write_without_rsp(bd_addr_type, bd_addr, hdl, val, val_mtp=None):
 
 
 def gatt_cl_signed_write(bd_addr_type, bd_addr, hdl, val, val_mtp=None):
-    logging.debug("%s %r %r %r %r %r", gatt_cl_signed_write.__name__,
+    logging.debug("%r %r %r %r %r",
                   bd_addr_type, bd_addr, hdl, val, val_mtp)
     iutctl = get_iut()
 
@@ -1076,7 +1061,7 @@ def gatt_cl_signed_write(bd_addr_type, bd_addr, hdl, val, val_mtp=None):
 
 
 def gatt_cl_write(bd_addr_type, bd_addr, hdl, val, val_mtp=None):
-    logging.debug("%s %r %r %r %r %r", gatt_cl_write.__name__, bd_addr_type,
+    logging.debug("%r %r %r %r %r", bd_addr_type,
                   bd_addr, hdl, val, val_mtp)
     iutctl = get_iut()
 
@@ -1110,7 +1095,7 @@ def gatt_cl_write(bd_addr_type, bd_addr, hdl, val, val_mtp=None):
 
 
 def gatt_cl_write_long(bd_addr_type, bd_addr, hdl, off, val, length=None):
-    logging.debug("%s %r %r %r %r %r", gatt_cl_write_long.__name__,
+    logging.debug("%r %r %r %r %r",
                   bd_addr_type, hdl, off, val, length)
     gap_wait_for_connection()
 
@@ -1148,7 +1133,7 @@ def gatt_cl_write_long(bd_addr_type, bd_addr, hdl, off, val, length=None):
 
 
 def gatt_cl_write_reliable(bd_addr_type, bd_addr, hdl, off, val, val_mtp=None):
-    logging.debug("%s %r %r %r %r %r", gatt_cl_write_reliable.__name__,
+    logging.debug("%r %r %r %r %r",
                   bd_addr_type, bd_addr, hdl, val, val_mtp)
     iutctl = get_iut()
 
@@ -1185,7 +1170,7 @@ def gatt_cl_write_reliable(bd_addr_type, bd_addr, hdl, off, val, val_mtp=None):
 
 
 def gatt_cl_cfg_notify(bd_addr_type, bd_addr, enable, ccc_hdl):
-    logging.debug("%s %r %r, %r, %r", gatt_cl_cfg_notify.__name__, bd_addr_type,
+    logging.debug("%r %r, %r, %r", bd_addr_type,
                   bd_addr, enable, ccc_hdl)
     gap_wait_for_connection()
 
@@ -1209,7 +1194,7 @@ def gatt_cl_cfg_notify(bd_addr_type, bd_addr, enable, ccc_hdl):
 
 
 def gatt_cl_cfg_indicate(bd_addr_type, bd_addr, enable, ccc_hdl):
-    logging.debug("%s %r %r, %r, %r", gatt_cl_cfg_indicate.__name__,
+    logging.debug("%r %r, %r, %r",
                   bd_addr_type, bd_addr, enable, ccc_hdl)
     gap_wait_for_connection()
 

--- a/autopts/pybtp/btp/gmcs.py
+++ b/autopts/pybtp/btp/gmcs.py
@@ -45,8 +45,6 @@ GMCS = {
 
 
 def gmcs_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", gmcs_command_rsp_succ.__name__)
-
     iutctl = get_iut()
 
     tuple_hdr, tuple_data = iutctl.btp_socket.read(timeout)
@@ -57,6 +55,8 @@ def gmcs_command_rsp_succ(timeout=20.0):
 
 
 def address_to_ba(bd_addr_type=None, bd_addr=None):
+    logging.debug("")
+
     data = bytearray()
     bd_addr_ba = addr_str_to_le_bytes(pts_addr_get(bd_addr))
     bd_addr_type_ba = chr(pts_addr_type_get(bd_addr_type)).encode('utf-8')
@@ -66,7 +66,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def gmcs_control_point_cmd(opcode, use_param, param=None):
-    logging.debug(f"{gmcs_control_point_cmd.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data.extend(struct.pack("b", opcode))
@@ -83,7 +83,7 @@ def gmcs_control_point_cmd(opcode, use_param, param=None):
 
 
 def gmcs_current_track_obj_id_get():
-    logging.debug(f"{gmcs_current_track_obj_id_get.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -102,7 +102,7 @@ def gmcs_current_track_obj_id_get():
 
 
 def gmcs_next_track_obj_id_get():
-    logging.debug(f"{gmcs_next_track_obj_id_get.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -121,7 +121,7 @@ def gmcs_next_track_obj_id_get():
 
 
 def gmcs_inactive_state_set():
-    logging.debug(f"{gmcs_inactive_state_set.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -139,7 +139,7 @@ def gmcs_inactive_state_set():
 
 
 def gmcs_parent_group_set():
-    logging.debug(f"{gmcs_parent_group_set.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 

--- a/autopts/pybtp/btp/hap.py
+++ b/autopts/pybtp/btp/hap.py
@@ -76,7 +76,7 @@ HAP = {
 
 
 def hap_command_rsp_succ(timeout=20.0, exp_op=None):
-    logging.debug(f"{hap_command_rsp_succ.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -88,7 +88,7 @@ def hap_command_rsp_succ(timeout=20.0, exp_op=None):
 
 
 def hap_read_supported_cmds():
-    logging.debug(f"{hap_read_supported_cmds.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*HAP['read_supported_cmds'])
@@ -98,7 +98,7 @@ def hap_read_supported_cmds():
 
 
 def hap_ha_init(hap_type, options):
-    logging.debug(f"{hap_ha_init.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray()
@@ -111,7 +111,7 @@ def hap_ha_init(hap_type, options):
 
 
 def hap_harc_init():
-    logging.debug(f"{hap_harc_init.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*HAP['harc_init'])
@@ -120,7 +120,7 @@ def hap_harc_init():
 
 
 def hap_hauc_init():
-    logging.debug(f"{hap_hauc_init.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*HAP['hauc_init'])
@@ -129,7 +129,7 @@ def hap_hauc_init():
 
 
 def hap_iac_init():
-    logging.debug(f"{hap_iac_init.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*HAP['iac_init'])
@@ -138,7 +138,7 @@ def hap_iac_init():
 
 
 def hap_iac_discover(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{hap_iac_discover.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
 
@@ -149,7 +149,7 @@ def hap_iac_discover(bd_addr_type=None, bd_addr=None):
 
 
 def hap_iac_set_alert(bd_addr_type=None, bd_addr=None, alert=None):
-    logging.debug(f"{hap_iac_set_alert.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', alert)
@@ -161,7 +161,7 @@ def hap_iac_set_alert(bd_addr_type=None, bd_addr=None, alert=None):
 
 
 def hap_hauc_discover(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{hap_hauc_discover.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
 
@@ -172,7 +172,7 @@ def hap_hauc_discover(bd_addr_type=None, bd_addr=None):
 
 
 def hap_read_presets(start_index, num_presets, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{hap_read_presets.__name__}, start_index {start_index}, num_presets {num_presets}")
+    logging.debug("start_index %r, num_presets %r", start_index, num_presets)
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', start_index)
@@ -185,7 +185,7 @@ def hap_read_presets(start_index, num_presets, bd_addr_type=None, bd_addr=None):
 
 
 def hap_write_preset_name(index, name, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{hap_write_preset_name.__name__}, index {index}, name {name}")
+    logging.debug("index %r, name %r", index, name)
     encoded_name = name.encode()
     size = len(encoded_name)
 
@@ -201,7 +201,7 @@ def hap_write_preset_name(index, name, bd_addr_type=None, bd_addr=None):
 
 
 def hap_set_active_preset(index, synchronize_locally=0, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{hap_set_active_preset.__name__}, index {index}, synchronize_locally {synchronize_locally}")
+    logging.debug("index %r, synchronize_locally %r", index, synchronize_locally)
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', index)
@@ -214,7 +214,7 @@ def hap_set_active_preset(index, synchronize_locally=0, bd_addr_type=None, bd_ad
 
 
 def hap_set_next_preset(synchronize_locally=0, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{hap_set_next_preset.__name__}, synchronize_locally {synchronize_locally}")
+    logging.debug("synchronize_locally %r", synchronize_locally)
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', synchronize_locally)
@@ -226,7 +226,7 @@ def hap_set_next_preset(synchronize_locally=0, bd_addr_type=None, bd_addr=None):
 
 
 def hap_set_previous_preset(synchronize_locally=0, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{hap_set_previous_preset.__name__}, synchronize_locally {synchronize_locally}")
+    logging.debug("synchronize_locally %r", synchronize_locally)
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', synchronize_locally)
@@ -238,7 +238,7 @@ def hap_set_previous_preset(synchronize_locally=0, bd_addr_type=None, bd_addr=No
 
 
 def hap_ev_iac_discovery_complete_(hap, data, data_len):
-    logging.debug("%s %r", hap_ev_iac_discovery_complete_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sB'
     if len(data) < struct.calcsize(fmt):
@@ -247,14 +247,13 @@ def hap_ev_iac_discovery_complete_(hap, data, data_len):
     addr_type, addr, status = struct.unpack_from(fmt, data)
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'IAC Discovery complete: addr {addr} addr_type '
-                  f'{addr_type} status {status}')
+    logging.debug("IAC Discovery complete: addr %r, addr_type %r, status %r", addr, addr_type, status)
 
     hap.event_received(defs.BTP_HAP_EV_IAC_DISCOVERY_COMPLETE, (addr_type, addr, status))
 
 
 def hap_ev_hauc_discovery_complete_(hap, data, data_len):
-    logging.debug("%s %r", hap_ev_hauc_discovery_complete_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sbHHH'
     if len(data) < struct.calcsize(fmt):
@@ -266,11 +265,11 @@ def hap_ev_hauc_discovery_complete_(hap, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'HAUC Discovery complete: addr {addr} addr_type {addr_type} '
-                  f'status {status} '
-                  f'has_hearing_aid_features_handle {hearing_aid_features_handle} '
-                  f'has_control_point_handle {hearing_aid_control_point_handle} '
-                  f'has_active_preset_index_handle {active_preset_index_handle}')
+    logging.debug(
+        "HAUC Discovery complete: addr %r, addr_type %r, status %r, has_hearing_aid_features_handle %r,"
+        "has_control_point_handle %r, has_active_preset_index_handle %r",
+        addr, addr_type, status, hearing_aid_features_handle, hearing_aid_control_point_handle,
+        active_preset_index_handle)
 
     hap.event_received(defs.BTP_HAP_EV_HAUC_DISCOVERY_COMPLETE, (addr_type, addr, status,
                                                              hearing_aid_features_handle,
@@ -279,7 +278,7 @@ def hap_ev_hauc_discovery_complete_(hap, data, data_len):
 
 
 def hap_ev_preset_changed_(hap, data, data_len):
-    logging.debug("%s %r", hap_ev_preset_changed_.__name__, data)
+    logging.debug("%r", data)
 
     fmt = '<B6sBBBBBB'
     fixed_size = struct.calcsize(fmt)
@@ -291,13 +290,10 @@ def hap_ev_preset_changed_(hap, data, data_len):
     name = data[fixed_size:].decode('utf-8')
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'Preset Changed: addr {addr} addr_type {addr_type} '
-                  f'change_id {change_id} '
-                  f'is_last {is_last} '
-                  f'preset_index {preset_index} '
-                  f'prev_index {prev_index}'
-                  f'prev_index {properties}'
-                  f'name {name}')
+    logging.debug(
+        "Preset Changed: addr %r, addr_type %r, change_id %r, is_last %r, preset_index %r, prev_index %r,"
+        "properties %r, name %r",
+        addr, addr_type, change_id, is_last, preset_index, prev_index, properties, name)
 
     hap.event_received(defs.BTP_HAP_EV_PRESET_READ, (addr_type, addr, change_id,
                                                 is_last, preset_index,

--- a/autopts/pybtp/btp/has.py
+++ b/autopts/pybtp/btp/has.py
@@ -45,7 +45,7 @@ HAS = {
 
 
 def has_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", has_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -67,7 +67,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def has_set_active_index(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{has_set_active_index.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', index)
@@ -79,7 +79,7 @@ def has_set_active_index(index, bd_addr_type=None, bd_addr=None):
 
 
 def has_set_preset_name(index, name, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{has_set_preset_name.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     size = len(name.encode())
@@ -92,7 +92,7 @@ def has_set_preset_name(index, name, bd_addr_type=None, bd_addr=None):
 
 
 def has_remove_preset(index, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{has_remove_preset.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('B', index)
@@ -104,7 +104,7 @@ def has_remove_preset(index, bd_addr_type=None, bd_addr=None):
 
 
 def has_add_preset(index, properties, name, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{has_add_preset.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     size = len(name.encode())
@@ -117,7 +117,7 @@ def has_add_preset(index, properties, name, bd_addr_type=None, bd_addr=None):
 
 
 def has_set_properties(index, properties, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{has_add_preset.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data += struct.pack('BB', index, properties)

--- a/autopts/pybtp/btp/ias.py
+++ b/autopts/pybtp/btp/ias.py
@@ -20,7 +20,7 @@ from autopts.pybtp import defs
 
 
 def ias_ev_out_alert_action(ias, data, data_len):
-    logging.debug("%s %r", ias_ev_out_alert_action.__name__, data)
+    logging.debug("%r", data)
     stack = get_stack()
 
     alert_lvl = int.from_bytes(data, "little")

--- a/autopts/pybtp/btp/l2cap.py
+++ b/autopts/pybtp/btp/l2cap.py
@@ -53,7 +53,7 @@ L2CAP = {
 
 
 def l2cap_command_rsp_succ(op=None):
-    logging.debug("%s", l2cap_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -64,7 +64,7 @@ def l2cap_command_rsp_succ(op=None):
 
 
 def l2cap_conn(bd_addr, bd_addr_type, psm, mtu=0, num=1, ecfc=0, hold_credit=0):
-    logging.debug("%s %r %r %r", l2cap_conn.__name__, bd_addr, bd_addr_type,
+    logging.debug("%r %r %r", bd_addr, bd_addr_type,
                   psm)
     iutctl = get_iut()
     gap_wait_for_connection()
@@ -100,7 +100,7 @@ def l2cap_conn(bd_addr, bd_addr_type, psm, mtu=0, num=1, ecfc=0, hold_credit=0):
 
 
 def l2cap_conn_v2_rsp():
-    logging.debug("%s", l2cap_conn_v2_rsp.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -115,7 +115,7 @@ def l2cap_conn_v2_rsp():
 
 def l2cap_conn_v2(bd_addr, bd_addr_type, psm, mtu=0, num=1, ecfc=0, hold_credit=0, mode=0,
                   options=0):
-    logging.debug("%s %r %r %r %r %r", l2cap_conn_v2.__name__, bd_addr, bd_addr_type, psm, mode,
+    logging.debug("%r %r %r %r %r", bd_addr, bd_addr_type, psm, mode,
                   options)
 
     iutctl = get_iut()
@@ -167,7 +167,7 @@ l2cap_result_str = {0: "Success",
 
 
 def l2cap_conn_rsp():
-    logging.debug("%s", l2cap_conn_rsp.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -181,7 +181,7 @@ def l2cap_conn_rsp():
 
 
 def l2cap_disconn(chan_id):
-    logging.debug("%s %r", l2cap_disconn.__name__, chan_id)
+    logging.debug("%r", chan_id)
 
     iutctl = get_iut()
 
@@ -193,7 +193,7 @@ def l2cap_disconn(chan_id):
 
 
 def l2cap_send_data(chan_id, val, val_mtp=None):
-    logging.debug("%s %r %r %r", l2cap_send_data.__name__, chan_id, val,
+    logging.debug("%r %r %r", chan_id, val,
                   val_mtp)
 
     iutctl = get_iut()
@@ -215,7 +215,7 @@ def l2cap_send_data(chan_id, val, val_mtp=None):
 
 
 def l2cap_listen(psm, transport, mtu=0, response=L2CAPConnectionResponse.success):
-    logging.debug("%s %r %r %r %r", l2cap_le_listen.__name__, psm, transport, mtu, response)
+    logging.debug("%r %r %r %r", psm, transport, mtu, response)
 
     iutctl = get_iut()
 
@@ -234,7 +234,7 @@ def l2cap_listen(psm, transport, mtu=0, response=L2CAPConnectionResponse.success
 
 def l2cap_listen_v2(psm, transport, mtu=0, response=L2CAPConnectionResponse.success, mode=0,
                     options=0):
-    logging.debug("%s %r %r %r %r %r %r", l2cap_listen_v2.__name__, psm, transport, mtu, response,
+    logging.debug("%r %r %r %r %r %r", psm, transport, mtu, response,
                   mode, options)
 
     iutctl = get_iut()
@@ -255,7 +255,7 @@ def l2cap_listen_v2(psm, transport, mtu=0, response=L2CAPConnectionResponse.succ
 
 
 def l2cap_disconn_eatt_chans(bd_addr, bd_addr_type, channel_count):
-    logging.debug("%s %r", l2cap_disconn_eatt_chans.__name__, channel_count)
+    logging.debug("%r", channel_count)
 
     iutctl = get_iut()
 
@@ -289,7 +289,7 @@ def l2cap_br_listen_v2(psm, mtu=0, response=0, mode=0, options=0):
 
 
 def l2cap_reconfigure(bd_addr, bd_addr_type, mtu, channels):
-    logging.debug("%s %r %r %r %r", l2cap_reconfigure.__name__,
+    logging.debug("%r %r %r %r",
                   bd_addr, bd_addr_type, mtu, channels)
 
     iutctl = get_iut()
@@ -311,7 +311,7 @@ def l2cap_reconfigure(bd_addr, bd_addr_type, mtu, channels):
 
 
 def l2cap_credits(chan_id):
-    logging.debug("%s %r", l2cap_credits.__name__, chan_id)
+    logging.debug("%r", chan_id)
 
     iutctl = get_iut()
 
@@ -323,7 +323,7 @@ def l2cap_credits(chan_id):
 
 
 def l2cap_echo_req(bd_addr, bd_addr_type, val, val_mtp=None):
-    logging.debug("%s %r %r %r %r", l2cap_echo_req.__name__, bd_addr, bd_addr_type, val, val_mtp)
+    logging.debug("%r %r %r %r", bd_addr, bd_addr_type, val, val_mtp)
 
     iutctl = get_iut()
 
@@ -349,7 +349,7 @@ def l2cap_echo_req(bd_addr, bd_addr_type, val, val_mtp=None):
 
 
 def l2cap_cls_send(bd_addr, bd_addr_type, psm, val, val_mtp=None, options=0):
-    logging.debug("%s %r %r %r %r %r %r", l2cap_cls_send.__name__, bd_addr, bd_addr_type, psm, val,
+    logging.debug("%r %r %r %r %r %r", bd_addr, bd_addr_type, psm, val,
                   val_mtp, options)
 
     iutctl = get_iut()
@@ -381,7 +381,7 @@ def l2cap_cls_send(bd_addr, bd_addr_type, psm, val, val_mtp=None, options=0):
 
 
 def l2cap_connected_ev(l2cap, data, data_len):
-    logging.debug("%s %r %r", l2cap_connected_ev.__name__, data, data_len)
+    logging.debug("%r %r", data, data_len)
 
     hdr_fmt = '<BHHHHHB6s'
     chan_id, psm, peer_mtu, peer_mps, our_mtu, our_mps, \
@@ -396,7 +396,7 @@ def l2cap_connected_ev(l2cap, data, data_len):
 
 
 def l2cap_disconnected_ev(l2cap, data, data_len):
-    logging.debug("%s %r %r", l2cap_disconnected_ev.__name__, data, data_len)
+    logging.debug("%r %r", data, data_len)
 
     hdr_fmt = '<HBHB6s'
     res, chan_id, psm, bd_addr_type, bd_addr = struct.unpack_from(hdr_fmt, data)
@@ -408,7 +408,7 @@ def l2cap_disconnected_ev(l2cap, data, data_len):
 
 
 def l2cap_data_rcv_ev(l2cap, data, data_len):
-    logging.debug("%s %r %r", l2cap_data_rcv_ev.__name__, data, data_len)
+    logging.debug("%r %r", data, data_len)
 
     hdr_fmt = '<BH'
     hdr_len = struct.calcsize(hdr_fmt)
@@ -421,7 +421,7 @@ def l2cap_data_rcv_ev(l2cap, data, data_len):
 
 
 def l2cap_reconfigured_ev(l2cap, data, data_len):
-    logging.debug("%s %r %r", l2cap_reconfigured_ev.__name__, data, data_len)
+    logging.debug("%r %r", data, data_len)
 
     hdr_fmt = '<BHHHH'
     chan_id, peer_mtu, peer_mps, our_mtu, our_mps = \

--- a/autopts/pybtp/btp/mcp.py
+++ b/autopts/pybtp/btp/mcp.py
@@ -102,7 +102,7 @@ MCP = {
 
 
 def mcp_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", mcp_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -123,7 +123,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_discover(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_discover.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -134,7 +134,7 @@ def mcp_discover(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_track_duration_get(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_track_duration_get.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -145,7 +145,7 @@ def mcp_track_duration_get(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_track_position_get(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_track_position_get.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -156,7 +156,7 @@ def mcp_track_position_get(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_track_position_set(position, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_track_position_set.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -168,7 +168,7 @@ def mcp_track_position_set(position, bd_addr_type=None, bd_addr=None):
 
 
 def mcp_playback_speed_get(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_playback_speed_get.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -179,7 +179,7 @@ def mcp_playback_speed_get(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_playback_speed_set(speed, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_playback_speed_set.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -192,7 +192,7 @@ def mcp_playback_speed_set(speed, bd_addr_type=None, bd_addr=None):
 
 
 def mcp_seeking_speed_get(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_seeking_speed_get.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -203,7 +203,7 @@ def mcp_seeking_speed_get(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_icon_obj_id_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_icon_obj_id_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -214,7 +214,7 @@ def mcp_icon_obj_id_read(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_next_track_obj_id_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_next_track_obj_id_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -225,7 +225,7 @@ def mcp_next_track_obj_id_read(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_next_track_obj_id_set(obj_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_next_track_obj_id_set.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     obj_id_bytes = obj_id.to_bytes(6, 'little')
@@ -238,7 +238,7 @@ def mcp_next_track_obj_id_set(obj_id, bd_addr_type=None, bd_addr=None):
 
 
 def mcp_parent_group_obj_id_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_parent_group_obj_id_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -249,7 +249,7 @@ def mcp_parent_group_obj_id_read(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_current_group_obj_id_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_current_group_obj_id_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -260,7 +260,7 @@ def mcp_current_group_obj_id_read(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_current_group_obj_id_set(obj_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_current_group_obj_id_set.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     obj_id_bytes = obj_id.to_bytes(6, 'little')
@@ -273,7 +273,7 @@ def mcp_current_group_obj_id_set(obj_id, bd_addr_type=None, bd_addr=None):
 
 
 def mcp_playing_order_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_playing_order_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -284,7 +284,7 @@ def mcp_playing_order_read(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_playing_order_set(order, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_playing_order_set.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data.extend(struct.pack("b", order))
@@ -296,7 +296,7 @@ def mcp_playing_order_set(order, bd_addr_type=None, bd_addr=None):
 
 
 def mcp_playing_orders_supported_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_playing_orders_supported_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -307,7 +307,7 @@ def mcp_playing_orders_supported_read(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_media_state_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_media_state_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -318,7 +318,7 @@ def mcp_media_state_read(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_content_control_id_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_content_control_id_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -329,7 +329,7 @@ def mcp_content_control_id_read(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_segments_obj_id_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_segments_obj_id_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -340,7 +340,7 @@ def mcp_segments_obj_id_read(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_current_track_obj_id_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_current_track_obj_id_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -351,7 +351,7 @@ def mcp_current_track_obj_id_read(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_current_track_obj_id_set(obj_id, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_current_track_obj_id_set.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     obj_id_bytes = obj_id.to_bytes(6, 'little')
@@ -364,7 +364,7 @@ def mcp_current_track_obj_id_set(obj_id, bd_addr_type=None, bd_addr=None):
 
 
 def mcp_opcodes_supported_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_opcodes_supported_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -375,7 +375,7 @@ def mcp_opcodes_supported_read(bd_addr_type=None, bd_addr=None):
 
 
 def mcp_control_point_cmd(opcode, use_param, param, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_control_point_cmd.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data.extend(struct.pack("b", opcode))
@@ -389,7 +389,7 @@ def mcp_control_point_cmd(opcode, use_param, param, bd_addr_type=None, bd_addr=N
 
 
 def mcp_search_control_point_cmd(search_type, param, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{mcp_search_control_point_cmd.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     data.extend(struct.pack("b", search_type))
@@ -406,7 +406,7 @@ def mcp_search_control_point_cmd(search_type, param, bd_addr_type=None, bd_addr=
 
 
 def mcp_ev_discovery_completed(mcp, data, data_len):
-    logging.debug('%s %r', mcp_ev_discovery_completed.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH'
     if len(data) < struct.calcsize(fmt):
@@ -422,23 +422,19 @@ def mcp_ev_discovery_completed(mcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MCP Discovery: MCS and OTS service characteristic handles:'
-                  f'addr {addr} addr_type {addr_type},'
-                  f'Status {status}, Player Name {player_name}, Icon Obj ID {icon_obj_id},'
-                  f'Icon Url {icon_url}, Track Changed {track_changed}, Track Title {track_title},'
-                  f'Track Duration {track_duration}, Track Position {track_position},'
-                  f'Playback Speed {playback_speed}, Seeking Speed {seeking_speed},'
-                  f'Segments Obj ID {segments_obj_id}, Current Track Obj ID {current_track_obj_id},'
-                  f'Next Track Obj ID {next_track_obj_id}, Current Group Obj ID {current_group_obj_id}, '
-                  f'Parent Group Obj ID {parent_group_obj_id}, Playing Order {playing_order}, '
-                  f'Playing Orders Supported {playing_orders_supported}, Media State {media_state}, '
-                  f'Control Point {cp}, Opcodes Supported {opcodes_supported}, Search Control Point {scp},'
-                  f'Search Results Obj ID {search_results_obj_id}, Content Control ID {content_control_id},'
-                  f'OTS Feature {feature}, Object Name {obj_name}, Object Type {obj_type},'
-                  f'Object Size {obj_size}, Object Properties {obj_prop}, Object Created {obj_created},'
-                  f'Object Modified {obj_modified}, Object ID {obj_id},'
-                  f'Object Action Control Point {oacp},'
-                  f'Object List Control Point {olcp}')
+    logging.debug(
+        "MCP Discovery: MCS and OTS service characteristic handles:addr %r, addr_type %r, Status %r, Player Name %r,"
+        "Icon Obj ID %r, Icon Url %r, Track Changed %r, Track Title %r,Track Duration %r, Track Position %r,"
+        "Playback Speed %r, Seeking Speed %r, Segments Obj ID %r, Current Track Obj ID %r, Next Track Obj ID %r,"
+        "Current Group Obj ID %r, Parent Group Obj ID %r, Playing Order %r, Playing Orders Supported %r, Media State %r,"
+        "Control Point %r, Opcodes Supported %r, Search Control Point %r, Search Results Obj ID %r, Content Control ID %r,"
+        "OTS Feature %r, Object Name %r, Object Type %r,Object Size %r, Object Properties %r, Object Created %r,"
+        "Object Modified %r, Object ID %r, Object Action Control Point %r, Object List Control Point %r",
+        addr, addr_type, status, player_name, icon_obj_id, icon_url, track_changed, track_title, track_duration,
+        track_position, playback_speed, seeking_speed, segments_obj_id, current_track_obj_id, next_track_obj_id,
+        current_group_obj_id, parent_group_obj_id, playing_order, playing_orders_supported, media_state, cp,
+        opcodes_supported, scp, search_results_obj_id, content_control_id, feature, obj_name, obj_type, obj_size,
+        obj_prop, obj_created, obj_modified, obj_id, oacp, olcp)
 
     mcp.event_received(defs.BTP_MCP_EV_DISCOVERED, (addr_type, addr, status, player_name,
                                                 icon_obj_id, icon_url, track_changed,
@@ -454,7 +450,7 @@ def mcp_ev_discovery_completed(mcp, data, data_len):
 
 
 def mcp_track_duration_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_track_duration_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbI'
     if len(data) < struct.calcsize(fmt):
@@ -464,15 +460,15 @@ def mcp_track_duration_ev(mcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MCP Track Duration ev: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, track duration {duration}')
+    logging.debug("MCP Track Duration ev: addr %r, addr_type %r, Status %r, track duration %r",
+                  addr, addr_type, status, duration)
 
     mcp.event_received(defs.BTP_MCP_EV_TRACK_DURATION, (addr_type, addr, status,
                                                     duration))
 
 
 def mcp_track_position_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_track_position_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbI'
     if len(data) < struct.calcsize(fmt):
@@ -482,15 +478,15 @@ def mcp_track_position_ev(mcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MCP Track Position ev: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, track position {position}')
+    logging.debug("MCP Track Position ev: addr %r, addr_type %r, Status %r, track position %r",
+                  addr, addr_type, status, position)
 
     mcp.event_received(defs.BTP_MCP_EV_TRACK_POSITION, (addr_type, addr, status,
                                                     position))
 
 
 def mcp_playback_speed_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_playback_speed_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbb'
     if len(data) < struct.calcsize(fmt):
@@ -500,15 +496,15 @@ def mcp_playback_speed_ev(mcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MCP Playback speed: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, playback speed {speed}')
+    logging.debug("MCP Playback speed: addr %r, addr_type %r, Status %r, playback speed %r",
+                  addr, addr_type, status, speed)
 
     mcp.event_received(defs.BTP_MCP_EV_PLAYBACK_SPEED, (addr_type, addr, status,
                                                     speed))
 
 
 def mcp_seeking_speed_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_seeking_speed_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbb'
     if len(data) < struct.calcsize(fmt):
@@ -518,15 +514,15 @@ def mcp_seeking_speed_ev(mcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MCP Seeking speed: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, seeking speed {speed}')
+    logging.debug("MCP Seeking speed: addr %r, addr_type %r, Status %r, seeking speed %r",
+                  addr, addr_type, status, speed)
 
     mcp.event_received(defs.BTP_MCP_EV_SEEKING_SPEED, (addr_type, addr, status,
                                                    speed))
 
 
 def mcp_icon_obj_id_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_icon_obj_id_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sb'
     if len(data) < struct.calcsize(fmt):
@@ -537,15 +533,15 @@ def mcp_icon_obj_id_ev(mcp, data, data_len):
     obj_id_bytes = data[-6:]
     obj_id = int.from_bytes(obj_id_bytes, byteorder='little', signed=False)
 
-    logging.debug(f'MCP Icon Object ID: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, Icon Object ID {obj_id}')
+    logging.debug("MCP Icon Object ID: addr %r, addr_type %r, Status %r, Icon Object ID %r",
+                  addr, addr_type, status, obj_id)
 
     mcp.event_received(defs.BTP_MCP_EV_ICON_OBJ_ID, (addr_type, addr, status,
                                                  obj_id))
 
 
 def mcp_next_track_obj_id_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_next_track_obj_id_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sb'
     if len(data) < struct.calcsize(fmt):
@@ -556,15 +552,15 @@ def mcp_next_track_obj_id_ev(mcp, data, data_len):
     obj_id_bytes = data[-6:]
     obj_id = int.from_bytes(obj_id_bytes, byteorder='little', signed=False)
 
-    logging.debug(f'MCP Next Track Object ID: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, Next Track object ID {obj_id}')
+    logging.debug("MCP Next Track Object ID: addr %r, addr_type %r, Status %r, Next Track object ID %r",
+                  addr, addr_type, status, obj_id)
 
     mcp.event_received(defs.BTP_MCP_EV_NEXT_TRACK_OBJ_ID, (addr_type, addr, status,
                                                        obj_id))
 
 
 def mcp_parent_group_obj_id_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_parent_group_obj_id_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sb'
     if len(data) < struct.calcsize(fmt):
@@ -575,15 +571,15 @@ def mcp_parent_group_obj_id_ev(mcp, data, data_len):
     obj_id_bytes = data[-6:]
     obj_id = int.from_bytes(obj_id_bytes, byteorder='little', signed=False)
 
-    logging.debug(f'MCP Parent Group Object ID: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, Parent Group Object ID {obj_id}')
+    logging.debug("MCP Parent Group Object ID: addr %r, addr_type %r, Status %r, Parent Group Object ID %r",
+                  addr, addr_type, status, obj_id)
 
     mcp.event_received(defs.BTP_MCP_EV_PARENT_GROUP_OBJ_ID, (addr_type, addr, status,
                                                          obj_id))
 
 
 def mcp_current_group_obj_id_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_current_group_obj_id_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sb'
     if len(data) < struct.calcsize(fmt):
@@ -594,15 +590,15 @@ def mcp_current_group_obj_id_ev(mcp, data, data_len):
     obj_id_bytes = data[-6:]
     obj_id = int.from_bytes(obj_id_bytes, byteorder='little', signed=False)
 
-    logging.debug(f'MCP Current Group Object ID: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, Current Group Object ID {obj_id}')
+    logging.debug("MCP Current Group Object ID: addr %r, addr_type %r, Status %r, Current Group Object ID %r",
+                  addr, addr_type, status, obj_id)
 
     mcp.event_received(defs.BTP_MCP_EV_CURRENT_GROUP_OBJ_ID, (addr_type, addr, status,
                                                           obj_id))
 
 
 def mcp_playing_order_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_playing_order_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbb'
     if len(data) < struct.calcsize(fmt):
@@ -612,15 +608,15 @@ def mcp_playing_order_ev(mcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MCP Playing Order: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, playing order {order}')
+    logging.debug("MCP Playing Order: addr %r, addr_type %r, Status %r, playing order %r",
+                  addr, addr_type, status, order)
 
     mcp.event_received(defs.BTP_MCP_EV_PLAYING_ORDER, (addr_type, addr, status,
                                                    order))
 
 
 def mcp_playing_orders_supported_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_playing_orders_supported_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbB'
     if len(data) < struct.calcsize(fmt):
@@ -630,15 +626,15 @@ def mcp_playing_orders_supported_ev(mcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MCP Playing orders supported: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, playing orders supported {orders}')
+    logging.debug("MCP Playing orders supported: addr %r, addr_type %r, Status %r, playing orders supported %r",
+                  addr, addr_type, status, orders)
 
     mcp.event_received(defs.BTP_MCP_EV_PLAYING_ORDERS_SUPPORTED, (addr_type, addr,
                                                               status, orders))
 
 
 def mcp_media_state_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_media_state_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbb'
     if len(data) < struct.calcsize(fmt):
@@ -648,15 +644,15 @@ def mcp_media_state_ev(mcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MCP Media State: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, media state {state}')
+    logging.debug("MCP Media State: addr %r, addr_type %r, Status %r, media state %r",
+                  addr, addr_type, status, state)
 
     mcp.event_received(defs.BTP_MCP_EV_MEDIA_STATE, (addr_type, addr, status,
                                                  state))
 
 
 def mcp_opcodes_supported_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_opcodes_supported_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbI'
     if len(data) < struct.calcsize(fmt):
@@ -666,15 +662,15 @@ def mcp_opcodes_supported_ev(mcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MCP Opcodes Supported: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, opcodes {opcodes}')
+    logging.debug("MCP Opcodes Supported: addr %r, addr_type %r, Status %r, opcodes %r",
+                  addr, addr_type, status, opcodes)
 
     mcp.event_received(defs.BTP_MCP_EV_OPCODES_SUPPORTED, (addr_type, addr,
                                                        status, opcodes))
 
 
 def mcp_content_control_id_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_content_control_id_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbb'
     if len(data) < struct.calcsize(fmt):
@@ -684,15 +680,15 @@ def mcp_content_control_id_ev(mcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MCP Content Control ID: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, content control ID {ccid}')
+    logging.debug("MCP Content Control ID: addr %r, addr_type %r, Status %r, content control ID %r",
+                  addr, addr_type, status, ccid)
 
     mcp.event_received(defs.BTP_MCP_EV_CONTENT_CONTROL_ID, (addr_type, addr, status,
                                                         ccid))
 
 
 def mcp_segments_obj_id_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_segments_obj_id_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sb'
     if len(data) < struct.calcsize(fmt):
@@ -703,15 +699,15 @@ def mcp_segments_obj_id_ev(mcp, data, data_len):
     obj_id_bytes = data[-6:]
     obj_id = int.from_bytes(obj_id_bytes, byteorder='little', signed=False)
 
-    logging.debug(f'MCP Track Segments Object ID: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, Track Segments Object ID {obj_id}')
+    logging.debug("MCP Track Segments Object ID: addr %r, addr_type %r, Status %r, Track Segments Object ID %r",
+                  addr, addr_type, status, obj_id)
 
     mcp.event_received(defs.BTP_MCP_EV_SEGMENTS_OBJ_ID, (addr_type, addr, status,
                                                      obj_id))
 
 
 def mcp_current_track_obj_id_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_current_track_obj_id_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sb'
     if len(data) < struct.calcsize(fmt):
@@ -722,15 +718,15 @@ def mcp_current_track_obj_id_ev(mcp, data, data_len):
     obj_id_bytes = data[-6:]
     obj_id = int.from_bytes(obj_id_bytes, byteorder='little', signed=False)
 
-    logging.debug(f'MCP Current Track Object ID: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, Current Track Object ID {obj_id}')
+    logging.debug("MCP Current Track Object ID: addr %r, addr_type %r, Status %r, Current Track Object ID %r",
+                  addr, addr_type, status, obj_id)
 
     mcp.event_received(defs.BTP_MCP_EV_CURRENT_TRACK_OBJ_ID, (addr_type, addr, status,
                                                           obj_id))
 
 
 def mcp_control_point_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_control_point_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbbbI'
     if len(data) < struct.calcsize(fmt):
@@ -741,15 +737,15 @@ def mcp_control_point_ev(mcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MCP Media Control Point: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, Opcode {opcode}, Param {param}')
+    logging.debug("MCP Media Control Point: addr %r, addr_type %r, Status %r, Opcode %r, Param %r",
+                  addr, addr_type, status, opcode, param)
 
     mcp.event_received(defs.BTP_MCP_EV_COMMAND, (addr_type, addr, status, opcode,
                                              use_param, param))
 
 
 def mcp_search_control_point_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_search_control_point_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbbb'
 
@@ -763,16 +759,15 @@ def mcp_search_control_point_ev(mcp, data, data_len):
     param = struct.unpack_from(f'<{len(data) - fmt_size - 1}s',
                                data, offset=fmt_size)[0].decode('utf-8')
 
-    logging.debug(f'MCP Search Control Point: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, param_len {param_len},'
-                  f'search type {search}, param {param}')
+    logging.debug("MCP Search Control Point: addr %r, addr_type %r, Status %r, param_len %r, search type %r, param %r",
+                  addr, addr_type, status, param_len, search, param)
 
     mcp.event_received(defs.BTP_MCP_EV_SEARCH, (addr_type, addr, status, param_len,
                                             search, param))
 
 
 def mcp_cmd_ntf_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_cmd_ntf_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbbb'
     if len(data) < struct.calcsize(fmt):
@@ -783,16 +778,16 @@ def mcp_cmd_ntf_ev(mcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MCP Media Control Point Notification: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, Requested Opcode {requested_opcode},'
-                  f' Result Code {result_code}')
+    logging.debug(
+        "MCP Media Control Point Notification: addr %r, addr_type %r, Status %r, Requested Opcode %r, Result Code %r",
+        addr, addr_type, status, requested_opcode, result_code)
 
     mcp.event_received(defs.BTP_MCP_EV_CMD_NTF, (addr_type, addr, status,
                                              requested_opcode, result_code))
 
 
 def mcp_search_ntf_ev(mcp, data, data_len):
-    logging.debug('%s %r', mcp_search_ntf_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbb'
     if len(data) < struct.calcsize(fmt):
@@ -802,8 +797,8 @@ def mcp_search_ntf_ev(mcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MCP Search Control Point Notification: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, Result Code {result_code}')
+    logging.debug("MCP Search Control Point Notification: addr %r, addr_type %r, Status %r, Result Code %r",
+                  addr, addr_type, status, result_code)
 
     mcp.event_received(defs.BTP_MCP_EV_SEARCH_NTF, (addr_type, addr, status,
                                                 result_code))

--- a/autopts/pybtp/btp/mesh.py
+++ b/autopts/pybtp/btp/mesh.py
@@ -29,7 +29,7 @@ MESH = mesh_btp
 
 
 def mesh_config_prov():
-    logging.debug("%s", mesh_config_prov.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -63,7 +63,7 @@ def mesh_config_prov():
 
 
 def mesh_prov_node():
-    logging.debug("%s", mesh_prov_node.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -84,7 +84,7 @@ def mesh_prov_node():
 
 
 def mesh_provision_adv(uuid, addr, attention_duration):
-    logging.debug("%s %r %r %r", mesh_provision_adv.__name__, uuid, addr, attention_duration)
+    logging.debug("%r %r %r", uuid, addr, attention_duration)
 
     iutctl = get_iut()
     stack = get_stack()
@@ -99,7 +99,7 @@ def mesh_provision_adv(uuid, addr, attention_duration):
 
 
 def mesh_init(comp=0):
-    logging.debug("%s %r", mesh_init.__name__, comp)
+    logging.debug("%r", comp)
 
     iutctl = get_iut()
 
@@ -109,7 +109,7 @@ def mesh_init(comp=0):
 
 
 def mesh_start():
-    logging.debug("%s", mesh_start.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -123,7 +123,7 @@ def mesh_start():
 
 
 def mesh_reset():
-    logging.debug("%s", mesh_reset.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -138,7 +138,7 @@ def mesh_reset():
 
 
 def mesh_input_number(number):
-    logging.debug("%s %r", mesh_input_number.__name__, number)
+    logging.debug("%r", number)
 
     iutctl = get_iut()
 
@@ -151,7 +151,7 @@ def mesh_input_number(number):
 
 
 def mesh_input_string(string):
-    logging.debug("%s %s", mesh_input_string.__name__, string)
+    logging.debug("%s", string)
 
     iutctl = get_iut()
 
@@ -164,7 +164,7 @@ def mesh_input_string(string):
 
 
 def mesh_iv_update_test_mode(enable):
-    logging.debug("%s", mesh_iv_update_test_mode.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -180,7 +180,7 @@ def mesh_iv_update_test_mode(enable):
 
 
 def mesh_iv_update_toggle():
-    logging.debug("%s", mesh_iv_update_toggle.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -192,7 +192,7 @@ def mesh_iv_update_toggle():
 
 
 def mesh_net_send(ttl, src, dst, payload):
-    logging.debug("%s %r %r %r %r", mesh_net_send.__name__, ttl, src, dst,
+    logging.debug("%r %r %r %r", ttl, src, dst,
                   payload)
 
     if ttl is None:
@@ -220,7 +220,7 @@ def mesh_net_send(ttl, src, dst, payload):
 
 
 def mesh_va_add(label):
-    logging.debug("%s %r", mesh_va_add.__name__, label)
+    logging.debug("%r", label)
 
     label = binascii.unhexlify(label)
 
@@ -238,7 +238,7 @@ def mesh_va_add(label):
 
 
 def mesh_va_del(label):
-    logging.debug("%s %r", mesh_va_del.__name__, label)
+    logging.debug("%r", label)
 
     label = binascii.unhexlify(label)
 
@@ -253,7 +253,7 @@ def mesh_va_del(label):
 
 
 def mesh_health_generate_faults():
-    logging.debug("%s", mesh_health_generate_faults.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MESH['health_generate_faults'])
@@ -273,14 +273,14 @@ def mesh_health_generate_faults():
 
 
 def mesh_health_clear_faults():
-    logging.debug("%s", mesh_health_clear_faults.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send_wait_rsp(*MESH['mesh_clear_faults'])
 
 
 def mesh_lpn(enable):
-    logging.debug("%s %r", mesh_lpn.__name__, enable)
+    logging.debug("%r", enable)
 
     if enable:
         enable = 0x01
@@ -294,14 +294,14 @@ def mesh_lpn(enable):
 
 
 def mesh_lpn_poll():
-    logging.debug("%s", mesh_lpn_poll.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send_wait_rsp(*MESH['lpn_poll'])
 
 
 def mesh_model_send(src, dst, payload, ttl=0xff):
-    logging.debug("%s %r %r %r %r", mesh_model_send.__name__, src, dst, payload, ttl)
+    logging.debug("%r %r %r %r", src, dst, payload, ttl)
 
     if isinstance(src, str):
         src = int(src, 16)
@@ -326,7 +326,7 @@ def mesh_model_send(src, dst, payload, ttl=0xff):
 
 
 def mesh_lpn_subscribe(address):
-    logging.debug("%s %r", mesh_lpn_subscribe.__name__, address)
+    logging.debug("%r", address)
 
     if isinstance(address, str):
         address = int(address, 16)
@@ -338,7 +338,7 @@ def mesh_lpn_subscribe(address):
 
 
 def mesh_lpn_unsubscribe(address):
-    logging.debug("%s %r", mesh_lpn_unsubscribe.__name__, address)
+    logging.debug("%r", address)
 
     if isinstance(address, str):
         address = int(address, 16)
@@ -350,21 +350,21 @@ def mesh_lpn_unsubscribe(address):
 
 
 def mesh_rpl_clear():
-    logging.debug("%s", mesh_rpl_clear.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send_wait_rsp(*MESH['rpl_clear'])
 
 
 def mesh_proxy_identity():
-    logging.debug("%s", mesh_proxy_identity.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send_wait_rsp(*MESH['proxy_identity'])
 
 
 def mesh_proxy_private_identity(enabled):
-    logging.debug("%s %s", mesh_proxy_private_identity.__name__, "Enabled" if enabled else "Disable")
+    logging.debug("%s", "Enabled" if enabled else "Disable")
 
     enable = bytearray(struct.pack("<B", 0x01 if enabled else 0x00))
 
@@ -373,7 +373,7 @@ def mesh_proxy_private_identity(enabled):
 
 
 def mesh_sar_transmitter_get(dst):
-    logging.debug("%s 0x%02x", mesh_sar_transmitter_get.__name__, dst)
+    logging.debug("0x%02x", dst)
 
     data = bytearray(struct.pack("<H", dst))
 
@@ -388,7 +388,7 @@ def mesh_sar_transmitter_set(dst, seg_int_step,
                              unicast_retrans_int_inc,
                              multicast_retrans_count,
                              multicast_retrans_int):
-    logging.debug("%s 0x%02x %r %r %r %r %r %r %r", mesh_sar_transmitter_set.__name__,
+    logging.debug("0x%02x %r %r %r %r %r %r %r",
                   dst,
                   seg_int_step,
                   unicast_retrans_count,
@@ -411,7 +411,7 @@ def mesh_sar_transmitter_set(dst, seg_int_step,
 
 
 def mesh_sar_receiver_get(dst):
-    logging.debug("%s 0x%02x", mesh_sar_receiver_get.__name__, dst)
+    logging.debug("0x%02x", dst)
 
     data = bytearray(struct.pack("<H", dst))
 
@@ -424,7 +424,7 @@ def mesh_sar_receiver_set(dst, seg_thresh,
                           ack_retrans_count,
                           discard_timeout,
                           rx_seg_int_step):
-    logging.debug("%s 0x%02x %r %r %r %r %r", mesh_sar_receiver_set.__name__,
+    logging.debug("0x%02x %r %r %r %r %r",
                   dst,
                   seg_thresh,
                   ack_delay_inc,
@@ -443,7 +443,7 @@ def mesh_sar_receiver_set(dst, seg_thresh,
 
 
 def mesh_large_comp_data_get(net_idx, addr, page, offset):
-    logging.debug("%s %r %r %r %r", mesh_large_comp_data_get.__name__,
+    logging.debug("%r %r %r %r",
                   net_idx, addr, page, offset)
 
     data = bytearray(struct.pack("<HHBH", net_idx, addr, page, offset))
@@ -458,7 +458,7 @@ def mesh_large_comp_data_get(net_idx, addr, page, offset):
 
 
 def mesh_models_metadata_get(net_idx, addr, page, offset):
-    logging.debug("%s %r %r %r %r", mesh_models_metadata_get.__name__,
+    logging.debug("%r %r %r %r",
                   net_idx, addr, page, offset)
 
     data = bytearray(struct.pack("<HHBH", net_idx, addr, page, offset))
@@ -473,7 +473,7 @@ def mesh_models_metadata_get(net_idx, addr, page, offset):
 
 
 def mesh_opcodes_aggregator_init(net_idx, app_idx, dst, elem_addr):
-    logging.debug("%s %r %r %r %r", mesh_opcodes_aggregator_init.__name__,
+    logging.debug("%r %r %r %r",
                   net_idx, app_idx, dst, elem_addr)
 
     data = bytearray(struct.pack("<HHHH", net_idx, app_idx, dst, elem_addr))
@@ -483,14 +483,14 @@ def mesh_opcodes_aggregator_init(net_idx, app_idx, dst, elem_addr):
 
 
 def mesh_opcodes_aggregator_send():
-    logging.debug("%s", mesh_opcodes_aggregator_send.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send_wait_rsp(*MESH['opcodes_aggregator_send'])
 
 
 def mesh_out_number_action_ev(mesh, data, data_len):
-    logging.debug("%s %r", mesh_out_number_action_ev.__name__, data)
+    logging.debug("%r", data)
 
     action, number = struct.unpack_from('<HI', data)
 
@@ -499,7 +499,7 @@ def mesh_out_number_action_ev(mesh, data, data_len):
 
 
 def mesh_out_string_action_ev(mesh, data, data_len):
-    logging.debug("%s %r", mesh_out_string_action_ev.__name__, data)
+    logging.debug("%r", data)
 
     hdr_fmt = '<B'
     hdr_len = struct.calcsize(hdr_fmt)
@@ -511,13 +511,13 @@ def mesh_out_string_action_ev(mesh, data, data_len):
 
 
 def mesh_in_action_ev(mesh, data, data_len):
-    logging.debug("%s %r", mesh_in_action_ev.__name__, data)
+    logging.debug("%r", data)
 
     action, size = struct.unpack('<HB', data)
 
 
 def mesh_provisioned_ev(mesh, data, data_len):
-    logging.debug("%s %r", mesh_provisioned_ev.__name__, data)
+    logging.debug("%r", data)
     stack = get_stack()
 
     mesh.is_provisioned.data = True
@@ -527,7 +527,7 @@ def mesh_provisioned_ev(mesh, data, data_len):
 
 
 def mesh_prov_link_open_ev(mesh, data, data_len):
-    logging.debug("%s %r", mesh_prov_link_open_ev.__name__, data)
+    logging.debug("%r", data)
 
     (bearer,) = struct.unpack('<B', data)
 
@@ -535,7 +535,7 @@ def mesh_prov_link_open_ev(mesh, data, data_len):
 
 
 def mesh_prov_link_closed_ev(mesh, data, data_len):
-    logging.debug("%s %r", mesh_prov_link_closed_ev.__name__, data)
+    logging.debug("%r", data)
     stack = get_stack()
 
     (bearer,) = struct.unpack('<B', data)
@@ -569,7 +569,7 @@ def mesh_net_rcv_ev(mesh, data, data_len):
     if not stack.mesh.net_recv_ev_store.data:
         return
 
-    logging.debug("%s %r %r", mesh_net_rcv_ev.__name__, data, data_len)
+    logging.debug("%r %r", data, data_len)
 
     hdr_fmt = '<BBHHB'
     hdr_len = struct.calcsize(hdr_fmt)
@@ -584,7 +584,7 @@ def mesh_net_rcv_ev(mesh, data, data_len):
 def mesh_invalid_bearer_ev(mesh, data, data_len):
     stack = get_stack()
 
-    logging.debug("%s %r %r", mesh_invalid_bearer_ev.__name__, data, data_len)
+    logging.debug("%r %r", data, data_len)
 
     hdr_fmt = '<B'
     (opcode,) = struct.unpack_from(hdr_fmt, data, 0)
@@ -593,7 +593,7 @@ def mesh_invalid_bearer_ev(mesh, data, data_len):
 
 
 def mesh_incomp_timer_exp_ev(mesh, data, data_len):
-    logging.debug("%s", mesh_incomp_timer_exp_ev.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -601,7 +601,7 @@ def mesh_incomp_timer_exp_ev(mesh, data, data_len):
 
 
 def mesh_frnd_established_ev(mesh, data, data_len):
-    logging.debug("%s", mesh_frnd_established_ev.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -614,7 +614,7 @@ def mesh_frnd_established_ev(mesh, data, data_len):
 
 
 def mesh_frnd_terminated_ev(mesh, data, data_len):
-    logging.debug("%s", mesh_frnd_terminated_ev.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -626,7 +626,7 @@ def mesh_frnd_terminated_ev(mesh, data, data_len):
 
 
 def mesh_lpn_established_ev(mesh, data, data_len):
-    logging.debug("%s", mesh_lpn_established_ev.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -639,7 +639,7 @@ def mesh_lpn_established_ev(mesh, data, data_len):
 
 
 def mesh_lpn_terminated_ev(mesh, data, data_len):
-    logging.debug("%s", mesh_lpn_terminated_ev.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -651,7 +651,7 @@ def mesh_lpn_terminated_ev(mesh, data, data_len):
 
 
 def mesh_cfg_beacon_get(net_idx, addr):
-    logging.debug("%s", mesh_cfg_beacon_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -665,7 +665,7 @@ def mesh_cfg_beacon_get(net_idx, addr):
 
 
 def mesh_cfg_beacon_set(net_idx, addr, val):
-    logging.debug("%s", mesh_cfg_beacon_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -679,7 +679,7 @@ def mesh_cfg_beacon_set(net_idx, addr, val):
 
 
 def mesh_composition_data_get(net_idx, addr, page):
-    logging.debug("%s", mesh_composition_data_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -699,7 +699,7 @@ def mesh_composition_data_get(net_idx, addr, page):
 
 
 def mesh_cfg_krp_get(net_idx, addr, net_key_idx):
-    logging.debug("%s", mesh_cfg_krp_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -714,7 +714,7 @@ def mesh_cfg_krp_get(net_idx, addr, net_key_idx):
 
 
 def mesh_cfg_krp_set(net_idx, addr, net_key_idx, phase):
-    logging.debug("%s", mesh_cfg_krp_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -729,7 +729,7 @@ def mesh_cfg_krp_set(net_idx, addr, net_key_idx, phase):
 
 
 def mesh_cfg_default_ttl_get(net_idx, addr):
-    logging.debug("%s", mesh_cfg_default_ttl_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -742,7 +742,7 @@ def mesh_cfg_default_ttl_get(net_idx, addr):
 
 
 def mesh_cfg_default_ttl_set(net_idx, addr, val):
-    logging.debug("%s", mesh_cfg_default_ttl_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -756,7 +756,7 @@ def mesh_cfg_default_ttl_set(net_idx, addr, val):
 
 
 def mesh_cfg_gatt_proxy_get(net_idx, addr):
-    logging.debug("%s", mesh_cfg_gatt_proxy_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -770,7 +770,7 @@ def mesh_cfg_gatt_proxy_get(net_idx, addr):
 
 
 def mesh_cfg_gatt_proxy_set(net_idx, addr, val):
-    logging.debug("%s", mesh_cfg_gatt_proxy_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -784,7 +784,7 @@ def mesh_cfg_gatt_proxy_set(net_idx, addr, val):
 
 
 def mesh_cfg_friend_get(net_idx, addr):
-    logging.debug("%s", mesh_cfg_friend_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -798,7 +798,7 @@ def mesh_cfg_friend_get(net_idx, addr):
 
 
 def mesh_cfg_friend_set(net_idx, addr, val):
-    logging.debug("%s", mesh_cfg_friend_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -812,7 +812,7 @@ def mesh_cfg_friend_set(net_idx, addr, val):
 
 
 def mesh_cfg_relay_get(net_idx, addr):
-    logging.debug("%s", mesh_cfg_relay_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -826,7 +826,7 @@ def mesh_cfg_relay_get(net_idx, addr):
 
 
 def mesh_cfg_relay_set(net_idx, addr, new_relay, new_transmit):
-    logging.debug("%s", mesh_cfg_relay_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -840,7 +840,7 @@ def mesh_cfg_relay_set(net_idx, addr, new_relay, new_transmit):
 
 
 def mesh_cfg_model_publication_get(net_idx, addr, el_address, model_id):
-    logging.debug("%s", mesh_cfg_model_publication_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -855,7 +855,7 @@ def mesh_cfg_model_publication_get(net_idx, addr, el_address, model_id):
 
 def mesh_cfg_model_publication_set(net_idx, addr, el_address, model_id, pub_addr, appkey_index,
                                       cred_flag, ttl, period, transmit):
-    logging.debug("%s", mesh_cfg_model_publication_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -871,7 +871,7 @@ def mesh_cfg_model_publication_set(net_idx, addr, el_address, model_id, pub_addr
 
 def mesh_cfg_model_pub_va_set(net_idx, addr, el_address, model_id, uuid, appkey_index,
                                  cred_flag, ttl, period, transmit):
-    logging.debug("%s", mesh_cfg_model_pub_va_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -888,7 +888,7 @@ def mesh_cfg_model_pub_va_set(net_idx, addr, el_address, model_id, uuid, appkey_
 
 
 def mesh_cfg_model_sub_add(net_idx, addr, el_address, sub_address, model_id):
-    logging.debug("%s", mesh_cfg_model_sub_add.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -902,7 +902,7 @@ def mesh_cfg_model_sub_add(net_idx, addr, el_address, sub_address, model_id):
 
 
 def mesh_cfg_model_sub_del(net_idx, addr, el_address, sub_address, model_id):
-    logging.debug("%s", mesh_cfg_model_sub_del.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -916,7 +916,7 @@ def mesh_cfg_model_sub_del(net_idx, addr, el_address, sub_address, model_id):
 
 
 def mesh_cfg_model_sub_ovw(net_idx, addr, el_address, sub_address, model_id):
-    logging.debug("%s", mesh_cfg_model_sub_ovw.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -930,7 +930,7 @@ def mesh_cfg_model_sub_ovw(net_idx, addr, el_address, sub_address, model_id):
 
 
 def mesh_cfg_model_sub_del_all(net_idx, addr, el_address, model_id):
-    logging.debug("%s", mesh_cfg_model_sub_del_all.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -944,7 +944,7 @@ def mesh_cfg_model_sub_del_all(net_idx, addr, el_address, model_id):
 
 
 def mesh_cfg_model_sub_get(net_idx, addr, el_address, model_id):
-    logging.debug("%s", mesh_cfg_model_sub_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -958,7 +958,7 @@ def mesh_cfg_model_sub_get(net_idx, addr, el_address, model_id):
 
 
 def mesh_cfg_model_sub_vnd_get(net_idx, addr, el_address, model_id, cid):
-    logging.debug("%s", mesh_cfg_model_sub_vnd_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -972,7 +972,7 @@ def mesh_cfg_model_sub_vnd_get(net_idx, addr, el_address, model_id, cid):
 
 
 def mesh_cfg_model_sub_va_add(net_idx, addr, el_address, model_id, uuid):
-    logging.debug("%s", mesh_cfg_model_sub_va_add.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -988,7 +988,7 @@ def mesh_cfg_model_sub_va_add(net_idx, addr, el_address, model_id, uuid):
 
 
 def mesh_cfg_model_sub_va_del(net_idx, addr, el_address, model_id, uuid):
-    logging.debug("%s", mesh_cfg_model_sub_va_del.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1004,7 +1004,7 @@ def mesh_cfg_model_sub_va_del(net_idx, addr, el_address, model_id, uuid):
 
 
 def mesh_cfg_model_sub_va_ovw(net_idx, addr, el_address, model_id, uuid):
-    logging.debug("%s", mesh_cfg_model_sub_va_ovw.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1020,7 +1020,7 @@ def mesh_cfg_model_sub_va_ovw(net_idx, addr, el_address, model_id, uuid):
 
 
 def mesh_cfg_netkey_add(net_idx, addr, net_key, net_key_idx):
-    logging.debug("%s", mesh_cfg_netkey_add.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1036,7 +1036,7 @@ def mesh_cfg_netkey_add(net_idx, addr, net_key, net_key_idx):
 
 
 def mesh_cfg_netkey_get(net_idx, addr, net_key_idx):
-    logging.debug("%s", mesh_cfg_netkey_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1050,7 +1050,7 @@ def mesh_cfg_netkey_get(net_idx, addr, net_key_idx):
 
 
 def mesh_cfg_netkey_update(net_idx, addr, net_key, net_key_idx):
-    logging.debug("%s", mesh_cfg_netkey_update.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1066,7 +1066,7 @@ def mesh_cfg_netkey_update(net_idx, addr, net_key, net_key_idx):
 
 
 def mesh_cfg_netkey_del(net_idx, addr, net_key_idx):
-    logging.debug("%s", mesh_cfg_netkey_del.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1080,7 +1080,7 @@ def mesh_cfg_netkey_del(net_idx, addr, net_key_idx):
 
 
 def mesh_cfg_appkey_add(net_idx, addr, net_key_idx, app_key, app_key_idx):
-    logging.debug("%s", mesh_cfg_appkey_add.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1096,7 +1096,7 @@ def mesh_cfg_appkey_add(net_idx, addr, net_key_idx, app_key, app_key_idx):
 
 
 def mesh_cfg_appkey_update(net_idx, addr, net_key_idx, app_key, app_key_idx):
-    logging.debug("%s", mesh_cfg_appkey_update.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1112,7 +1112,7 @@ def mesh_cfg_appkey_update(net_idx, addr, net_key_idx, app_key, app_key_idx):
 
 
 def mesh_cfg_appkey_del(net_idx, addr, net_key_idx, app_key_idx):
-    logging.debug("%s", mesh_cfg_appkey_del.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1126,7 +1126,7 @@ def mesh_cfg_appkey_del(net_idx, addr, net_key_idx, app_key_idx):
 
 
 def mesh_cfg_appkey_get(net_idx, addr, net_key_idx):
-    logging.debug("%s", mesh_cfg_appkey_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1140,7 +1140,7 @@ def mesh_cfg_appkey_get(net_idx, addr, net_key_idx):
 
 
 def mesh_cfg_model_app_bind(net_idx, addr, el_address, app_key_idx, model_id):
-    logging.debug("%s", mesh_cfg_model_app_bind.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1154,7 +1154,7 @@ def mesh_cfg_model_app_bind(net_idx, addr, el_address, app_key_idx, model_id):
 
 
 def mesh_config_model_app_bind_vnd(net_idx, addr, el_address, app_key_idx, model_id, cid):
-    logging.debug("%s", mesh_config_model_app_bind_vnd.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1168,7 +1168,7 @@ def mesh_config_model_app_bind_vnd(net_idx, addr, el_address, app_key_idx, model
 
 
 def mesh_cfg_model_app_unbind(net_idx, addr, el_address, app_key_idx, model_id):
-    logging.debug("%s", mesh_cfg_model_app_unbind.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1182,7 +1182,7 @@ def mesh_cfg_model_app_unbind(net_idx, addr, el_address, app_key_idx, model_id):
 
 
 def mesh_cfg_model_app_get(net_idx, addr, el_address, model_id):
-    logging.debug("%s", mesh_cfg_model_app_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1196,7 +1196,7 @@ def mesh_cfg_model_app_get(net_idx, addr, el_address, model_id):
 
 
 def mesh_cfg_model_app_vnd_get(net_idx, addr, el_address, model_id, cid):
-    logging.debug("%s", mesh_cfg_model_app_vnd_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1210,7 +1210,7 @@ def mesh_cfg_model_app_vnd_get(net_idx, addr, el_address, model_id, cid):
 
 
 def mesh_cfg_heartbeat_pub_set(net_idx, addr, net_key_idx, destination, count_log, period_log, ttl, features):
-    logging.debug("%s", mesh_cfg_heartbeat_pub_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1225,7 +1225,7 @@ def mesh_cfg_heartbeat_pub_set(net_idx, addr, net_key_idx, destination, count_lo
 
 
 def mesh_cfg_heartbeat_pub_get(net_idx, addr):
-    logging.debug("%s", mesh_cfg_heartbeat_pub_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1239,7 +1239,7 @@ def mesh_cfg_heartbeat_pub_get(net_idx, addr):
 
 
 def mesh_cfg_heartbeat_sub_set(net_idx, addr, source, destination, period_log):
-    logging.debug("%s", mesh_cfg_heartbeat_sub_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1253,7 +1253,7 @@ def mesh_cfg_heartbeat_sub_set(net_idx, addr, source, destination, period_log):
 
 
 def mesh_cfg_heartbeat_sub_get(net_idx, addr):
-    logging.debug("%s", mesh_cfg_heartbeat_sub_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1267,7 +1267,7 @@ def mesh_cfg_heartbeat_sub_get(net_idx, addr):
 
 
 def mesh_cfg_net_transmit_get(net_idx, addr):
-    logging.debug("%s", mesh_cfg_net_transmit_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1281,7 +1281,7 @@ def mesh_cfg_net_transmit_get(net_idx, addr):
 
 
 def mesh_cfg_net_transmit_set(net_idx, addr, transmit):
-    logging.debug("%s", mesh_cfg_net_transmit_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1295,7 +1295,7 @@ def mesh_cfg_net_transmit_set(net_idx, addr, transmit):
 
 
 def mesh_cfg_node_idt_set(net_idx, addr, net_key_idx, identity):
-    logging.debug("%s", mesh_cfg_node_idt_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1311,7 +1311,7 @@ def mesh_cfg_node_idt_set(net_idx, addr, net_key_idx, identity):
 
 
 def mesh_cfg_node_idt_get(net_idx, addr, net_key_idx):
-    logging.debug("%s", mesh_cfg_node_idt_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1326,7 +1326,7 @@ def mesh_cfg_node_idt_get(net_idx, addr, net_key_idx):
 
 
 def mesh_cfg_node_reset(net_idx, addr):
-    logging.debug("%s", mesh_cfg_node_reset.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1340,7 +1340,7 @@ def mesh_cfg_node_reset(net_idx, addr):
 
 
 def mesh_cfg_lpn_polltimeout_get(net_idx, addr, unicast_addr):
-    logging.debug("%s", mesh_cfg_lpn_polltimeout_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1355,7 +1355,7 @@ def mesh_cfg_lpn_polltimeout_get(net_idx, addr, unicast_addr):
 
 
 def mesh_health_fault_get(addr, app_idx, cid):
-    logging.debug("%s", mesh_health_fault_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1366,7 +1366,7 @@ def mesh_health_fault_get(addr, app_idx, cid):
 
 
 def mesh_health_fault_clear(addr, app_idx, cid, ack):
-    logging.debug("%s", mesh_health_fault_clear.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1381,7 +1381,7 @@ def mesh_health_fault_clear(addr, app_idx, cid, ack):
 
 
 def mesh_health_fault_test(addr, app_idx, cid, test_id, ack):
-    logging.debug("%s", mesh_health_fault_test.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1396,7 +1396,7 @@ def mesh_health_fault_test(addr, app_idx, cid, test_id, ack):
 
 
 def mesh_health_period_get(addr, app_idx):
-    logging.debug("%s", mesh_health_period_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1407,7 +1407,7 @@ def mesh_health_period_get(addr, app_idx):
 
 
 def mesh_health_period_set(addr, app_idx, divisor, ack):
-    logging.debug("%s", mesh_health_period_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1422,7 +1422,7 @@ def mesh_health_period_set(addr, app_idx, divisor, ack):
 
 
 def mesh_health_attention_get(addr, app_idx):
-    logging.debug("%s", mesh_health_attention_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1433,7 +1433,7 @@ def mesh_health_attention_get(addr, app_idx):
 
 
 def mesh_health_attention_set(addr, app_idx, attention, ack):
-    logging.debug("%s", mesh_health_attention_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1448,7 +1448,7 @@ def mesh_health_attention_set(addr, app_idx, attention, ack):
 
 
 def mesh_proxy_connect(net_idx=None):
-    logging.debug("%s", mesh_proxy_connect.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -1463,7 +1463,7 @@ def mesh_proxy_connect(net_idx=None):
 
 
 def mesh_comp_change_prepare():
-    logging.debug("%s", mesh_comp_change_prepare.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1474,7 +1474,7 @@ def mesh_comp_change_prepare():
 
 
 def mesh_priv_beacon_get(dst):
-    logging.debug("%s", mesh_priv_beacon_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1485,7 +1485,7 @@ def mesh_priv_beacon_get(dst):
 
 
 def mesh_priv_beacon_set(dst, enabled, rand_interval):
-    logging.debug("%s", mesh_priv_beacon_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1496,7 +1496,7 @@ def mesh_priv_beacon_set(dst, enabled, rand_interval):
 
 
 def mesh_priv_gatt_proxy_get(dst):
-    logging.debug("%s", mesh_priv_gatt_proxy_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1507,7 +1507,7 @@ def mesh_priv_gatt_proxy_get(dst):
 
 
 def mesh_priv_gatt_proxy_set(dst, state):
-    logging.debug("%s", mesh_priv_gatt_proxy_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1518,7 +1518,7 @@ def mesh_priv_gatt_proxy_set(dst, state):
 
 
 def mesh_priv_node_id_get(dst, key_net_idx):
-    logging.debug("%s", mesh_priv_node_id_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1529,7 +1529,7 @@ def mesh_priv_node_id_get(dst, key_net_idx):
 
 
 def mesh_priv_node_id_set(dst, net_idx, state):
-    logging.debug("%s", mesh_priv_node_id_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1540,7 +1540,7 @@ def mesh_priv_node_id_set(dst, net_idx, state):
 
 
 def mesh_rpr_scan_start(dst, timeout, uuid):
-    logging.debug("%s", mesh_rpr_scan_start.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1550,7 +1550,7 @@ def mesh_rpr_scan_start(dst, timeout, uuid):
 
 
 def mesh_rpr_ext_scan_start(dst, timeout, uuid, ad_count, ad_types):
-    logging.debug("%s", mesh_rpr_ext_scan_start.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1562,7 +1562,7 @@ def mesh_rpr_ext_scan_start(dst, timeout, uuid, ad_count, ad_types):
 
 
 def mesh_rpr_scan_caps_get(dst):
-    logging.debug("%s", mesh_rpr_scan_caps_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1572,7 +1572,7 @@ def mesh_rpr_scan_caps_get(dst):
 
 
 def mesh_rpr_scan_get(dst):
-    logging.debug("%s", mesh_rpr_scan_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1582,7 +1582,7 @@ def mesh_rpr_scan_get(dst):
 
 
 def mesh_rpr_scan_stop(dst):
-    logging.debug("%s", mesh_rpr_scan_stop.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1592,7 +1592,7 @@ def mesh_rpr_scan_stop(dst):
 
 
 def mesh_rpr_link_get(dst):
-    logging.debug("%s", mesh_rpr_link_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1602,7 +1602,7 @@ def mesh_rpr_link_get(dst):
 
 
 def mesh_rpr_link_close(dst):
-    logging.debug("%s", mesh_rpr_link_close.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1612,7 +1612,7 @@ def mesh_rpr_link_close(dst):
 
 
 def mesh_rpr_prov_remote(dst, uuid, net_idx, addr):
-    logging.debug("%s", mesh_rpr_prov_remote.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1622,7 +1622,7 @@ def mesh_rpr_prov_remote(dst, uuid, net_idx, addr):
 
 
 def mesh_rpr_reprov_remote(dst, addr, comp_change):
-    logging.debug("%s", mesh_rpr_reprov_remote.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1632,7 +1632,7 @@ def mesh_rpr_reprov_remote(dst, addr, comp_change):
 
 
 def mesh_subnet_bridge_get(dst):
-    logging.debug("%s", mesh_subnet_bridge_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1643,7 +1643,7 @@ def mesh_subnet_bridge_get(dst):
 
 
 def mesh_subnet_bridge_set(dst, val):
-    logging.debug("%s", mesh_subnet_bridge_set.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1654,7 +1654,7 @@ def mesh_subnet_bridge_set(dst, val):
 
 
 def mesh_bridging_table_add(dst, direction, net_idx1, net_idx2, addr1, addr2):
-    logging.debug("%s", mesh_bridging_table_add.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1665,7 +1665,7 @@ def mesh_bridging_table_add(dst, direction, net_idx1, net_idx2, addr1, addr2):
 
 
 def mesh_bridging_table_remove(dst, net_idx1, net_idx2, addr1, addr2):
-    logging.debug("%s", mesh_bridging_table_remove.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1676,7 +1676,7 @@ def mesh_bridging_table_remove(dst, net_idx1, net_idx2, addr1, addr2):
 
 
 def mesh_bridged_subnets_get(dst, filter_mesh, net_idx, start_idx):
-    logging.debug("%s", mesh_bridged_subnets_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1687,7 +1687,7 @@ def mesh_bridged_subnets_get(dst, filter_mesh, net_idx, start_idx):
 
 
 def mesh_bridging_table_get(dst, net_idx1, net_idx2, start_idx):
-    logging.debug("%s", mesh_bridging_table_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1698,7 +1698,7 @@ def mesh_bridging_table_get(dst, net_idx1, net_idx2, start_idx):
 
 
 def mesh_bridge_capability_get(dst):
-    logging.debug("%s", mesh_bridge_capability_get.__name__)
+    logging.debug("")
 
     stack = get_stack()
     iutctl = get_iut()
@@ -1709,7 +1709,7 @@ def mesh_bridge_capability_get(dst):
 
 
 def mesh_od_priv_proxy_get(dst):
-    logging.debug("%s", mesh_od_priv_proxy_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1719,7 +1719,7 @@ def mesh_od_priv_proxy_get(dst):
 
 
 def mesh_od_priv_proxy_set(dst, val):
-    logging.debug("%s", mesh_od_priv_proxy_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1729,7 +1729,7 @@ def mesh_od_priv_proxy_set(dst, val):
 
 
 def mesh_srpl_clear(dst, range_start, range_len, acked):
-    logging.debug("%s", mesh_srpl_clear.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1739,7 +1739,7 @@ def mesh_srpl_clear(dst, range_start, range_len, acked):
 
 
 def mesh_proxy_solicit(net_idx=None):
-    logging.debug("%s", mesh_proxy_solicit.__name__)
+    logging.debug("")
 
     stack = get_stack()
 
@@ -1754,7 +1754,7 @@ def mesh_proxy_solicit(net_idx=None):
 
 
 def mesh_lpn_polled_ev(mesh, data, data_len):
-    logging.debug("%s", mesh_lpn_polled_ev.__name__)
+    logging.debug("")
 
     hdr_fmt = '<HHB'
 
@@ -1762,7 +1762,7 @@ def mesh_lpn_polled_ev(mesh, data, data_len):
 
 
 def mesh_prov_node_added_ev(mesh, data, data_len):
-    logging.debug("%s", mesh_prov_node_added_ev.__name__)
+    logging.debug("")
 
     stack = get_stack()
     hdr_fmt = '<HH16sB'
@@ -1774,7 +1774,7 @@ def mesh_prov_node_added_ev(mesh, data, data_len):
 
 
 def mesh_model_recv_ev(mesh, data, data_len):
-    logging.debug("%s %r %r", mesh_model_recv_ev.__name__, data, data_len)
+    logging.debug("%r %r", data, data_len)
 
     stack = get_stack()
 
@@ -1796,7 +1796,7 @@ def mesh_model_recv_ev(mesh, data, data_len):
 
 
 def mesh_blob_lost_target_ev(mesh, data, data_len):
-    logging.debug("%s %r %r", mesh_blob_lost_target_ev.__name__, data, data_len)
+    logging.debug("%r %r", data, data_len)
 
     stack = get_stack()
 

--- a/autopts/pybtp/btp/micp.py
+++ b/autopts/pybtp/btp/micp.py
@@ -39,7 +39,7 @@ MICP = {
 
 
 def micp_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", micp_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -60,7 +60,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def micp_discover(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{micp_discover.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -71,7 +71,7 @@ def micp_discover(bd_addr_type=None, bd_addr=None):
 
 
 def micp_mute(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{micp_mute.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -82,7 +82,7 @@ def micp_mute(bd_addr_type=None, bd_addr=None):
 
 
 def micp_mute_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{micp_mute_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -93,7 +93,7 @@ def micp_mute_read(bd_addr_type=None, bd_addr=None):
 
 
 def micp_ev_discovery_completed_(micp, data, data_len):
-    logging.debug('%s %r', micp_ev_discovery_completed_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbHHHHHHH'
     if len(data) < struct.calcsize(fmt):
@@ -104,11 +104,10 @@ def micp_ev_discovery_completed_(micp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MICP Discovery completed: addr {addr}, addr_type {addr_type}, '
-                  f'att_status {att_status} mute handle {mute_handle},'
-                  f' state handle {state_handle}, gain handle {gain_handle},'
-                  f' type handle {type_handle}, status handle {status_handle},'
-                  f' control handle {control_handle}, description handle {desc_handle}')
+    logging.debug("MICP Discovery completed: addr %r, addr_type %r, att_status %r, mute handle %r, state handle %r,"
+                  "gain handle %r, type handle %r, status handle %r, control handle %r, description handle %r",
+                  addr, addr_type, att_status, mute_handle, state_handle, gain_handle, type_handle, status_handle,
+                  control_handle, desc_handle)
 
     micp.event_received(defs.BTP_MICP_EV_DISCOVERED, (addr_type, addr, att_status, mute_handle,
                                                   state_handle, gain_handle, type_handle,
@@ -116,7 +115,7 @@ def micp_ev_discovery_completed_(micp, data, data_len):
 
 
 def micp_mute_state_ev(micp, data, data_len):
-    logging.debug('%s %r', micp_mute_state_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbb'
     if len(data) < struct.calcsize(fmt):
@@ -126,8 +125,8 @@ def micp_mute_state_ev(micp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'MICP Mute Read: addr {addr} addr_type '
-                  f'{addr_type}, att_status {att_status} mute {mute}')
+    logging.debug("MICP Mute Read: addr %r, addr_type %r, att_status %r, mute %r",
+                  addr, addr_type, att_status, mute)
 
     micp.event_received(defs.BTP_MICP_EV_MUTE_STATE, (addr_type, addr, att_status, mute))
 

--- a/autopts/pybtp/btp/mics.py
+++ b/autopts/pybtp/btp/mics.py
@@ -42,7 +42,7 @@ MICS = {
 
 
 def mics_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", mics_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -63,7 +63,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def mics_mute_disable():
-    logging.debug(f"{mics_mute_disable.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -73,7 +73,7 @@ def mics_mute_disable():
 
 
 def mics_mute_read():
-    logging.debug(f"{mics_mute_read.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -83,7 +83,7 @@ def mics_mute_read():
 
 
 def mics_mute():
-    logging.debug(f"{mics_mute.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -93,7 +93,7 @@ def mics_mute():
 
 
 def mics_unmute():
-    logging.debug(f"{mics_unmute.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -103,7 +103,7 @@ def mics_unmute():
 
 
 def mics_mute_state_ev(mics, data, data_len):
-    logging.debug('%s %r', mics_mute_state_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<b'
     if len(data) < struct.calcsize(fmt):
@@ -111,7 +111,7 @@ def mics_mute_state_ev(mics, data, data_len):
 
     mute = struct.unpack_from(fmt, data)
 
-    logging.debug(f'MICS Mute state: {mute[0]}')
+    logging.debug("MICS Mute state: %r", mute[0])
 
     mics.event_received(defs.BTP_MICS_EV_MUTE_STATE, mute)
 

--- a/autopts/pybtp/btp/mmdl.py
+++ b/autopts/pybtp/btp/mmdl.py
@@ -351,7 +351,7 @@ MMDL = {
 
 
 def mmdl_gen_onoff_get():
-    logging.debug("%s", mmdl_gen_onoff_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -366,7 +366,7 @@ def mmdl_gen_onoff_get():
 
 
 def mmdl_gen_onoff_set(onoff, tt=None, delay=None, ack=True):
-    logging.debug("%s", mmdl_gen_onoff_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BB", ack, onoff))
@@ -391,7 +391,7 @@ def mmdl_gen_onoff_set(onoff, tt=None, delay=None, ack=True):
 
 
 def mmdl_gen_lvl_get():
-    logging.debug("%s", mmdl_gen_lvl_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['gen_lvl_get'])
@@ -405,7 +405,7 @@ def mmdl_gen_lvl_get():
 
 
 def mmdl_gen_lvl_set(lvl, tt=None, delay=None, ack=True):
-    logging.debug("%s", mmdl_gen_lvl_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<Bh", ack, lvl))
@@ -429,7 +429,7 @@ def mmdl_gen_lvl_set(lvl, tt=None, delay=None, ack=True):
 
 
 def mmdl_gen_lvl_delta_set(delta, tt=None, delay=None, ack=True):
-    logging.debug("%s", mmdl_gen_lvl_delta_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<Bi", ack, delta))
@@ -454,7 +454,7 @@ def mmdl_gen_lvl_delta_set(delta, tt=None, delay=None, ack=True):
 
 
 def mmdl_gen_lvl_move_set(move, tt=None, delay=None, ack=True):
-    logging.debug("%s", mmdl_gen_lvl_move_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<Bh", ack, move))
@@ -479,7 +479,7 @@ def mmdl_gen_lvl_move_set(move, tt=None, delay=None, ack=True):
 
 
 def mmdl_gen_dtt_get():
-    logging.debug("%s", mmdl_gen_dtt_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['gen_dtt_get'])
@@ -492,7 +492,7 @@ def mmdl_gen_dtt_get():
 
 
 def mmdl_gen_dtt_set(tt, ack=True):
-    logging.debug("%s", mmdl_gen_dtt_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BB", ack, tt))
@@ -509,7 +509,7 @@ def mmdl_gen_dtt_set(tt, ack=True):
 
 
 def mmdl_gen_ponoff_get():
-    logging.debug("%s", mmdl_gen_ponoff_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['gen_ponoff_get'])
@@ -523,7 +523,7 @@ def mmdl_gen_ponoff_get():
 
 
 def mmdl_gen_ponoff_set(on_power_up, ack=True):
-    logging.debug("%s", mmdl_gen_ponoff_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BB", ack, on_power_up))
@@ -541,7 +541,7 @@ def mmdl_gen_ponoff_set(on_power_up, ack=True):
 
 
 def mmdl_gen_plvl_get():
-    logging.debug("%s", mmdl_gen_plvl_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['gen_plvl_get'])
@@ -555,7 +555,7 @@ def mmdl_gen_plvl_get():
 
 
 def mmdl_gen_plvl_set(power_lvl, tt=None, delay=None, ack=True):
-    logging.debug("%s", mmdl_gen_plvl_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BH", ack, power_lvl))
@@ -580,7 +580,7 @@ def mmdl_gen_plvl_set(power_lvl, tt=None, delay=None, ack=True):
 
 
 def mmdl_gen_plvl_last_get():
-    logging.debug("%s", mmdl_gen_plvl_last_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['gen_plvl_last_get'])
@@ -594,7 +594,7 @@ def mmdl_gen_plvl_last_get():
 
 
 def mmdl_gen_plvl_dflt_get():
-    logging.debug("%s", mmdl_gen_plvl_dflt_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['gen_plvl_dflt_get'])
@@ -608,7 +608,7 @@ def mmdl_gen_plvl_dflt_get():
 
 
 def mmdl_gen_plvl_dflt_set(dflt, ack=True):
-    logging.debug("%s", mmdl_gen_plvl_dflt_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BH", ack, dflt))
@@ -626,7 +626,7 @@ def mmdl_gen_plvl_dflt_set(dflt, ack=True):
 
 
 def mmdl_gen_plvl_range_get():
-    logging.debug("%s", mmdl_gen_plvl_range_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['gen_plvl_range_get'])
@@ -641,7 +641,7 @@ def mmdl_gen_plvl_range_get():
 
 
 def mmdl_gen_plvl_range_set(range_min, range_max, ack=True):
-    logging.debug("%s", mmdl_gen_plvl_range_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHH", ack, range_min, range_max))
@@ -661,7 +661,7 @@ def mmdl_gen_plvl_range_set(range_min, range_max, ack=True):
 
 
 def mmdl_gen_battery_get():
-    logging.debug("%s", mmdl_gen_battery_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['gen_battery_get'])
@@ -679,7 +679,7 @@ def mmdl_gen_battery_get():
 
 
 def mmdl_gen_loc_global_get():
-    logging.debug("%s", mmdl_gen_loc_global_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['gen_loc_global_get'])
@@ -692,7 +692,7 @@ def mmdl_gen_loc_global_get():
 
 
 def mmdl_gen_loc_local_get():
-    logging.debug("%s", mmdl_gen_loc_local_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['gen_loc_local_get'])
@@ -707,7 +707,7 @@ def mmdl_gen_loc_local_get():
 
 
 def mmdl_gen_loc_global_set(lat, lon, alt, ack=True):
-    logging.debug("%s", mmdl_gen_loc_global_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BIIH", ack, lat, lon, alt))
@@ -725,7 +725,7 @@ def mmdl_gen_loc_global_set(lat, lon, alt, ack=True):
 
 
 def mmdl_gen_loc_local_set(north, east, alt, floor, location_uncert, ack=True):
-    logging.debug("%s", mmdl_gen_loc_local_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHHHBH", ack, north,
@@ -746,7 +746,7 @@ def mmdl_gen_loc_local_set(north, east, alt, floor, location_uncert, ack=True):
 
 
 def mmdl_gen_props_get(kind, prop_id=0):
-    logging.debug("%s", mmdl_gen_props_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BH", kind, prop_id))
@@ -760,7 +760,7 @@ def mmdl_gen_props_get(kind, prop_id=0):
 
 
 def mmdl_gen_prop_get(kind, prop_id):
-    logging.debug("%s", mmdl_gen_prop_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BH", kind, prop_id))
@@ -777,7 +777,7 @@ def mmdl_gen_prop_get(kind, prop_id):
 
 
 def mmdl_gen_prop_set(kind, prop_id, access, value, ack=True):
-    logging.debug("%s", mmdl_gen_prop_set.__name__)
+    logging.debug("")
 
     payload = binascii.unhexlify(value)
     payload_len = len(payload)
@@ -802,7 +802,7 @@ def mmdl_gen_prop_set(kind, prop_id, access, value, ack=True):
 
 
 def mmdl_sensor_desc_get(sensor_id=None):
-    logging.debug("%s", mmdl_sensor_desc_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     if sensor_id:
@@ -821,7 +821,7 @@ def mmdl_sensor_desc_get(sensor_id=None):
 
 
 def mmdl_sensor_get(sensor_id):
-    logging.debug("%s", mmdl_sensor_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     if sensor_id:
@@ -862,7 +862,7 @@ def mmdl_sensor_get(sensor_id):
 
 
 def mmdl_sensor_cadence_get(sensor_id):
-    logging.debug("%s", mmdl_sensor_cadence_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<H", sensor_id))
@@ -879,7 +879,7 @@ def mmdl_sensor_cadence_get(sensor_id):
 
 
 def mmdl_sensor_cadence_set(sensor_id, payload, ack=True):
-    logging.debug("%s", mmdl_sensor_cadence_set.__name__)
+    logging.debug("")
 
     payload = binascii.unhexlify(payload)
     payload_len = len(payload)
@@ -898,7 +898,7 @@ def mmdl_sensor_cadence_set(sensor_id, payload, ack=True):
 
 
 def mmdl_sensor_settings_get(sensor_id):
-    logging.debug("%s", mmdl_sensor_settings_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<H", sensor_id))
@@ -914,7 +914,7 @@ def mmdl_sensor_settings_get(sensor_id):
 
 
 def mmdl_sensor_setting_get(sensor_id, setting_id):
-    logging.debug("%s", mmdl_sensor_setting_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<HH", sensor_id, setting_id))
@@ -923,7 +923,7 @@ def mmdl_sensor_setting_get(sensor_id, setting_id):
 
 
 def mmdl_sensor_setting_set(sensor_id, setting_id, setting_raw, ack=True):
-    logging.debug("%s", mmdl_sensor_setting_set.__name__)
+    logging.debug("")
 
     payload = binascii.unhexlify(setting_raw)
     payload_len = len(payload)
@@ -937,7 +937,7 @@ def mmdl_sensor_setting_set(sensor_id, setting_id, setting_raw, ack=True):
 
 
 def mmdl_sensor_column_get(sensor_id, raw_value):
-    logging.debug("%s", mmdl_sensor_column_get.__name__)
+    logging.debug("")
 
     payload = binascii.unhexlify(raw_value)
     payload_len = len(payload)
@@ -959,7 +959,7 @@ def mmdl_sensor_column_get(sensor_id, raw_value):
 
 
 def mmdl_sensor_series_get(sensor_id, raw_values):
-    logging.debug("%s", mmdl_sensor_series_get.__name__)
+    logging.debug("")
 
     payload = binascii.unhexlify(raw_values)
     payload_len = len(payload)
@@ -980,7 +980,7 @@ def mmdl_sensor_series_get(sensor_id, raw_values):
 
 
 def mmdl_time_get():
-    logging.debug("%s", mmdl_time_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['time_get'])
@@ -1002,7 +1002,7 @@ def mmdl_time_get():
 
 
 def mmdl_time_set(tai, subsecond, uncertainty, tai_utc_delta, time_zone_offset):
-    logging.debug("%s", mmdl_time_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1029,7 +1029,7 @@ def mmdl_time_set(tai, subsecond, uncertainty, tai_utc_delta, time_zone_offset):
 
 
 def mmdl_time_role_get():
-    logging.debug("%s", mmdl_time_role_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['time_role_get'])
@@ -1042,7 +1042,7 @@ def mmdl_time_role_get():
 
 
 def mmdl_time_role_set(role):
-    logging.debug("%s", mmdl_time_role_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<B", role))
@@ -1057,7 +1057,7 @@ def mmdl_time_role_set(role):
 
 
 def mmdl_time_zone_get():
-    logging.debug("%s", mmdl_time_zone_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['time_zone_get'])
@@ -1072,7 +1072,7 @@ def mmdl_time_zone_get():
 
 
 def mmdl_time_zone_set(new_offset, timestamp):
-    logging.debug("%s", mmdl_time_zone_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<hQ", new_offset, timestamp))
@@ -1088,7 +1088,7 @@ def mmdl_time_zone_set(new_offset, timestamp):
 
 
 def mmdl_time_tai_utc_delta_get():
-    logging.debug("%s", mmdl_time_tai_utc_delta_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['time_tai_utc_delta_get'])
@@ -1103,7 +1103,7 @@ def mmdl_time_tai_utc_delta_get():
 
 
 def mmdl_time_tai_utc_delta_set(delta_new, timestamp):
-    logging.debug("%s", mmdl_time_tai_utc_delta_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<hQ", delta_new, timestamp))
@@ -1120,7 +1120,7 @@ def mmdl_time_tai_utc_delta_set(delta_new, timestamp):
 
 
 def mmdl_light_lightness_get():
-    logging.debug("%s", mmdl_light_lightness_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_lightness_get'])
@@ -1133,7 +1133,7 @@ def mmdl_light_lightness_get():
 
 
 def mmdl_light_lightness_set(lightness, tt=None, delay=None, ack=True):
-    logging.debug("%s", mmdl_light_lightness_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BH", ack, lightness))
@@ -1159,7 +1159,7 @@ def mmdl_light_lightness_set(lightness, tt=None, delay=None, ack=True):
 
 
 def mmdl_light_lightness_linear_get():
-    logging.debug("%s", mmdl_light_lightness_linear_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(
@@ -1175,7 +1175,7 @@ def mmdl_light_lightness_linear_get():
 
 
 def mmdl_light_lightness_linear_set(lightness_linear, tt=None, delay=None, ack=True):
-    logging.debug("%s", mmdl_light_lightness_linear_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BH", ack, lightness_linear))
@@ -1202,7 +1202,7 @@ def mmdl_light_lightness_linear_set(lightness_linear, tt=None, delay=None, ack=T
 
 
 def mmdl_light_lightness_last_get():
-    logging.debug("%s", mmdl_light_lightness_last_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_lightness_last_get'])
@@ -1217,7 +1217,7 @@ def mmdl_light_lightness_last_get():
 
 
 def mmdl_light_lightness_default_get():
-    logging.debug("%s", mmdl_light_lightness_default_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(
@@ -1233,7 +1233,7 @@ def mmdl_light_lightness_default_get():
 
 
 def mmdl_light_lightness_default_set(dflt, ack=True):
-    logging.debug("%s", mmdl_light_lightness_default_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BH", ack, dflt))
@@ -1252,7 +1252,7 @@ def mmdl_light_lightness_default_set(dflt, ack=True):
 
 
 def mmdl_light_lightness_range_get():
-    logging.debug("%s", mmdl_light_lightness_range_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(
@@ -1267,7 +1267,7 @@ def mmdl_light_lightness_range_get():
 
 
 def mmdl_light_lightness_range_set(min_val, max_val, ack=True):
-    logging.debug("%s", mmdl_light_lightness_range_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHH", ack, min_val, max_val))
@@ -1285,7 +1285,7 @@ def mmdl_light_lightness_range_set(min_val, max_val, ack=True):
 
 
 def mmdl_light_lc_mode_get():
-    logging.debug("%s", mmdl_light_lc_mode_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_lc_mode_get'])
@@ -1298,7 +1298,7 @@ def mmdl_light_lc_mode_get():
 
 
 def mmdl_light_lc_mode_set(mode, ack=True):
-    logging.debug("%s", mmdl_light_lc_mode_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BB", ack, mode))
@@ -1315,7 +1315,7 @@ def mmdl_light_lc_mode_set(mode, ack=True):
 
 
 def mmdl_light_lc_occupancy_mode_get():
-    logging.debug("%s", mmdl_light_lc_occupancy_mode_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(
@@ -1329,7 +1329,7 @@ def mmdl_light_lc_occupancy_mode_get():
 
 
 def mmdl_light_lc_occupancy_mode_set(occupancy_mode, ack=True):
-    logging.debug("%s", mmdl_light_lc_occupancy_mode_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BB", ack, occupancy_mode))
@@ -1346,7 +1346,7 @@ def mmdl_light_lc_occupancy_mode_set(occupancy_mode, ack=True):
 
 
 def mmdl_light_lc_light_onoff_mode_get():
-    logging.debug("%s", mmdl_light_lc_light_onoff_mode_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(
@@ -1360,7 +1360,7 @@ def mmdl_light_lc_light_onoff_mode_get():
 
 
 def mmdl_light_lc_light_onoff_mode_set(light_onoff_mode, tt=None, delay=None, ack=True):
-    logging.debug("%s", mmdl_light_lc_light_onoff_mode_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BB", ack, light_onoff_mode))
@@ -1387,7 +1387,7 @@ def mmdl_light_lc_light_onoff_mode_set(light_onoff_mode, tt=None, delay=None, ac
 
 
 def mmdl_light_lc_property_get(prop_id):
-    logging.debug("%s", mmdl_light_lc_property_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<H", prop_id))
@@ -1404,7 +1404,7 @@ def mmdl_light_lc_property_get(prop_id):
 
 
 def mmdl_light_lc_property_set(prop_id, prop_val, ack=True):
-    logging.debug("%s", mmdl_light_lc_property_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHH", ack, prop_id, prop_val))
@@ -1422,7 +1422,7 @@ def mmdl_light_lc_property_set(prop_id, prop_val, ack=True):
 
 
 def mmdl_sensor_data_set(sensor_id, raw_values):
-    logging.debug("%s", mmdl_sensor_data_set.__name__)
+    logging.debug("")
 
     payload_len = len(raw_values)
 
@@ -1434,7 +1434,7 @@ def mmdl_sensor_data_set(sensor_id, raw_values):
 
 
 def mmdl_light_ctl_states_get():
-    logging.debug("%s", mmdl_light_ctl_states_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_ctl_states_get'])
@@ -1449,7 +1449,7 @@ def mmdl_light_ctl_states_get():
 
 
 def mmdl_light_ctl_states_set(ctl_lightness, ctl_temperature, ctl_delta_uv, tt=None, delay=None, ack=True):
-    logging.debug("%s", mmdl_light_ctl_states_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHHh", ack, ctl_lightness,
@@ -1480,7 +1480,7 @@ def mmdl_light_ctl_states_set(ctl_lightness, ctl_temperature, ctl_delta_uv, tt=N
 
 
 def mmdl_light_ctl_temperature_get():
-    logging.debug("%s", mmdl_light_ctl_temperature_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(
@@ -1496,7 +1496,7 @@ def mmdl_light_ctl_temperature_get():
 
 
 def mmdl_light_ctl_temperature_set(ctl_temperature, ctl_delta_uv, tt=None, delay=None, ack=True):
-    logging.debug("%s", mmdl_light_ctl_temperature_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHh", ack, ctl_temperature, ctl_delta_uv))
@@ -1526,7 +1526,7 @@ def mmdl_light_ctl_temperature_set(ctl_temperature, ctl_delta_uv, tt=None, delay
 
 
 def mmdl_light_ctl_default_get():
-    logging.debug("%s", mmdl_light_ctl_default_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -1540,7 +1540,7 @@ def mmdl_light_ctl_default_get():
 
 
 def mmdl_light_ctl_default_set(ctl_lightness, ctl_temperature, ctl_delta_uv, ack=True):
-    logging.debug("%s", mmdl_light_ctl_default_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHHh", ack, ctl_lightness,
@@ -1559,7 +1559,7 @@ def mmdl_light_ctl_default_set(ctl_lightness, ctl_temperature, ctl_delta_uv, ack
 
 
 def mmdl_light_ctl_temp_range_get():
-    logging.debug("%s", mmdl_light_ctl_temp_range_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_ctl_temp_range_get'])
@@ -1572,7 +1572,7 @@ def mmdl_light_ctl_temp_range_get():
 
 
 def mmdl_light_ctl_temp_range_set(range_min, range_max, ack=True):
-    logging.debug("%s", mmdl_light_ctl_temp_range_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHH", ack, range_min, range_max))
@@ -1589,7 +1589,7 @@ def mmdl_light_ctl_temp_range_set(range_min, range_max, ack=True):
 
 
 def mmdl_scene_get():
-    logging.debug("%s", mmdl_scene_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['scene_get'])
@@ -1603,7 +1603,7 @@ def mmdl_scene_get():
 
 
 def mmdl_scene_register_get():
-    logging.debug("%s", mmdl_scene_register_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['scene_register_get'])
@@ -1616,7 +1616,7 @@ def mmdl_scene_register_get():
 
 
 def mmdl_scene_store_procedure(scene_num, ack=True):
-    logging.debug("%s", mmdl_scene_store_procedure.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BH", ack, scene_num))
@@ -1633,7 +1633,7 @@ def mmdl_scene_store_procedure(scene_num, ack=True):
 
 
 def mmdl_scene_recall(scene_num, tt=None, delay=None, ack=True):
-    logging.debug("%s", mmdl_scene_recall.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BH", ack, scene_num))
@@ -1659,7 +1659,7 @@ def mmdl_scene_recall(scene_num, tt=None, delay=None, ack=True):
 
 
 def mmdl_light_xyl_get():
-    logging.debug("%s", mmdl_light_xyl_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_xyl_get'])
@@ -1672,7 +1672,7 @@ def mmdl_light_xyl_get():
 
 
 def mmdl_light_xyl_set(lightness, x_value, y_value, tt, delay, ack=True):
-    logging.debug("%s", mmdl_light_xyl_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHHH", ack, lightness, x_value, y_value))
@@ -1693,7 +1693,7 @@ def mmdl_light_xyl_set(lightness, x_value, y_value, tt, delay, ack=True):
 
 
 def mmdl_light_xyl_target_get():
-    logging.debug("%s", mmdl_light_xyl_target_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_xyl_target_get'])
@@ -1706,7 +1706,7 @@ def mmdl_light_xyl_target_get():
 
 
 def mmdl_light_xyl_default_get():
-    logging.debug("%s", mmdl_light_xyl_default_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_xyl_default_get'])
@@ -1719,7 +1719,7 @@ def mmdl_light_xyl_default_get():
 
 
 def mmdl_light_xyl_default_set(lightness, x_value, y_value, ack=True):
-    logging.debug("%s", mmdl_light_xyl_default_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHHH", ack, lightness, x_value, y_value))
@@ -1735,7 +1735,7 @@ def mmdl_light_xyl_default_set(lightness, x_value, y_value, ack=True):
 
 
 def mmdl_light_xyl_range_get():
-    logging.debug("%s", mmdl_light_xyl_range_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_xyl_range_get'])
@@ -1748,7 +1748,7 @@ def mmdl_light_xyl_range_get():
 
 
 def mmdl_light_xyl_range_set(lmin_x, min_y, max_x, max_y, ack=True):
-    logging.debug("%s", mmdl_light_xyl_range_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHHHH", ack, lmin_x, min_y, max_x, max_y))
@@ -1764,7 +1764,7 @@ def mmdl_light_xyl_range_set(lmin_x, min_y, max_x, max_y, ack=True):
 
 
 def mmdl_light_hsl_get():
-    logging.debug("%s", mmdl_light_hsl_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_hsl_get'])
@@ -1777,7 +1777,7 @@ def mmdl_light_hsl_get():
 
 
 def mmdl_light_hsl_set(lightness, hue, saturation, tt, delay, ack=True):
-    logging.debug("%s", mmdl_light_hsl_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHHH", ack, lightness, hue, saturation))
@@ -1798,7 +1798,7 @@ def mmdl_light_hsl_set(lightness, hue, saturation, tt, delay, ack=True):
 
 
 def mmdl_light_hsl_target_get():
-    logging.debug("%s", mmdl_light_hsl_target_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_hsl_target_get'])
@@ -1811,7 +1811,7 @@ def mmdl_light_hsl_target_get():
 
 
 def mmdl_light_hsl_default_get():
-    logging.debug("%s", mmdl_light_hsl_default_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_hsl_default_get'])
@@ -1824,7 +1824,7 @@ def mmdl_light_hsl_default_get():
 
 
 def mmdl_light_hsl_default_set(lightness, hue, saturation, ack=True):
-    logging.debug("%s", mmdl_light_hsl_default_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHHH", ack, lightness, hue, saturation))
@@ -1840,7 +1840,7 @@ def mmdl_light_hsl_default_set(lightness, hue, saturation, ack=True):
 
 
 def mmdl_light_hsl_range_get():
-    logging.debug("%s", mmdl_light_hsl_range_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_hsl_range_get'])
@@ -1853,7 +1853,7 @@ def mmdl_light_hsl_range_get():
 
 
 def mmdl_light_hsl_range_set(hue_min, saturation_min, hue_max, saturation_max, ack=True):
-    logging.debug("%s", mmdl_light_hsl_range_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BHHHH", ack, hue_min, saturation_min, hue_max, saturation_max))
@@ -1869,7 +1869,7 @@ def mmdl_light_hsl_range_set(hue_min, saturation_min, hue_max, saturation_max, a
 
 
 def mmdl_light_hsl_hue_get():
-    logging.debug("%s", mmdl_light_hsl_hue_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_hsl_hue_get'])
@@ -1882,7 +1882,7 @@ def mmdl_light_hsl_hue_get():
 
 
 def mmdl_light_hsl_hue_set(hue, tt, delay, ack=True):
-    logging.debug("%s", mmdl_light_hsl_hue_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BH", ack, hue))
@@ -1905,7 +1905,7 @@ def mmdl_light_hsl_hue_set(hue, tt, delay, ack=True):
 
 
 def mmdl_light_hsl_saturation_get():
-    logging.debug("%s", mmdl_light_hsl_saturation_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['light_hsl_saturation_get'])
@@ -1918,7 +1918,7 @@ def mmdl_light_hsl_saturation_get():
 
 
 def mmdl_light_hsl_saturation_set(hue, tt, delay, ack=True):
-    logging.debug("%s", mmdl_light_hsl_saturation_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<BH", ack, hue))
@@ -1941,7 +1941,7 @@ def mmdl_light_hsl_saturation_set(hue, tt, delay, ack=True):
 
 
 def mmdl_scheduler_get():
-    logging.debug("%s", mmdl_scheduler_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     (rsp,) = iutctl.btp_socket.send_wait_rsp(*MMDL['scheduler_get'])
@@ -1954,7 +1954,7 @@ def mmdl_scheduler_get():
 
 
 def mmdl_scheduler_action_get(index):
-    logging.debug("%s", mmdl_scheduler_action_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(struct.pack("<B", index))
@@ -1972,7 +1972,7 @@ def mmdl_scheduler_action_get(index):
 
 def mmdl_scheduler_action_set(index, year, month, day, hour, minute, second, day_of_week, action, transition_time,
                               scene_num, ack=True):
-    logging.debug("%s", mmdl_scheduler_action_set.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     data = bytearray(
@@ -1991,7 +1991,7 @@ def mmdl_scheduler_action_set(index, year, month, day, hour, minute, second, day
 
 
 def mmdl_dfu_info_get(limit):
-    logging.debug("%s", mmdl_dfu_info_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     stack = get_stack()
@@ -2002,7 +2002,7 @@ def mmdl_dfu_info_get(limit):
 
 
 def mmdl_blob_info_get(addrs):
-    logging.debug("%s", mmdl_blob_info_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -2014,7 +2014,7 @@ def mmdl_blob_info_get(addrs):
 
 
 def mmdl_dfu_update_firmware_check(index, slot_idx, slot_size, fwid, metadata):
-    logging.debug("%s", mmdl_dfu_update_firmware_check.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -2038,7 +2038,7 @@ def mmdl_dfu_update_firmware_check(index, slot_idx, slot_size, fwid, metadata):
 
 
 def mmdl_dfu_update_firmware_get():
-    logging.debug("%s", mmdl_dfu_update_firmware_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -2049,7 +2049,7 @@ def mmdl_dfu_update_firmware_get():
 
 
 def mmdl_dfu_update_firmware_cancel():
-    logging.debug("%s", mmdl_dfu_update_firmware_cancel.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -2057,7 +2057,7 @@ def mmdl_dfu_update_firmware_cancel():
 
 
 def mmdl_dfu_update_firmware_start(addrs, slot_idx, slot_size, block_size, chunk_size, fwid, metadata):
-    logging.debug("%s", mmdl_dfu_update_firmware_start.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -2077,7 +2077,7 @@ def mmdl_dfu_update_firmware_start(addrs, slot_idx, slot_size, block_size, chunk
 
 
 def mmdl_blob_srv_recv(id_mmdl, timeout, ttl):
-    logging.debug("%s", mmdl_blob_srv_recv.__name__)
+    logging.debug("")
     iutctl = get_iut()
 
     data = bytearray(struct.pack("<QHB", id_mmdl, timeout, ttl))
@@ -2086,7 +2086,7 @@ def mmdl_blob_srv_recv(id_mmdl, timeout, ttl):
 
 
 def mmdl_blob_transfer_start(id_mmdl, block_size, chunk_size, timeout, ttl, size):
-    logging.debug("%s", mmdl_blob_transfer_start.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -2096,7 +2096,7 @@ def mmdl_blob_transfer_start(id_mmdl, block_size, chunk_size, timeout, ttl, size
 
 
 def mmdl_blob_transfer_cancel():
-    logging.debug("%s", mmdl_blob_transfer_cancel.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -2104,7 +2104,7 @@ def mmdl_blob_transfer_cancel():
 
 
 def mmdl_blob_transfer_get():
-    logging.debug("%s", mmdl_blob_transfer_get.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -2112,7 +2112,7 @@ def mmdl_blob_transfer_get():
 
 
 def mmdl_blob_srv_cancel():
-    logging.debug("%s", mmdl_blob_srv_cancel.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -2120,7 +2120,7 @@ def mmdl_blob_srv_cancel():
 
 
 def mmdl_dfu_update_firmware_apply():
-    logging.debug("%s", mmdl_dfu_update_firmware_apply.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -2128,7 +2128,7 @@ def mmdl_dfu_update_firmware_apply():
 
 
 def mmdl_dfu_srv_apply():
-    logging.debug("%s", mmdl_dfu_srv_apply.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 

--- a/autopts/pybtp/btp/ots.py
+++ b/autopts/pybtp/btp/ots.py
@@ -34,7 +34,7 @@ OTS = {
 
 
 def otc_register_object(index, name, flags=0, props=0, alloc_size=0, current_size=0):
-    logging.debug(f"{otc_register_object.__name__}")
+    logging.debug("")
 
     data_ba = bytearray(struct.pack('<BIIIB', flags, props, alloc_size, current_size, len(name)))
     data_ba.extend(name.encode())
@@ -46,7 +46,7 @@ def otc_register_object(index, name, flags=0, props=0, alloc_size=0, current_siz
 
 
 def ots_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", ots_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 

--- a/autopts/pybtp/btp/pacs.py
+++ b/autopts/pybtp/btp/pacs.py
@@ -35,7 +35,7 @@ PACS = {
 
 
 def pacs_update_characteristic(characteristic):
-    logging.debug(f"{pacs_update_characteristic.__name__} {characteristic}")
+    logging.debug("%r", characteristic)
 
     iutctl = get_iut()
 
@@ -69,7 +69,7 @@ def pacs_update_supported_audio_contexts():
 
 
 def pacs_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", pacs_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -82,7 +82,7 @@ def pacs_command_rsp_succ(timeout=20.0):
 
 
 def pacs_set_location(direction, location):
-    logging.debug(f"{pacs_set_location.__name__} {direction} {location}")
+    logging.debug("direction %r, location %r", direction, location)
 
     iutctl = get_iut()
 
@@ -94,7 +94,7 @@ def pacs_set_location(direction, location):
 
 
 def pacs_set_available_contexts(sink_contexts, source_contexts):
-    logging.debug(f"{pacs_set_available_contexts.__name__} {sink_contexts} {source_contexts}")
+    logging.debug("sink_contexts %r, source_contexts %r", sink_contexts, source_contexts)
 
     iutctl = get_iut()
 
@@ -106,7 +106,7 @@ def pacs_set_available_contexts(sink_contexts, source_contexts):
 
 
 def pacs_set_supported_contexts(sink_contexts, source_contexts):
-    logging.debug(f"{pacs_set_supported_contexts.__name__} {sink_contexts} {source_contexts}")
+    logging.debug("sink_contexts %r, source_contexts %r", sink_contexts, source_contexts)
 
     iutctl = get_iut()
 
@@ -118,7 +118,7 @@ def pacs_set_supported_contexts(sink_contexts, source_contexts):
 
 
 def pacs_ev_characteristic_subscribed_(pacs, data, data_len):
-    logging.debug('%s %r', pacs_ev_characteristic_subscribed_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sB'
     header_size = struct.calcsize(fmt)
@@ -129,7 +129,7 @@ def pacs_ev_characteristic_subscribed_(pacs, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'PACS characteristic with handle {handle} subscribed')
+    logging.debug("PACS characteristic with handle %r subscribed", handle)
 
     pacs.event_received(defs.BTP_PACS_EV_CHARACTERISTIC_SUBSCRIBED,
                         (addr_type, addr, handle))

--- a/autopts/pybtp/btp/pbp.py
+++ b/autopts/pybtp/btp/pbp.py
@@ -43,7 +43,7 @@ PBP = {
 
 
 def pbp_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", pbp_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -56,7 +56,7 @@ def pbp_command_rsp_succ(timeout=20.0):
 
 
 def pbp_set_public_broadcast_announcement(features, metadata):
-    logging.debug(f"{pbp_set_public_broadcast_announcement.__name__}")
+    logging.debug("")
 
     data = bytearray()
     metadata_len = len(metadata)
@@ -72,7 +72,7 @@ def pbp_set_public_broadcast_announcement(features, metadata):
 
 
 def pbp_set_broadcast_name(name):
-    logging.debug(f"{pbp_set_broadcast_name.__name__}")
+    logging.debug("")
 
     name_data = name.encode('utf-8')
     data = bytearray()
@@ -86,7 +86,7 @@ def pbp_set_broadcast_name(name):
 
 
 def pbp_broadcast_scan_start():
-    logging.debug(f"{pbp_broadcast_scan_start.__name__}")
+    logging.debug("")
 
     data = bytearray()
     iutctl = get_iut()
@@ -96,7 +96,7 @@ def pbp_broadcast_scan_start():
 
 
 def pbp_broadcast_scan_stop():
-    logging.debug(f"{pbp_broadcast_scan_stop.__name__}")
+    logging.debug("")
 
     data = bytearray()
     iutctl = get_iut()
@@ -106,7 +106,7 @@ def pbp_broadcast_scan_stop():
 
 
 def pbp_ev_public_broadcast_announcement_found(pbp, data, data_len):
-    logging.debug('%s %r', pbp_ev_public_broadcast_announcement_found.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6s3sBHBB'
     fmt_len = struct.calcsize(fmt)
@@ -129,7 +129,7 @@ def pbp_ev_public_broadcast_announcement_found(pbp, data, data_len):
           'pba_features': pba_features,
           'broadcast_name': broadcast_name}
 
-    logging.debug(f'Public Broadcast Announcement received: {ev}')
+    logging.debug("Public Broadcast Announcement received: %r", ev)
 
     pbp.event_received(defs.BTP_PBP_EV_PUBLIC_BROADCAST_ANNOUNCEMENT_FOUND, ev)
 

--- a/autopts/pybtp/btp/rfcomm.py
+++ b/autopts/pybtp/btp/rfcomm.py
@@ -45,7 +45,7 @@ RFCOMM = {
 
 
 def rfcomm_command_rsp_succ(op=None):
-    logging.debug("%s", rfcomm_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -56,7 +56,7 @@ def rfcomm_command_rsp_succ(op=None):
 
 
 def rfcomm_connect(bd_addr=None, bd_addr_type=defs.BTP_BR_ADDRESS_TYPE, channel=5):
-    logging.debug("%s %r %r %r", rfcomm_connect.__name__, bd_addr, bd_addr_type, channel)
+    logging.debug("%r %r %r", bd_addr, bd_addr_type, channel)
 
     iutctl = get_iut()
     gap_wait_for_connection()
@@ -76,7 +76,7 @@ def rfcomm_connect(bd_addr=None, bd_addr_type=defs.BTP_BR_ADDRESS_TYPE, channel=
 
 
 def rfcomm_disconnect(bd_addr=None, bd_addr_type=defs.BTP_BR_ADDRESS_TYPE, channel=5):
-    logging.debug("%s %r %r %r", rfcomm_disconnect.__name__, bd_addr, bd_addr_type, channel)
+    logging.debug("%r %r %r", bd_addr, bd_addr_type, channel)
 
     iutctl = get_iut()
 
@@ -96,7 +96,7 @@ def rfcomm_disconnect(bd_addr=None, bd_addr_type=defs.BTP_BR_ADDRESS_TYPE, chann
 
 def rfcomm_send_data(bd_addr=None, bd_addr_type=defs.BTP_BR_ADDRESS_TYPE, channel=5, val='00',
                      val_mtp=None):
-    logging.debug("%s %r %r %r %r %r", rfcomm_send_data.__name__, bd_addr, bd_addr_type,
+    logging.debug("%r %r %r %r %r", bd_addr, bd_addr_type,
                   channel, val, val_mtp)
 
     iutctl = get_iut()
@@ -123,7 +123,7 @@ def rfcomm_send_data(bd_addr=None, bd_addr_type=defs.BTP_BR_ADDRESS_TYPE, channe
 
 
 def rfcomm_listen(channel=5):
-    logging.debug("%s %r", rfcomm_listen.__name__, channel)
+    logging.debug("%r", channel)
 
     iutctl = get_iut()
 
@@ -134,7 +134,7 @@ def rfcomm_listen(channel=5):
 
 def rfcomm_send_rpn(bd_addr=None, bd_addr_type=defs.BTP_BR_ADDRESS_TYPE, channel=5, baud_rate=0,
                     line_settings=0, flow_control=0, xon_char=0, xoff_char=0, param_mask=0):
-    logging.debug("%s %r %r %r %r %r %r %r %r %r", rfcomm_send_rpn.__name__,
+    logging.debug("%r %r %r %r %r %r %r %r %r",
                   bd_addr, bd_addr_type, channel, baud_rate, line_settings,
                   flow_control, xon_char, xoff_char, param_mask)
 
@@ -161,7 +161,7 @@ def rfcomm_send_rpn(bd_addr=None, bd_addr_type=defs.BTP_BR_ADDRESS_TYPE, channel
 
 
 def rfcomm_get_dlc_info(bd_addr=None, bd_addr_type=defs.BTP_BR_ADDRESS_TYPE, channel=5):
-    logging.debug("%s %r %r %r", rfcomm_get_dlc_info.__name__, bd_addr, bd_addr_type, channel)
+    logging.debug("%r %r %r", bd_addr, bd_addr_type, channel)
 
     iutctl = get_iut()
 
@@ -182,7 +182,7 @@ def rfcomm_get_dlc_info(bd_addr=None, bd_addr_type=defs.BTP_BR_ADDRESS_TYPE, cha
 
 
 def rfcomm_get_dlc_info_rsp():
-    logging.debug("%s", rfcomm_get_dlc_info_rsp.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -200,7 +200,7 @@ def rfcomm_get_dlc_info_rsp():
 
 
 def rfcomm_connected_ev(rfcomm, data, data_len):
-    logging.debug("%s %r %r", rfcomm_connected_ev.__name__, data, data_len)
+    logging.debug("%r %r", data, data_len)
 
     hdr_fmt = '<B6sBH'
     _, bd_addr, channel, mtu = struct.unpack_from(hdr_fmt, data)
@@ -212,7 +212,7 @@ def rfcomm_connected_ev(rfcomm, data, data_len):
 
 
 def rfcomm_disconnected_ev(rfcomm, data, data_len):
-    logging.debug("%s %r %r", rfcomm_disconnected_ev.__name__, data, data_len)
+    logging.debug("%r %r", data, data_len)
 
     hdr_fmt = '<B6sB'
     _, bd_addr, channel = struct.unpack_from(hdr_fmt, data)
@@ -224,7 +224,7 @@ def rfcomm_disconnected_ev(rfcomm, data, data_len):
 
 
 def rfcomm_data_received_ev(rfcomm, data, data_len):
-    logging.debug("%s %r %r", rfcomm_data_received_ev.__name__, data, data_len)
+    logging.debug("%r %r", data, data_len)
 
     hdr_fmt = '<B6sBH'
     hdr_len = struct.calcsize(hdr_fmt)
@@ -239,7 +239,7 @@ def rfcomm_data_received_ev(rfcomm, data, data_len):
 
 
 def rfcomm_data_sent_ev(rfcomm, data, data_len):
-    logging.debug("%s %r %r", rfcomm_data_sent_ev.__name__, data, data_len)
+    logging.debug("%r %r", data, data_len)
 
     hdr_fmt = '<B6sBb'
     _, bd_addr, channel, err = struct.unpack_from(hdr_fmt, data)

--- a/autopts/pybtp/btp/sdp.py
+++ b/autopts/pybtp/btp/sdp.py
@@ -41,7 +41,7 @@ SDP = {
 
 
 def sdp_search_req(bd_addr=None, bd_addr_type=None, uuid=0x0100):
-    logging.debug("%s %r %r", sdp_search_req.__name__, bd_addr, uuid)
+    logging.debug("%r %r", bd_addr, uuid)
     iutctl = get_iut()
 
     data_ba = bytearray()
@@ -58,7 +58,7 @@ def sdp_search_req(bd_addr=None, bd_addr_type=None, uuid=0x0100):
 
 
 def sdp_attr_req(bd_addr=None, bd_addr_type=None, service_record_handle=0):
-    logging.debug("%s %r %r", sdp_attr_req.__name__, bd_addr, service_record_handle)
+    logging.debug("%r %r", bd_addr, service_record_handle)
     iutctl = get_iut()
 
     data_ba = bytearray()
@@ -73,7 +73,7 @@ def sdp_attr_req(bd_addr=None, bd_addr_type=None, service_record_handle=0):
 
 
 def sdp_search_attr_req(bd_addr=None, bd_addr_type=None, uuid=0x0100):
-    logging.debug("%s %r %r", sdp_search_attr_req.__name__, bd_addr, uuid)
+    logging.debug("%r %r", bd_addr, uuid)
     iutctl = get_iut()
 
     data_ba = bytearray()
@@ -96,7 +96,7 @@ def sdp_wait_for_service_record_handle(timeout=30, addr=None):
 
 
 def sdp_service_record_handle_ev_(sdp, data, data_len):
-    logging.debug("%s %r", sdp_service_record_handle_ev_.__name__, data)
+    logging.debug("%r", data)
 
     hdr_fmt = '<B6sB'
     hdr_len = struct.calcsize(hdr_fmt)

--- a/autopts/pybtp/btp/tbs.py
+++ b/autopts/pybtp/btp/tbs.py
@@ -95,7 +95,7 @@ def tbs_register_bearer(gtbs, technology, optional_opcodes, provider_name, uci, 
 
 
 def tbs_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", tbs_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -116,7 +116,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def tbs_remote_incoming(index, receiver_uri, caller_uri, friendly_name):
-    logging.debug(f"{tbs_remote_incoming.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data.extend(struct.pack("b", index))
@@ -136,7 +136,7 @@ def tbs_remote_incoming(index, receiver_uri, caller_uri, friendly_name):
 
 
 def tbs_originate_call(index, uri):
-    logging.debug(f"{tbs_originate_call.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data.extend(struct.pack("b", index))
@@ -153,7 +153,7 @@ def tbs_originate_call(index, uri):
 
 
 def tbs_set_bearer_name(index, name):
-    logging.debug(f"{tbs_set_bearer_name.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data.extend(struct.pack("B", index))
@@ -170,7 +170,7 @@ def tbs_set_bearer_name(index, name):
 
 
 def tbs_set_bearer_technology(index, technology):
-    logging.debug(f"{tbs_set_bearer_technology.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data.extend(struct.pack("Bb", index, technology))
@@ -182,7 +182,7 @@ def tbs_set_bearer_technology(index, technology):
 
 
 def tbs_hold_call(index):
-    logging.debug(f"{tbs_hold_call.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data.extend(struct.pack("b", index))
@@ -194,7 +194,7 @@ def tbs_hold_call(index):
 
 
 def tbs_remote_hold_call(index):
-    logging.debug(f"{tbs_remote_hold_call.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data.extend(struct.pack("b", index))
@@ -206,7 +206,7 @@ def tbs_remote_hold_call(index):
 
 
 def tbs_set_signal_strength(index, strength):
-    logging.debug(f"{tbs_set_signal_strength.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data.extend(struct.pack("Bb", index, strength))
@@ -218,7 +218,7 @@ def tbs_set_signal_strength(index, strength):
 
 
 def tbs_set_uri_scheme_list(index, uri):
-    logging.debug(f"{tbs_set_uri_scheme_list.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data.extend(struct.pack("B", index))
@@ -237,7 +237,7 @@ def tbs_set_uri_scheme_list(index, uri):
 
 
 def tbs_set_status_flags(index, flags):
-    logging.debug(f"{tbs_set_status_flags.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data.extend(struct.pack("B", index))
@@ -250,7 +250,7 @@ def tbs_set_status_flags(index, flags):
 
 
 def tbs_terminate_call(index):
-    logging.debug(f"{tbs_terminate_call.__name__}")
+    logging.debug("")
 
     data = bytearray()
     data.extend(struct.pack("b", index))

--- a/autopts/pybtp/btp/tmap.py
+++ b/autopts/pybtp/btp/tmap.py
@@ -44,7 +44,7 @@ TMAP = {
 
 
 def tmap_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", tmap_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -57,7 +57,7 @@ def tmap_command_rsp_succ(timeout=20.0):
 
 
 def tmap_read_supported_cmds():
-    logging.debug(f"{tmap_read_supported_cmds.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*TMAP['read_supported_cmds'])
@@ -67,7 +67,7 @@ def tmap_read_supported_cmds():
 
 
 def tmap_discover(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{tmap_discover.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
 
@@ -78,7 +78,7 @@ def tmap_discover(bd_addr_type=None, bd_addr=None):
 
 
 def tmap_ev_discovery_completed(tmap, data, data_len):
-    logging.debug('%s %r', tmap_ev_discovery_completed.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sBH'
     if len(data) < struct.calcsize(fmt):
@@ -88,9 +88,8 @@ def tmap_ev_discovery_completed(tmap, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'TMAP Discovery completed: addr {addr} addr_type '
-                  f'{addr_type} status {status}'
-                  f'role {role}')
+    logging.debug("TMAP Discovery completed: addr %r, addr_type %r, status %r, role %r",
+                  addr, addr_type, status, role)
 
     tmap.event_received(defs.BTP_TMAP_EV_DISCOVERY_COMPLETED, (addr_type, addr, status, role))
 

--- a/autopts/pybtp/btp/vcp.py
+++ b/autopts/pybtp/btp/vcp.py
@@ -60,7 +60,7 @@ VCP = {
 
 
 def vcp_command_rsp_succ(timeout=20.0):
-    logging.debug("%s", vcp_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -81,7 +81,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def vcp_discover(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{vcp_discover.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -92,7 +92,7 @@ def vcp_discover(bd_addr_type=None, bd_addr=None):
 
 
 def vcp_state_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{vcp_state_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -103,7 +103,7 @@ def vcp_state_read(bd_addr_type=None, bd_addr=None):
 
 
 def vcp_volume_flags_read(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{vcp_volume_flags_read.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -114,7 +114,7 @@ def vcp_volume_flags_read(bd_addr_type=None, bd_addr=None):
 
 
 def vcp_volume_down(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{vcp_volume_down.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -125,7 +125,7 @@ def vcp_volume_down(bd_addr_type=None, bd_addr=None):
 
 
 def vcp_volume_up(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{vcp_volume_up.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -136,7 +136,7 @@ def vcp_volume_up(bd_addr_type=None, bd_addr=None):
 
 
 def vcp_unmute_vol_down(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{vcp_unmute_vol_down.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -147,7 +147,7 @@ def vcp_unmute_vol_down(bd_addr_type=None, bd_addr=None):
 
 
 def vcp_unmute_vol_up(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{vcp_unmute_vol_up.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -158,7 +158,7 @@ def vcp_unmute_vol_up(bd_addr_type=None, bd_addr=None):
 
 
 def vcp_set_vol(volume, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{vcp_set_vol.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -173,7 +173,7 @@ def vcp_set_vol(volume, bd_addr_type=None, bd_addr=None):
 
 
 def vcp_unmute(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{vcp_unmute.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -184,7 +184,7 @@ def vcp_unmute(bd_addr_type=None, bd_addr=None):
 
 
 def vcp_mute(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{vcp_mute.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -195,7 +195,7 @@ def vcp_mute(bd_addr_type=None, bd_addr=None):
 
 
 def vcp_ev_discovery_completed_(vcp, data, data_len):
-    logging.debug('%s %r', vcp_ev_discovery_completed_.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbHHHHHHHHHHHHH'
     if len(data) < struct.calcsize(fmt):
@@ -207,21 +207,13 @@ def vcp_ev_discovery_completed_(vcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'VCP Discovery completed: addr {addr}, addr_type {addr_type},'
-                  f' ATT Status {att_status},'
-                  f' Volume Control Point handle {control_handle},'
-                  f' Volume Flags handle {flag_handle},'
-                  f' Volume State handle {state_handle},'
-                  f' VOCS State handle {vocs_state},'
-                  f' VOCS Location handle {vocs_location},'
-                  f' VOCS Control handle {vocs_control},'
-                  f' VOCS Description handle {vocs_desc},'
-                  f' AICS State handle {aics_state},'
-                  f' AICS Gain handle {aics_gain},'
-                  f' AICS Type handle {aics_type},'
-                  f' AICS Status handle {aics_status},'
-                  f' AICS Control Point {aics_control},'
-                  f' AICS Description {aics_desc}')
+    logging.debug(
+        "VCP Discovery completed: addr %r, addr_type %r, ATT Status %r, Volume Control Point handle %r,"
+        "Volume Flags handle %r, Volume State handle %r, VOCS State handle %r, VOCS Location handle %r,"
+        "VOCS Control handle %r, VOCS Description handle %r, AICS State handle %r, AICS Gain handle %r,"
+        "AICS Type handle %r, AICS Status handle %r, AICS Control Point %r, AICS Description %r",
+        addr, addr_type, att_status, control_handle, flag_handle, state_handle, vocs_state, vocs_location,
+        vocs_control, vocs_desc, aics_state, aics_gain, aics_type, aics_status, aics_control, aics_desc)
 
     vcp.event_received(defs.BTP_VCP_EV_DISCOVERED, (addr_type, addr, att_status, control_handle,
                                                 flag_handle, state_handle, vocs_state,
@@ -232,7 +224,7 @@ def vcp_ev_discovery_completed_(vcp, data, data_len):
 
 
 def vcp_state_ev(vcp, data, data_len):
-    logging.debug('%s %r', vcp_state_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbbb'
     if len(data) < struct.calcsize(fmt):
@@ -242,14 +234,14 @@ def vcp_state_ev(vcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'VCP State: addr {addr} addr_type {addr_type}, ATT Status {att_status},'
-                  f' volume {volume}, mute {mute}')
+    logging.debug("VCP State: addr %r, addr_type %r, ATT Status %r, volume %r, mute %r",
+                  addr, addr_type, att_status, volume, mute)
 
     vcp.event_received(defs.BTP_VCP_EV_STATE, (addr_type, addr, att_status, volume, mute))
 
 
 def vcp_flags_ev(vcp, data, data_len):
-    logging.debug('%s %r', vcp_flags_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbb'
     if len(data) < struct.calcsize(fmt):
@@ -259,14 +251,14 @@ def vcp_flags_ev(vcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'VCP Volume Flags: addr {addr} addr_type {addr_type},'
-                  f'ATT Status {att_status}, flags {flags}')
+    logging.debug("VCP Volume Flags: addr %r, addr_type %r,ATT Status %r, flags %r",
+                  addr, addr_type, att_status, flags)
 
     vcp.event_received(defs.BTP_VCP_EV_FLAGS, (addr_type, addr, att_status, flags))
 
 
 def vcp_procedure_ev(vcp, data, data_len):
-    logging.debug('%s %r', vcp_procedure_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbb'
     if len(data) < struct.calcsize(fmt):
@@ -276,8 +268,8 @@ def vcp_procedure_ev(vcp, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'VCP Procedure Event: addr {addr} addr_type {addr_type},'
-                  f' ATT status {att_status}, opcode {opcode}')
+    logging.debug("VCP Procedure Event: addr %r, addr_type %r, ATT status %r, opcode %r",
+                  addr, addr_type, att_status, opcode)
 
     vcp.event_received(defs.BTP_VCP_EV_PROCEDURE, (addr_type, addr, att_status, opcode))
 

--- a/autopts/pybtp/btp/vcs.py
+++ b/autopts/pybtp/btp/vcs.py
@@ -43,7 +43,7 @@ VCS_EV = {
 
 
 def vcs_command_rsp_succ(op=None):
-    logging.debug("%s", vcs_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -56,7 +56,7 @@ def vcs_command_rsp_succ(op=None):
 
 
 def vcs_set_vol(vol):
-    logging.debug("%s %r", vcs_set_vol.__name__, vol)
+    logging.debug("%r", vol)
 
     iutctl = get_iut()
 
@@ -70,7 +70,7 @@ def vcs_set_vol(vol):
 
 
 def vcs_register(step, mute, vol):
-    logging.debug("%s", vcs_register.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     flags = 0
@@ -89,7 +89,7 @@ def vcs_register(step, mute, vol):
 
 
 def vcs_mute():
-    logging.debug("%s", vcs_mute.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -98,7 +98,7 @@ def vcs_mute():
 
 
 def vcs_unmute():
-    logging.debug("%s", vcs_unmute.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -107,7 +107,7 @@ def vcs_unmute():
 
 
 def vcs_vol_down():
-    logging.debug("%s", vcs_vol_down.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -116,7 +116,7 @@ def vcs_vol_down():
 
 
 def vcs_vol_up():
-    logging.debug("%s", vcs_vol_up.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 

--- a/autopts/pybtp/btp/vocs.py
+++ b/autopts/pybtp/btp/vocs.py
@@ -44,7 +44,7 @@ VOCS = {
 
 
 def vocs_command_rsp_succ(op=None):
-    logging.debug("%s", vocs_command_rsp_succ.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -66,7 +66,7 @@ def address_to_ba(bd_addr_type=None, bd_addr=None):
 
 
 def vocs_audio_desc(string):
-    logging.debug("%s", vocs_audio_desc.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
     string_len = len(string)
@@ -79,7 +79,7 @@ def vocs_audio_desc(string):
 
 
 def vocs_audio_loc(location, bd_addr_type=None, bd_addr=None):
-    logging.debug("%s", vocs_audio_loc.__name__)
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -91,7 +91,7 @@ def vocs_audio_loc(location, bd_addr_type=None, bd_addr=None):
 
 
 def vocs_offset_state_get(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{vocs_offset_state_get.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -102,7 +102,7 @@ def vocs_offset_state_get(bd_addr_type=None, bd_addr=None):
 
 
 def vocs_offset_state_set(offset, bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{vocs_offset_state_set.__name__}")
+    logging.debug("")
 
     iutctl = get_iut()
 
@@ -114,7 +114,7 @@ def vocs_offset_state_set(offset, bd_addr_type=None, bd_addr=None):
 
 
 def vocs_audio_location_get(bd_addr_type=None, bd_addr=None):
-    logging.debug(f"{vocs_audio_location_get.__name__}")
+    logging.debug("")
 
     data = address_to_ba(bd_addr_type, bd_addr)
     iutctl = get_iut()
@@ -125,7 +125,7 @@ def vocs_audio_location_get(bd_addr_type=None, bd_addr=None):
 
 
 def vocs_state_ev(vocs, data, data_len):
-    logging.debug('%s %r', vocs_state_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbh'
     if len(data) < struct.calcsize(fmt):
@@ -135,14 +135,14 @@ def vocs_state_ev(vocs, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'VOCS Offset State: addr {addr} addr_type {addr_type},'
-                  f'ATT status {att_status}, offset {offset}')
+    logging.debug("VOCS Offset State: addr %r, addr_type %r, ATT status %r, offset %r",
+                  addr, addr_type, att_status, offset)
 
     vocs.event_received(defs.BTP_VOCS_EV_OFFSET, (addr_type, addr, att_status, offset))
 
 
 def vocs_audio_loc_ev(vocs, data, data_len):
-    logging.debug('%s %r', vocs_audio_loc_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbI'
     if len(data) < struct.calcsize(fmt):
@@ -152,15 +152,15 @@ def vocs_audio_loc_ev(vocs, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'VOCS Audio Location: addr {addr} addr_type {addr_type},'
-                  f' ATT Status {att_status}, Audio Location {location}')
+    logging.debug("VOCS Audio Location: addr %r, addr_type %r, ATT Status %r, Audio Location %r",
+                  addr, addr_type, att_status, location)
 
     vocs.event_received(defs.BTP_VOCS_EV_AUDIO_LOC, (addr_type, addr, att_status,
                                                  location))
 
 
 def vocs_procedure_ev(vocs, data, data_len):
-    logging.debug('%s %r', vocs_procedure_ev.__name__, data)
+    logging.debug('%r', data)
 
     fmt = '<B6sbb'
     if len(data) < struct.calcsize(fmt):
@@ -170,8 +170,8 @@ def vocs_procedure_ev(vocs, data, data_len):
 
     addr = le_bytes_to_hex_str(addr)
 
-    logging.debug(f'VOCS Procedure Event: addr {addr} addr_type {addr_type},'
-                  f' ATT status {att_status}, opcode {opcode}')
+    logging.debug("VOCS Procedure Event: addr %r, addr_type %r, ATT status %r, opcode %r",
+                  addr, addr_type, att_status, opcode)
 
     vocs.event_received(defs.BTP_VOCS_EV_PROCEDURE, (addr_type, addr, att_status, opcode))
 

--- a/autopts/pybtp/iutctl_common.py
+++ b/autopts/pybtp/iutctl_common.py
@@ -158,8 +158,8 @@ class BTPSocket:
 
     def send(self, svc_id, op, ctrl_index, data):
         """Send BTP formated data over socket"""
-        logging.debug("%s, %r %r %r %r",
-                      self.send.__name__, svc_id, op, ctrl_index, str(data))
+        logging.debug("%r %r %r %r",
+                      svc_id, op, ctrl_index, str(data))
 
         frame = enc_frame(svc_id, op, ctrl_index, data)
 
@@ -336,7 +336,7 @@ class BTPWorker:
         flag.clear()
 
     def read(self, timeout=20.0):
-        logging.debug("%s", self.read.__name__)
+        logging.debug("")
 
         flag = threading.Event()
         flag.set()
@@ -399,7 +399,7 @@ class BTPWorker:
             self._rx_queue.task_done()
 
     def accept(self, timeout=10.0):
-        logging.debug("%s", self.accept.__name__)
+        logging.debug("")
 
         self._socket.accept(timeout)
 


### PR DESCRIPTION
Use automatic function name in logs instead of __name__.

fixes https://github.com/auto-pts/auto-pts/issues/1344