### PR TITLE
wid: vcp: fix wait for ev function

### DIFF
--- a/autopts/wid/vcp.py
+++ b/autopts/wid/vcp.py
@@ -208,7 +208,7 @@ def hdl_wid_20107(params: WIDParams):
                                     stack.aics.wait_aics_gain_setting_prop_ev),
         "Audio Input Type": (btp.aics_type_get, stack.aics.wait_aics_input_type_ev),
         "Audio Input Status": (btp.aics_status_get,
-                               stack.aics.wait_aics_input_type_ev),
+                               stack.aics.wait_aics_status_ev),
     }
 
     operation_name = re.findall(r'read\s(.*?)\scharacteristic', params.description)


### PR DESCRIPTION
After performing aics status get operation we should expect aics status ev. This fixes event timeout and will save time in weekly LE Audio runs.

Related issue: https://github.com/auto-pts/auto-pts/issues/1605