### PR TITLE
wid: BAP: Remove streaming state check from hdl_wid_305

### DIFF
--- a/autopts/wid/bap.py
+++ b/autopts/wid/bap.py
@@ -1356,10 +1356,6 @@ def hdl_wid_305(params: WIDParams):
     if not ascs_enable(addr_type, addr, ase_id):
         return False
 
-    ev = stack.ascs.wait_ascs_ase_state_changed_ev(addr_type, addr, ase_id, ASCSState.STREAMING, 30)
-    if ev is None:
-        return False
-
     if not ascs_disable(addr_type, addr, ase_id):
         return False
 


### PR DESCRIPTION
We only need to enter the enabling state before going into the disabling state for source ASEs.

Fixes timeout for BAP/UCL/SCC/BV-113-C