### PR TITLE
bluez: Fix IUTCtl

### DIFF
--- a/autopts/ptsprojects/bluez/iutctl.py
+++ b/autopts/ptsprojects/bluez/iutctl.py
@@ -18,6 +18,7 @@ import logging
 import shlex
 import subprocess
 
+from autopts.ptsprojects.stack import Stack
 from autopts.pybtp import defs
 from autopts.pybtp.iutctl_common import BTP_ADDRESS, BTPSocketSrv, BTPWorker
 from autopts.pybtp.types import BTPError, BTPInitError
@@ -46,11 +47,14 @@ class IUTCtl:
         log("%s.%s btpclient_path=%s", self.__class__, self.__init__.__name__,
             args.btpclient_path)
 
-        self.btpclient_path = args.btpclient_path
+        self.btpclient_path = args.btpclient_path[0]
         self.btp_socket = None
         self.btp_address = BTP_ADDRESS
         self.socket_srv = None
         self.iut_process = None
+
+        self.stack = Stack()
+        self.stack.synch_init()
 
     def start(self, test_case):
         """Starts the IUT"""
@@ -106,6 +110,9 @@ class IUTCtl:
             self.iut_process.terminate()
             self.iut_process.wait()  # do not let zombies take over
             self.iut_process = None
+
+    def get_stack(self):
+        return self.stack
 
 
 def get_iut():

--- a/autopts/pybtp/iutctl_common.py
+++ b/autopts/pybtp/iutctl_common.py
@@ -216,7 +216,7 @@ class BTPSocket:
 
 class BTPSocketSrv(BTPSocket):
 
-    def __init__(self, log_dir=None, log_file=None):
+    def __init__(self, log_dir=None, log_file="autopts-iutctl.log"):
         super().__init__(log_dir, log_file)
         self.sock = None
 


### PR DESCRIPTION
6b59bde29 introduces support for controller selection with per IUT contexts and stacks, which can be resolved by call to get_iut() and get_stack().

This currently crashes for BlueZ:
```
Traceback (most recent call last):
  File "/home/fdanis/src/auto-pts/./autoptsclient-bluez.py", line 40, in <module>
    main()
  File "/home/fdanis/src/auto-pts/./autoptsclient-bluez.py", line 36, in main
    client.start()
  File "/home/fdanis/src/auto-pts/autopts/client.py", line 1535, in start
    return self.main(args)
           ^^^^^^^^^^^^^^^
  File "/home/fdanis/src/auto-pts/autopts/client.py", line 1590, in main
    self.setup_test_cases(self.ptses)
  File "/home/fdanis/src/auto-pts/autopts/client.py", line 1613, in setup_test_cases
    self.test_cases = setup_test_cases(ptses)
                      ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fdanis/src/auto-pts/autopts/client.py", line 1831, in setup_test_cases
    test_cases += mod.test_cases(ptses)
                  ^^^^^^^^^^^^^^^^^^^^^
  File "/home/fdanis/src/auto-pts/autopts/ptsprojects/bluez/bap.py", line 90, in test_cases
    stack = get_stack()
            ^^^^^^^^^^^
  File "/home/fdanis/src/auto-pts/autopts/ptsprojects/stack/stack.py", line 305, in get_stack
    return _get_stack()
           ^^^^^^^^^^^^
  File "/home/fdanis/src/auto-pts/autopts/pybtp/btp/btp.py", line 687, in _get_stack
    return get_iut().get_stack()
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'IUTCtl' object has no attribute 'get_stack'
```

This also add default log_file for BTPSocketSrv.