### PR TITLE
gap: Fix GAP/DM/BON/BV-01-C pairing sequence

### DIFF
--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -537,6 +537,9 @@ def hdl_wid_78(params: WIDParams):
         btp.gap_conn(b"00:00:00:00:00:00", 0)
     else:
         btp.gap_conn()
+        if params.test_case_name in ['GAP/DM/BON/BV-01-C']:
+            btp.gap_wait_for_connection()
+            btp.gap_pair()
 
     return True
 

--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -537,6 +537,9 @@ def hdl_wid_78(params: WIDParams):
         btp.gap_connect(b"00:00:00:00:00:00", 0)
     else:
         btp.gap_connect()
+        if params.test_case_name in ['GAP/DM/BON/BV-01-C']:
+            btp.gap_wait_for_connection()
+            btp.gap_pair()
 
     return True
 


### PR DESCRIPTION
Add explicit pairing sequence for GAP/DM/BON/BV-01-C test case. After establishing connection, wait for connection completion and initiate pairing to properly handle the bonding procedure required by this test case.