### PR TITLE
common: Set UTF-8 encoding for log files

### DIFF
--- a/autopts/client.py
+++ b/autopts/client.py
@@ -446,7 +446,8 @@ def init_logging(tag="", log_filename=None):
                         filename=log_filename,
                         filemode='w',
                         level=logging.DEBUG,
-                        force=True)
+                        force=True,
+                        encoding="utf-8")
 
 
 def init_pts_thread_entry_wrapper(func):
@@ -1193,7 +1194,7 @@ def run_test_case(ptses, test_case_instances, test_case_name, stats,
         return 'IUT2_NOT_AVAILABLE'
 
     test_case_lts[0].initialize_logging(session_log_dir)
-    file_handler = logging.FileHandler(test_case_lts[0].log_filename)
+    file_handler = logging.FileHandler(test_case_lts[0].log_filename, encoding='utf-8')
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
 

--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -90,7 +90,7 @@ def init_logging(_args):
     format_template = ("%(asctime)s %(threadName)s %(name)s %(levelname)s %(filename)-25s "
                        "%(lineno)-5s %(funcName)-25s : %(message)s")
     formatter = root_logging.Formatter(format_template)
-    file_handler = root_logging.FileHandler(_args.log_filename, mode='w')
+    file_handler = root_logging.FileHandler(_args.log_filename, mode='w', encoding='utf-8')
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
     logger.setLevel(root_logging.DEBUG)


### PR DESCRIPTION
Ensures proper Unicode/emoji handling in logs.