### PR TITLE
zephyr: Fix 'iut_targets' config use case

### DIFF
--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -160,7 +160,7 @@ class ZephyrBotClient(BotClient):
 
             iutctl.select_iut(0)
         else:
-            self._apply_config(args, config, value)
+            self._apply_config(next(iter(args.iut_targets_args.values())), config, value)
 
     def _apply_config(self, args, config, value):
         pre_overlay = value.get('pre_overlay', [])


### PR DESCRIPTION
If only one iut was specified in 'iut_targets' of config.py:
 'iut_targets': [
        {
            'name': 'iut0',
            'tty_file': 'COM1',
            'debugger_snr': '1234567890',
            'board': 'nrf52',
        },
    ]
then the iut config was not used during an image build, but only the base configuration provided in the 'auto_pts'. CLI arguments were not applied too.