### PR TITLE
Bluez: Add BAP/UCL support

### DIFF
--- a/autopts/ptsprojects/bluez/bap.py
+++ b/autopts/ptsprojects/bluez/bap.py
@@ -99,6 +99,7 @@ def test_cases(ptses):
         iut_addr.set(addr)
 
     def _stop_audio():
+        iut.set_desynchronized(False)
         iut.set_audio_profile(None)
         iut.stop_audio()
 
@@ -173,6 +174,14 @@ def test_cases(ptses):
                   generic_wid_hdl=bap_wid_hdl),
         BTestCase("BAP", "BAP/UCL/SCC/BV-094-C",
                   cmds=[TestFunc(lambda: iut.set_audio_profile("high-reliability"))] +
+                        pre_conditions,
+                  generic_wid_hdl=bap_wid_hdl),
+        BTestCase("BAP", "BAP/UCL/STR/BV-543-C",
+                  cmds=[TestFunc(lambda: iut.set_desynchronized(True))] +
+                        pre_conditions,
+                  generic_wid_hdl=bap_wid_hdl),
+        BTestCase("BAP", "BAP/UCL/STR/BV-546-C",
+                  cmds=[TestFunc(lambda: iut.set_desynchronized(True))] +
                         pre_conditions,
                   generic_wid_hdl=bap_wid_hdl),
         ]

--- a/autopts/ptsprojects/bluez/bap.py
+++ b/autopts/ptsprojects/bluez/bap.py
@@ -118,7 +118,9 @@ def test_cases(ptses):
         TestFunc(btp.set_pts_addr, pts_bd_addr, Addr.le_public),
         TestFunc(stack.gatt_init),
         TestFunc(btp.gap_set_connectable),
+        TestFunc(btp.core_reg_svc_ascs),
         TestFunc(btp.core_reg_svc_bap),
+        TestFunc(stack.ascs_init),
         TestFunc(stack.bap_init),
         TestFunc(lambda: stack.bap.set_broadcast_code(BROADCAST_CODE)),
         TestFunc(lambda: set_addr(

--- a/autopts/ptsprojects/bluez/bap.py
+++ b/autopts/ptsprojects/bluez/bap.py
@@ -18,9 +18,9 @@
 
 from autopts.client import get_unique_name
 from autopts.ptsprojects.bluez.bap_wid import bap_wid_hdl
-from autopts.ptsprojects.bluez.btestcase import BTestCase
+from autopts.ptsprojects.bluez.btestcase import BTestCase, BTestCaseSlave
 from autopts.ptsprojects.bluez.iutctl import get_iut
-from autopts.ptsprojects.stack import get_stack
+from autopts.ptsprojects.stack import SynchPoint, get_stack
 from autopts.ptsprojects.testcase import TestFunc, TestFuncCleanUp
 from autopts.pybtp import btp
 from autopts.pybtp.types import Addr, IOCap
@@ -103,10 +103,14 @@ def test_cases(ptses):
         iut.set_audio_profile(None)
         iut.stop_audio()
 
+    def _unpair():
+        for p in ptses:
+            btp.gap_unpair(p.q_bd_addr, Addr.le_public)
+
     pre_conditions = [
         TestFunc(btp.core_reg_svc_vendor),
         TestFunc(btp.core_reg_svc_gap),
-        TestFunc(btp.gap_unpair, pts_bd_addr, Addr.le_public),
+        TestFunc(_unpair),
         TestFunc(btp.gap_reset),
         TestFunc(btp.gap_set_io_capability, IOCap.display_only),
         TestFunc(stack.gap_init, iut_device_name),
@@ -176,6 +180,39 @@ def test_cases(ptses):
                   cmds=[TestFunc(lambda: iut.set_audio_profile("high-reliability"))] +
                         pre_conditions,
                   generic_wid_hdl=bap_wid_hdl),
+        BTestCase("BAP", "BAP/UCL/STR/BV-526-C", cmds=pre_conditions +
+                  [
+                      TestFunc(get_stack().synch.add_synch_element,
+                               [SynchPoint("BAP/UCL/STR/BV-526-C", 20100),
+                                SynchPoint("BAP/UCL/STR/BV-526-C_LT2", 20100)]),
+                      TestFunc(get_stack().synch.add_synch_element,
+                               [SynchPoint("BAP/UCL/STR/BV-526-C", 311),
+                                SynchPoint("BAP/UCL/STR/BV-526-C_LT2", 311)]),
+                  ],
+                  generic_wid_hdl=bap_wid_hdl,
+                  lt2="BAP/UCL/STR/BV-526-C_LT2"),
+        BTestCase("BAP", "BAP/UCL/STR/BV-528-C", cmds=pre_conditions +
+                  [
+                      TestFunc(get_stack().synch.add_synch_element,
+                               [SynchPoint("BAP/UCL/STR/BV-528-C", 20100),
+                                SynchPoint("BAP/UCL/STR/BV-528-C_LT2", 20100)]),
+                      TestFunc(get_stack().synch.add_synch_element,
+                               [SynchPoint("BAP/UCL/STR/BV-528-C", 311),
+                                SynchPoint("BAP/UCL/STR/BV-528-C_LT2", 311)]),
+                  ],
+                  generic_wid_hdl=bap_wid_hdl,
+                  lt2="BAP/UCL/STR/BV-528-C_LT2"),
+        BTestCase("BAP", "BAP/UCL/STR/BV-530-C", cmds=pre_conditions +
+                  [
+                      TestFunc(get_stack().synch.add_synch_element,
+                               [SynchPoint("BAP/UCL/STR/BV-530-C", 20100),
+                                SynchPoint("BAP/UCL/STR/BV-530-C_LT2", 20100)]),
+                      TestFunc(get_stack().synch.add_synch_element,
+                               [SynchPoint("BAP/UCL/STR/BV-530-C", 311),
+                                SynchPoint("BAP/UCL/STR/BV-530-C_LT2", 311)]),
+                  ],
+                  generic_wid_hdl=bap_wid_hdl,
+                  lt2="BAP/UCL/STR/BV-530-C_LT2"),
         BTestCase("BAP", "BAP/UCL/STR/BV-543-C",
                   cmds=[TestFunc(lambda: iut.set_desynchronized(True))] +
                         pre_conditions,
@@ -201,4 +238,27 @@ def test_cases(ptses):
 
         tc_list.append(instance)
 
-    return tc_list
+    if len(ptses) < 2:
+        return tc_list
+
+    pts2 = ptses[1]
+
+    pre_conditions_lt2 = [
+        TestFunc(lambda: pts2.update_pixit_param(
+            "BAP", "TSPX_bd_addr_iut", iut_addr.get(timeout=90, clear=True))),
+        TestFunc(btp.set_lt2_addr, pts2.q_bd_addr, Addr.le_public),
+    ]
+
+    test_cases_lt2 = [
+        BTestCaseSlave("BAP", "BAP/UCL/STR/BV-526-C_LT2",
+                       cmds=pre_conditions_lt2,
+                       generic_wid_hdl=bap_wid_hdl),
+        BTestCaseSlave("BAP", "BAP/UCL/STR/BV-528-C_LT2",
+                       cmds=pre_conditions_lt2,
+                       generic_wid_hdl=bap_wid_hdl),
+        BTestCaseSlave("BAP", "BAP/UCL/STR/BV-530-C_LT2",
+                       cmds=pre_conditions_lt2,
+                       generic_wid_hdl=bap_wid_hdl),
+    ]
+
+    return tc_list + test_cases_lt2

--- a/autopts/ptsprojects/bluez/bap.py
+++ b/autopts/ptsprojects/bluez/bap.py
@@ -118,6 +118,7 @@ def test_cases(ptses):
         TestFunc(btp.set_pts_addr, pts_bd_addr, Addr.le_public),
         TestFunc(stack.gatt_init),
         TestFunc(btp.gap_set_connectable),
+        TestFunc(btp.core_reg_svc_pacs),
         TestFunc(btp.core_reg_svc_ascs),
         TestFunc(btp.core_reg_svc_bap),
         TestFunc(stack.ascs_init),

--- a/autopts/ptsprojects/bluez/bap.py
+++ b/autopts/ptsprojects/bluez/bap.py
@@ -103,6 +103,7 @@ def test_cases(ptses):
         iut.stop_audio()
 
     pre_conditions = [
+        TestFunc(btp.core_reg_svc_vendor),
         TestFunc(btp.core_reg_svc_gap),
         TestFunc(btp.gap_unpair, pts_bd_addr, Addr.le_public),
         TestFunc(btp.gap_reset),

--- a/autopts/ptsprojects/bluez/bap_wid.py
+++ b/autopts/ptsprojects/bluez/bap_wid.py
@@ -54,3 +54,29 @@ def hdl_wid_303(params: WIDParams):
     # and reply may occur after PTS has disconnected, which causes test case to fail.
     # So just return True here and let BlueZ handle QoS configuration internally.
     return True
+
+
+def hdl_wid_311(params: WIDParams):
+    """
+    Please configure 1 SOURCE ASE with Config Setting: IXIT.
+    After that, configure to streaming state.
+    """
+
+    if get_iut().external_audio is not None:
+        logging.debug("External audio supported, skipping WID 311 handling")
+        return True
+
+    return autopts.wid.bap.hdl_wid_311(params)
+
+
+def hdl_wid_313(params: WIDParams):
+    """
+    Please configure 1 SINK and 1 SOURCE ASE with Config Setting: IXIT.
+    After that, configure to streaming state.
+    """
+
+    if get_iut().external_audio is not None:
+        logging.debug("External audio supported, skipping WID 313 handling")
+        return True
+
+    return autopts.wid.bap.hdl_wid_313(params)

--- a/autopts/ptsprojects/bluez/bap_wid.py
+++ b/autopts/ptsprojects/bluez/bap_wid.py
@@ -39,3 +39,18 @@ def hdl_wid_302(params: WIDParams):
         return True
 
     return autopts.wid.bap.hdl_wid_302(params)
+
+
+def hdl_wid_303(params: WIDParams):
+    """
+    Please configure ASE state to QoS Configured with 16_2_1 in SINK direction.
+    """
+
+    if get_iut().external_audio is not None:
+        logging.debug("External audio supported, skipping WID 303 handling")
+        return True
+
+    # Don't use autopts.wid.bap.hdl_wid_303 which requests to read ASE characteristic
+    # and reply may occur after PTS has disconnected, which causes test case to fail.
+    # So just return True here and let BlueZ handle QoS configuration internally.
+    return True

--- a/autopts/ptsprojects/bluez/iutctl.py
+++ b/autopts/ptsprojects/bluez/iutctl.py
@@ -58,6 +58,7 @@ class IUTCtl:
         self.iut_process = None
         self.audio_profile = None
         self.audio_process = None
+        self.desynchronized = False
 
         self.stack = Stack()
         self.stack.synch_init()
@@ -136,7 +137,7 @@ class IUTCtl:
                 latency = 1
             elif self.audio_profile == "high-reliability":
                 latency = 3
-            vendor.vendor_ascs_setup(latency)
+            vendor.vendor_ascs_setup(latency, self.desynchronized)
             return
         elif self.external_audio != "wireplumber":
             return
@@ -173,6 +174,9 @@ class IUTCtl:
 
     def set_audio_profile(self, profile):
         self.audio_profile = profile
+
+    def set_desynchronized(self, desynchronized):
+        self.desynchronized = desynchronized
 
 
 def get_iut():

--- a/autopts/ptsprojects/bluez/iutctl.py
+++ b/autopts/ptsprojects/bluez/iutctl.py
@@ -19,6 +19,7 @@ import os
 import shlex
 import subprocess
 
+import autopts.ptsprojects.bluez.vendor as vendor
 from autopts.ptsprojects.stack import Stack
 from autopts.pybtp import defs
 from autopts.pybtp.iutctl_common import BTP_ADDRESS, BTPSocketSrv, BTPWorker
@@ -126,7 +127,18 @@ class IUTCtl:
         return self.external_audio
 
     def start_audio(self):
-        if self.external_audio != "wireplumber":
+        if self.external_audio is None:
+            if not (self.stack.supported_cmds['VENDOR'] & defs.BIT(vendor.BTP_VENDOR_CMD_ASCS_SETUP)):
+                raise BTPInitError("Vendor ASCS setup command not supported")
+
+            latency = 0
+            if self.audio_profile == "low-latency":
+                latency = 1
+            elif self.audio_profile == "high-reliability":
+                latency = 3
+            vendor.vendor_ascs_setup(latency)
+            return
+        elif self.external_audio != "wireplumber":
             return
 
         logging.debug("Starting external audio with profile: %s", self.audio_profile)

--- a/autopts/ptsprojects/bluez/vendor.py
+++ b/autopts/ptsprojects/bluez/vendor.py
@@ -1,0 +1,59 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2026, Collabora Ltd.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+import logging
+import struct
+
+from autopts.pybtp import defs
+from autopts.pybtp.btp.btp import CONTROLLER_INDEX, btp_hdr_check
+from autopts.pybtp.btp.btp import get_iut_method as get_iut
+from autopts.pybtp.types import BTPError
+
+BTP_VENDOR_CMD_ASCS_SETUP = 0x02
+BTP_VENDOR_EV_OPERATION_COMPLETED = 0x80
+
+VENDOR = {
+    'read_supported_cmds': (defs.BTP_SERVICE_ID_VENDOR,
+                            defs.BTP_VENDOR_CMD_READ_SUPPORTED_COMMANDS,
+                            defs.BTP_INDEX_NONE),
+    'ascs_setup': (defs.BTP_SERVICE_ID_VENDOR, BTP_VENDOR_CMD_ASCS_SETUP, CONTROLLER_INDEX),
+}
+
+
+def vendor_command_rsp_succ(op=None, timeout=20.0):
+    logging.debug("")
+
+    iutctl = get_iut()
+
+    tuple_hdr, tuple_data = iutctl.btp_socket.read(timeout)
+    logging.debug("received %r %r", tuple_hdr, tuple_data)
+
+    btp_hdr_check(tuple_hdr, defs.BTP_SERVICE_ID_VENDOR, op)
+
+    return tuple_data
+
+
+def vendor_ascs_setup(target_latency):
+    logging.debug("")
+
+    if not (0 <= target_latency <= 3):
+        raise BTPError('Invalid target latency, must be between 0 and 3')
+
+    data = struct.pack('B', target_latency)
+
+    iutctl = get_iut()
+    iutctl.btp_socket.send(*VENDOR['ascs_setup'], data=data)
+
+    vendor_command_rsp_succ(BTP_VENDOR_CMD_ASCS_SETUP)

--- a/autopts/ptsprojects/bluez/vendor.py
+++ b/autopts/ptsprojects/bluez/vendor.py
@@ -45,13 +45,17 @@ def vendor_command_rsp_succ(op=None, timeout=20.0):
     return tuple_data
 
 
-def vendor_ascs_setup(target_latency):
+def vendor_ascs_setup(target_latency, desynchronized):
     logging.debug("")
 
     if not (0 <= target_latency <= 3):
         raise BTPError('Invalid target latency, must be between 0 and 3')
 
+    if desynchronized not in (0, 1):
+        raise BTPError('Invalid desynchronized value, must be 0 or 1')
+
     data = struct.pack('B', target_latency)
+    data += struct.pack('B', int(desynchronized))
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*VENDOR['ascs_setup'], data=data)

--- a/autopts/pybtp/btp/btp.py
+++ b/autopts/pybtp/btp/btp.py
@@ -609,6 +609,11 @@ def core_reg_svc_rfcomm():
 
 # GENERATOR append 1
 
+
+def core_reg_svc_vendor():
+    core_reg_svc_univ("vendor_reg", "VENDOR")
+
+
 def core_reg_svc_rsp_succ(service_name):
     logging.debug("")
     iutctl = get_iut()

--- a/autopts/pybtp/common.py
+++ b/autopts/pybtp/common.py
@@ -604,6 +604,10 @@ supported_svcs_cmds = {
         "supported_commands": defs.BTP_RFCOMM_CMD_READ_SUPPORTED_COMMANDS
     },
 # GENERATOR append 1
+    "VENDOR": {
+        "service": 1 << defs.BTP_SERVICE_ID_VENDOR,
+        "supported_commands": defs.BTP_VENDOR_CMD_READ_SUPPORTED_COMMANDS
+    },
 }
 
 reg_unreg_service = {
@@ -682,6 +686,8 @@ reg_unreg_service = {
     "rfcomm_reg": (defs.BTP_SERVICE_ID_CORE, defs.BTP_CORE_CMD_REGISTER_SERVICE,
                  defs.BTP_INDEX_NONE, defs.BTP_SERVICE_ID_RFCOMM),
 # GENERATOR append 2
+    "vendor_reg": (defs.BTP_SERVICE_ID_CORE, defs.BTP_CORE_CMD_REGISTER_SERVICE,
+                   defs.BTP_INDEX_NONE, defs.BTP_SERVICE_ID_VENDOR),
     "read_supp_cmds": (defs.BTP_SERVICE_ID_CORE,
                        defs.BTP_CORE_CMD_READ_SUPPORTED_COMMANDS,
                        defs.BTP_INDEX_NONE, ""),

--- a/autopts/pybtp/defs.py
+++ b/autopts/pybtp/defs.py
@@ -58,6 +58,7 @@ BTP_SERVICE_ID_PBP = 0x1e
 BTP_SERVICE_ID_SDP = 0x1f
 BTP_SERVICE_ID_RFCOMM = 0x20
 # GENERATOR append 1
+BTP_SERVICE_ID_VENDOR = 0xff
 
 BTP_ERROR = 0x00
 BTP_STATUS_SUCCESS = 0x00
@@ -1008,6 +1009,9 @@ BTP_RFCOMM_EV_DATA_RECEIVED = 0x82
 BTP_RFCOMM_EV_DATA_SENT = 0x83
 
 # GENERATOR append 2
+
+BTP_VENDOR_CMD_READ_SUPPORTED_COMMANDS = 0x01
+# Other commands and events are vendor specific and not defined here.
 
 # The reason codes for pairing failures.
 # Vol 3, Part H, Section 3.5.5

--- a/autopts/wid/bap.py
+++ b/autopts/wid/bap.py
@@ -2046,7 +2046,7 @@ def hdl_wid_311(params: WIDParams):
         for config in stack.bap.ase_configs:
             if config.audio_dir == AudioDir.SINK:
                 try:
-                    btp.bap_send(config.ase_id, stream_data[config.ase_id])
+                    btp.bap_send(config.ase_id, stream_data[config.ase_id], config.addr_type, config.addr)
                 except BTPError:
                     # Buffer full
                     pass

--- a/doc/btp_vendor.txt
+++ b/doc/btp_vendor.txt
@@ -1,0 +1,29 @@
+VENDOR Service (ID 255)
+=======================
+
+        Other commands, responses and events than the ones described in
+        this document are vendor specific and should be defined in
+        a btp_vendor_<name>.txt file.
+
+Commands and responses:
+
+        Opcode 0x00 - Error response
+
+        Opcode 0x01 - Read Supported Commands command/response
+
+                Controller Index:       <non-controller>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
+
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
+
+                In case of an error, the error response will be returned.
+
+Events:
+
+        None

--- a/doc/btp_vendor_bluez.txt
+++ b/doc/btp_vendor_bluez.txt
@@ -1,0 +1,33 @@
+VENDOR Service (ID 255)
+=======================
+
+        BlueZ specific commands, responses and events.
+
+Commands and responses:
+
+        Opcode 0x00 - cf. btp_vendor.txt
+
+        Opcode 0x01 - cf. btp_vendor.txt
+
+        Opcode 0x02 - ASCS Setup
+
+                Controller Index:       <controller id>
+                Command parameters:     Target Latency (1 octet)
+                Response parameters:    <None>
+
+                The values of the Target Latency parameter as defined in
+                ASCS_v1.0.1.pdf Table 5.2: Config Codec operation format, i.e.:
+
+                Valid Target Latency values:
+                        0x00 = No specific target latency requested
+                        0x01 = Target low latency
+                        0x02 = Target balanced latency and reliability
+                        0x03 = Target high reliability
+
+                This command is used to configure the ASCS service.
+
+                In case of an error, the error status response will be returned.
+
+Events:
+
+        None

--- a/doc/btp_vendor_bluez.txt
+++ b/doc/btp_vendor_bluez.txt
@@ -13,6 +13,7 @@ Commands and responses:
 
                 Controller Index:       <controller id>
                 Command parameters:     Target Latency (1 octet)
+                                        Desynchronized (1 octet)
                 Response parameters:    <None>
 
                 The values of the Target Latency parameter as defined in
@@ -23,6 +24,10 @@ Commands and responses:
                         0x01 = Target low latency
                         0x02 = Target balanced latency and reliability
                         0x03 = Target high reliability
+
+                Valid Desynchronized values:
+                        0x00 = Synchronized
+                        0x01 = Desynchronized
 
                 This command is used to configure the ASCS service.
 


### PR DESCRIPTION
This adds a new `Setup` command used to configure the ASCS service for IUT stack managing states internally like `BlueZ`.

This allows to set the audio profile to use for BAP/UCL/SCC tests requiring specific profiles, and to desynchronized
linked transports to be able to acquire streams separately for BAP/UCL/STR/BV-54[36]-C.