### PR TITLE
boards:simplify logging by removing manual function name references.

### DIFF
--- a/autopts/ptsprojects/boards/board_ext.py
+++ b/autopts/ptsprojects/boards/board_ext.py
@@ -50,7 +50,7 @@ def build_and_flash(zephyr_wd, tester_app_dir, board, debugger_snr, conf_file=No
     if build_and_flash_cmd is None:
         raise Exception("AUTOPTS_BUILD_FLASH_CMD env variable is not set")
 
-    logging.debug("%s: %s %s %s %s", build_and_flash.__name__, zephyr_wd, tester_app_dir, board, conf_file)
+    logging.debug("%s %s %s %s", zephyr_wd, tester_app_dir, board, conf_file)
 
     tester_dir = os.path.join(zephyr_wd, tester_app_dir)
 

--- a/autopts/ptsprojects/boards/dialog_da1469x_dk_pro.py
+++ b/autopts/ptsprojects/boards/dialog_da1469x_dk_pro.py
@@ -48,8 +48,7 @@ def build_and_flash(project_path, board, overlay=None):
     :param board: IUT
     :param overlay: configuration map to be used
     """
-    logging.debug("%s: %s %s %s", build_and_flash.__name__, project_path,
-                  board, overlay)
+    logging.debug("%s %s %s", project_path, board, overlay)
 
     board = 'dialog_da1469x-dk-pro'
     check_call('rm -rf bin/'.split(), cwd=project_path)

--- a/autopts/ptsprojects/boards/frdm_mcxw71.py
+++ b/autopts/ptsprojects/boards/frdm_mcxw71.py
@@ -38,8 +38,7 @@ def build_and_flash(zephyr_wd, tester_app_dir, board, debugger_snr, conf_file=No
     :param debugger_snr serial number
     :param conf_file: configuration file to be used
     """
-    logging.debug("%s: %s %s %s", build_and_flash.__name__, zephyr_wd,
-                  board, conf_file)
+    logging.debug("%s %s %s", zephyr_wd, board, conf_file)
     tester_dir = os.path.join(zephyr_wd, tester_app_dir)
 
     check_call('rm -rf build/'.split(), cwd=tester_dir)

--- a/autopts/ptsprojects/boards/nordic_pca10056.py
+++ b/autopts/ptsprojects/boards/nordic_pca10056.py
@@ -46,8 +46,7 @@ def build_and_flash(project_path, board, overlay=None, debugger_snr=None):
     :param debugger_snr: JLink serial number
     :return: TTY path
     """
-    logging.debug("%s: %s %s %s", build_and_flash.__name__, project_path,
-                  board, overlay)
+    logging.debug("%s %s %s", project_path, board, overlay)
 
     nrfutil = NrfUtil(board, debugger_snr)
     if debugger_snr is None:

--- a/autopts/ptsprojects/boards/nordic_pca10095.py
+++ b/autopts/ptsprojects/boards/nordic_pca10095.py
@@ -49,8 +49,7 @@ def build_and_flash(project_path, board, overlay=None, debugger_snr=None):
     :param debugger_snr: JLink serial number
     :return: TTY path
     """
-    logging.debug("%s: %s %s %s", build_and_flash.__name__, project_path,
-                  board, overlay)
+    logging.debug("%s %s %s", project_path, board, overlay)
 
     nrfutil = NrfUtil(board, debugger_snr)
     if debugger_snr is None:

--- a/autopts/ptsprojects/boards/nrf52_wsl.py
+++ b/autopts/ptsprojects/boards/nrf52_wsl.py
@@ -44,8 +44,7 @@ def build_and_flash(zephyr_wd, tester_app_dir, board, debugger_snr, conf_file=No
     :param debugger_snr serial number
     :param conf_file: configuration file to be used
     """
-    logging.debug("%s: %s %s %s %s", build_and_flash.__name__, zephyr_wd, tester_app_dir,
-                  board, conf_file)
+    logging.debug("%s %s %s %s", zephyr_wd, tester_app_dir, board, conf_file)
 
     tester_dir = os.path.join(zephyr_wd, tester_app_dir)
 

--- a/autopts/ptsprojects/boards/nrf53.py
+++ b/autopts/ptsprojects/boards/nrf53.py
@@ -34,8 +34,7 @@ def build_and_flash(zephyr_wd, tester_app_dir, board, debugger_snr, conf_file=No
     :param project_repos: a list of repo paths
     :param env_cmd: a command to for environment activation, e.g. source /path/to/venv/activate
     """
-    logging.debug("%s: %s %s %s %s", build_and_flash.__name__, zephyr_wd, tester_app_dir,
-                  board, conf_file)
+    logging.debug("%s %s %s %s", zephyr_wd, tester_app_dir, board, conf_file)
 
     if env_cmd:
         env_cmd = env_cmd.split() + ['&&']

--- a/autopts/ptsprojects/boards/nrf53_appcore.py
+++ b/autopts/ptsprojects/boards/nrf53_appcore.py
@@ -34,8 +34,7 @@ def build_and_flash(zephyr_wd, tester_app_dir, board, debugger_snr, conf_file=No
     :param project_repos: a list of repo paths
     :param env_cmd: a command to for environment activation, e.g. source /path/to/venv/activate
     """
-    logging.debug("%s: %s %s %s %s", build_and_flash.__name__, zephyr_wd, tester_app_dir,
-                  board, conf_file)
+    logging.debug("%s %s %s %s", zephyr_wd, tester_app_dir, board, conf_file)
 
     if env_cmd:
         env_cmd = env_cmd.split() + ['&&']

--- a/autopts/ptsprojects/boards/nrf53_audio.py
+++ b/autopts/ptsprojects/boards/nrf53_audio.py
@@ -63,8 +63,7 @@ def build_and_flash(zephyr_wd, tester_app_dir, board, debugger_snr, conf_file=No
     """
     source_dir = os.getenv("AUTOPTS_SOURCE_DIR_APP")
 
-    logging.debug("%s: %s %s %s %s %s", build_and_flash.__name__, zephyr_wd, tester_app_dir,
-                  board, conf_file, source_dir)
+    logging.debug("%s %s %s %s %s", zephyr_wd, tester_app_dir, board, conf_file, source_dir)
 
     app_core_configs = []
     if conf_file and conf_file != 'default' and conf_file != 'prj.conf':

--- a/autopts/ptsprojects/boards/nrf54h.py
+++ b/autopts/ptsprojects/boards/nrf54h.py
@@ -43,8 +43,7 @@ def build_and_flash(zephyr_wd, tester_app_dir, board, debugger_snr, conf_file=No
     :param project_repos: a list of repo paths
     :param env_cmd: a command to for environment activation, e.g. source /path/to/venv/activate
     """
-    logging.debug("%s: %s %s %s %s", build_and_flash.__name__, zephyr_wd, tester_app_dir,
-                  board, conf_file)
+    logging.debug("%s %s %s %s", zephyr_wd, tester_app_dir, board, conf_file)
 
     if env_cmd:
         env_cmd = env_cmd.split() + ['&&']

--- a/autopts/ptsprojects/boards/nrf5x.py
+++ b/autopts/ptsprojects/boards/nrf5x.py
@@ -42,8 +42,7 @@ def build_and_flash(zephyr_wd, tester_app_dir, board, debugger_snr, conf_file=No
     :param project_repos: a list of repo paths
     :param env_cmd: a command to for environment activation, e.g. source /path/to/venv/activate
     """
-    logging.debug("%s: %s %s %s %s", build_and_flash.__name__, zephyr_wd, tester_app_dir,
-                  board, conf_file)
+    logging.debug("%s %s %s %s", zephyr_wd, tester_app_dir, board, conf_file)
 
     if env_cmd:
         env_cmd = env_cmd.split() + ['&&']


### PR DESCRIPTION
Use automatic function name in logs instead of name.

#1748 
