### PR TITLE
Replace nrfjprog with nrfutil for Nordic boards

### DIFF
--- a/autopts/ptsprojects/boards/nordic_pca10056.py
+++ b/autopts/ptsprojects/boards/nordic_pca10056.py
@@ -33,9 +33,9 @@ def reset_cmd(iutctl):
     with_srn = ''
 
     if iutctl.debugger_snr:
-        with_srn = f' -s {iutctl.debugger_snr}'
+        with_srn = f'{iutctl.debugger_snr}'
 
-    return f'nrfjprog -f nrf52 -r {with_srn}'
+    return f'nrfutil device reset --reset-kind RESET_PIN --serial-number {with_srn}'
 
 
 def build_and_flash(project_path, board, overlay=None, debugger_snr=None):
@@ -70,7 +70,7 @@ def build_and_flash(project_path, board, overlay=None, debugger_snr=None):
         f'newt target set {board}_boot bsp=@apache-mynewt-core/hw/bsp/{board}'.split(), cwd=project_path)
     check_call(
         f'newt target set {board}_boot app=@mcuboot/boot/mynewt'.split(), cwd=project_path)
-    check_call(f'newt target set {board}_boot syscfg=MYNEWT_DOWNLOADER=nrfjprog'.split(),
+    check_call(f'newt target set {board}_boot syscfg=MYNEWT_DOWNLOADER=nrfutil'.split(),
                cwd=project_path)
 
     check_call(
@@ -79,7 +79,7 @@ def build_and_flash(project_path, board, overlay=None, debugger_snr=None):
         'newt target set bttester app=@apache-mynewt-nimble/apps/bttester'.split(),
         cwd=project_path)
 
-    config = 'MYNEWT_DOWNLOADER=nrfjprog'
+    config = 'MYNEWT_DOWNLOADER=nrfutil'
     if overlay:
         config += ':' + ':'.join([f'{k}={v}' for k, v in list(overlay.items())])
 

--- a/autopts/ptsprojects/boards/nordic_pca10095.py
+++ b/autopts/ptsprojects/boards/nordic_pca10095.py
@@ -36,9 +36,9 @@ def reset_cmd(iutctl):
     with_srn = ''
 
     if iutctl.debugger_snr:
-        with_srn = f' -s {iutctl.debugger_snr}'
+        with_srn = f'{iutctl.debugger_snr}'
 
-    return f'nrfjprog -r {with_srn}'
+    return f'nrfutil device reset --reset-kind RESET_PIN --serial-number {with_srn}'
 
 
 def build_and_flash(project_path, board, overlay=None, debugger_snr=None):
@@ -85,13 +85,13 @@ def build_and_flash(project_path, board, overlay=None, debugger_snr=None):
     check_call('newt target set bttester app=@apache-mynewt-nimble/apps/bttester'
                .split(), cwd=project_path)
 
-    config = 'NRF5340_EMBED_NET_CORE=1:BSP_NRF5340_NET_ENABLE=1:MYNEWT_DOWNLOADER=nrfjprog'
+    config = 'NRF5340_EMBED_NET_CORE=1:BSP_NRF5340_NET_ENABLE=1:MYNEWT_DOWNLOADER=nrfutil'
     if overlay:
         config += ':' + ':'.join([f'{k}={v}' for k, v in list(overlay.items())])
     check_call(f'newt target set bttester syscfg={config}'
                .split(), cwd=project_path)
-    check_call(f'newt target set {board}_boot syscfg=MYNEWT_DOWNLOADER=nrfjprog'.split(), cwd=project_path)
-    check_call(f'newt target set {board}_net_boot syscfg=BOOTUTIL_OVERWRITE_ONLY=1:MYNEWT_DOWNLOADER=nrfjprog'
+    check_call(f'newt target set {board}_boot syscfg=MYNEWT_DOWNLOADER=nrfutil'.split(), cwd=project_path)
+    check_call(f'newt target set {board}_net_boot syscfg=BOOTUTIL_OVERWRITE_ONLY=1:MYNEWT_DOWNLOADER=nrfutil'
                .split(), cwd=project_path)
 
     check_call(f'newt build {board}_boot'.split(), cwd=project_path)

--- a/autopts/ptsprojects/mynewt/post_tc.py
+++ b/autopts/ptsprojects/mynewt/post_tc.py
@@ -18,8 +18,8 @@
 import sys
 
 CONFIG_PROC = None
-# XXX: Fill me - nrfjprog path example: /home/user/tool/nrfjprog
-CONFIG_PATH = 'nrfjprog'
+# XXX: Fill me - nrfutil path example: /home/user/tool/nrfutil
+CONFIG_PATH = None
 
 
 # def cleanup():

--- a/autopts/ptsprojects/zephyr/post_tc.py
+++ b/autopts/ptsprojects/zephyr/post_tc.py
@@ -18,7 +18,7 @@
 import sys
 
 CONFIG_PROC = None
-# XXX: Fill me - nrfjprog path example: /home/user/tool/nrfjprog
+# XXX: Fill me - nrfutil path example: /home/user/tool/nrfutil
 CONFIG_PATH = None
 
 


### PR DESCRIPTION
Migrate the flashing and reset toolchain for Nordic boards from nrfjprog to nrfutil.

Update the device reset commands and MYNEWT_DOWNLOADER configurations in the board scripts, while also adjusting toolchain path references in the post_tc.py files.

resolves https://github.com/auto-pts/auto-pts/issues/1774