### PR TITLE
rtt: discard btmon stdout/stderr to avoid pipe buffer hang

### DIFF
--- a/autopts/rtt.py
+++ b/autopts/rtt.py
@@ -216,8 +216,8 @@ class BTMON:
                 cmd = f"btmon -C 130 -J {device_core},{debugger_snr} -w {self.log_filename}"
             self.btmon_process = subprocess.Popen(cmd, cwd=self.log_filecwd,
                                                   shell=True,
-                                                  stdout=subprocess.PIPE,
-                                                  stderr=subprocess.PIPE,
+                                                  stdout=subprocess.DEVNULL,
+                                                  stderr=subprocess.DEVNULL,
                                                   preexec_fn=os.setsid)
 
     def stop(self):
@@ -244,8 +244,8 @@ class BTMON:
         else:
             proc = subprocess.Popen(cmd, cwd=self.log_filecwd,
                                     shell=True,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE,
+                                    stdout=subprocess.DEVNULL,
+                                    stderr=subprocess.DEVNULL,
                                     preexec_fn=os.setsid)
         proc.wait()
 


### PR DESCRIPTION
Both btmon invocations in BTMON.start()/stop() were spawned with stdout=subprocess.PIPE and stderr=subprocess.PIPE, but the pipes were never drained. Once the kernel pipe buffer (typically 64 KB) filled up, btmon blocked on write() and stalled.

For the recording process (btmon -i HCI -w FILE) this caused the btsnoop file to freeze a few seconds into a test case while the process appeared alive; for the conversion process (btmon -r FILE -P > TEXT) it could similarly hang on stderr.

Replace stdout/stderr with subprocess.DEVNULL in both Popen calls.