### PR TITLE
bluez: Explicitly remove PTS device on CleanUp

### DIFF
--- a/autopts/ptsprojects/bluez/bap.py
+++ b/autopts/ptsprojects/bluez/bap.py
@@ -123,6 +123,7 @@ def test_cases(ptses):
             stack.gap.iut_addr_get_str())),
         TestFunc(iut.start_audio),
         TestFuncCleanUp(_stop_audio),
+        TestFuncCleanUp(btp.gap_unpair, pts_bd_addr, Addr.le_public),
         ]
 
     custom_test_cases = [

--- a/autopts/ptsprojects/bluez/gap.py
+++ b/autopts/ptsprojects/bluez/gap.py
@@ -20,7 +20,7 @@ from autopts.client import get_unique_name
 from autopts.ptsprojects.bluez.btestcase import BTestCase
 from autopts.ptsprojects.bluez.gap_wid import gap_wid_hdl
 from autopts.ptsprojects.stack import get_stack
-from autopts.ptsprojects.testcase import TestFunc
+from autopts.ptsprojects.testcase import TestFunc, TestFuncCleanUp
 from autopts.pybtp import btp
 from autopts.pybtp.types import UUID, Addr, AdFlags, AdType, IOCap, Perm, Prop
 from autopts.wid.gap import hdl_wid_161
@@ -185,7 +185,9 @@ def test_cases(ptses):
         # We do this on test case, because previous one could
         # update this if RPA was used by PTS
         # TODO: Get PTS address type
-        TestFunc(btp.set_pts_addr, pts_bd_addr, Addr.le_public)]
+        TestFunc(btp.set_pts_addr, pts_bd_addr, Addr.le_public),
+        TestFuncCleanUp(btp.gap_unpair, pts_bd_addr, Addr.le_public),
+        ]
 
     custom_test_cases = [
         BTestCase("GAP", "GAP/BROB/BCST/BV-03-C",


### PR DESCRIPTION
Currently all paired devices are removed by btpclient when GAP reset command is called.  
This change explicitly call the Unpair command for the PTS device, allowing btpclient's GAP reset to not remove all paired devices, see https://patchwork.kernel.org/project/bluetooth/list/?series=1097130.