### PR TITLE
bluez: Restore unpairing at test start

### DIFF
--- a/autopts/ptsprojects/bluez/bap.py
+++ b/autopts/ptsprojects/bluez/bap.py
@@ -104,6 +104,7 @@ def test_cases(ptses):
 
     pre_conditions = [
         TestFunc(btp.core_reg_svc_gap),
+        TestFunc(btp.gap_unpair, pts_bd_addr, Addr.le_public),
         TestFunc(btp.gap_reset),
         TestFunc(btp.gap_set_io_cap, IOCap.display_only),
         TestFunc(stack.gap_init, iut_device_name),
@@ -123,7 +124,6 @@ def test_cases(ptses):
             stack.gap.iut_addr_get_str())),
         TestFunc(iut.start_audio),
         TestFuncCleanUp(_stop_audio),
-        TestFuncCleanUp(btp.gap_unpair, pts_bd_addr, Addr.le_public),
         ]
 
     custom_test_cases = [

--- a/autopts/ptsprojects/bluez/gap.py
+++ b/autopts/ptsprojects/bluez/gap.py
@@ -20,7 +20,7 @@ from autopts.client import get_unique_name
 from autopts.ptsprojects.bluez.btestcase import BTestCase
 from autopts.ptsprojects.bluez.gap_wid import gap_wid_hdl
 from autopts.ptsprojects.stack import get_stack
-from autopts.ptsprojects.testcase import TestFunc, TestFuncCleanUp
+from autopts.ptsprojects.testcase import TestFunc
 from autopts.pybtp import btp
 from autopts.pybtp.types import UUID, Addr, AdFlags, AdType, IOCap, Perm, Prop
 from autopts.wid.gap import hdl_wid_161
@@ -155,6 +155,7 @@ def test_cases(ptses):
 
     pre_conditions = [
         TestFunc(btp.core_reg_svc_gap),
+        TestFunc(btp.gap_unpair, pts_bd_addr, Addr.le_public),
         TestFunc(btp.gap_reset),
         TestFunc(stack.gap_init, iut_device_name,
                  iut_manufacturer_data, iut_appearance, iut_svc_data, iut_flags,
@@ -186,7 +187,6 @@ def test_cases(ptses):
         # update this if RPA was used by PTS
         # TODO: Get PTS address type
         TestFunc(btp.set_pts_addr, pts_bd_addr, Addr.le_public),
-        TestFuncCleanUp(btp.gap_unpair, pts_bd_addr, Addr.le_public),
         ]
 
     custom_test_cases = [


### PR DESCRIPTION
Unpairing on cleanup works fine but prevent to run further tests correctly due unexpected events for attribute read/write error after device disconnection:
```
$  python3 ./autoptsclient-bluez.py "C:\Users\fdanis\Documents\Profile Tuning Suite\BlueZ LE Audio tests\BlueZ LE Audio tests.pqw6" --btpclient_path=/home/fdanis/src/bluez/client/btpclient/btpclient -i 192.168.1.48 192.168.1.48 -l 192.168.1.150 192.168.1.150 --srv_port 65000 65002 --cli_port 65001 65003 -c BAP/CL/CGGIT/CHA/BV-01-C
130710977718864 Starting PTS: 192.168.1.48:65000 ...
(130710977718864) OK
130710977723616 Starting PTS: 192.168.1.48:65002 ...
(130710977723616) OK
Number of test cases to run: 1
1/1   BAP    BAP/CL/CGGIT/CHA/BV-01-C   PASS           19.49                  

Summary:

Status Count
============
PASS       1
============
Total      1

Bye!
$ python3 ./autoptsclient-bluez.py "C:\Users\fdanis\Documents\Profile Tuning Suite\BlueZ LE Audio tests\BlueZ LE Audio tests.pqw6" --btpclient_path=/home/fdanis/src/bluez/client/btpclient/btpclient -i 192.168.1.48 192.168.1.48 -l 192.168.1.150 192.168.1.150 --srv_port 65000 65002 --cli_port 65001 65003 -c BAP/CL/CGGIT/SER/BV-01-C -c BAP/CL/CGGIT/CHA/BV-01-C
127348376871104 Starting PTS: 192.168.1.48:65000 ...
(127348376871104) OK
127348376877872 Starting PTS: 192.168.1.48:65002 ...
(127348376877872) OK
Number of test cases to run: 2
1/2   BAP    BAP/CL/CGGIT/SER/BV-01-C   PASS           19.03
2/2   BAP    BAP/CL/CGGIT/CHA/BV-01-C   FATAL ERROR    5.662

Summary:

Status  Count
=============
PASS        1
FATAL ERROR 1
=============
Total       2

Bye!
```
Moving unpairing before gap_reset() call fix this, as it restore the previous sequence.