### PR TITLE
Add "Total" row in reports

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -1003,11 +1003,18 @@ class TestGroup:
         self.total = 0
         self.passed = 0
         self.failed = 0
-        self.pass_rate = 0.0
 
-    def get_pass_rate(self):
+    def get_pass_rate(self) -> float:
+        """
+        Get the pass rate in percentage (0.00 -> 100.00)
+
+        Returns:
+            float: Pass rate
+        """
         if self.total > 0:
-            self.pass_rate = (self.passed / float(self.total)) * 100
+            return (self.passed / float(self.total)) * 100.00
+        else:
+            return float(0.00)
 
 
 def get_tc_res_data(tc_results, test_groups):

--- a/autopts/bot/common_features/mail.py
+++ b/autopts/bot/common_features/mail.py
@@ -76,9 +76,6 @@ def html_profile_summary(tc_results):
     test_groups = {}
     common.get_tc_res_data(tc_results, test_groups)
 
-    for tg in test_groups.values():
-        tg.get_pass_rate()
-
     table_rows = ""
     for suite, stats in test_groups.items():
         table_rows += f"""
@@ -87,7 +84,7 @@ def html_profile_summary(tc_results):
                 <td>{stats.total}</td>
                 <td>{stats.passed}</td>
                 <td>{stats.failed}</td>
-                <td>{stats.pass_rate:.2f} %</td>
+                <td>{stats.get_pass_rate():.2f} %</td>
             </tr>
             """
 

--- a/autopts/bot/common_features/report.py
+++ b/autopts/bot/common_features/report.py
@@ -502,15 +502,20 @@ def ascii_profile_summary(tc_results):
     test_groups = {}
     common.get_tc_res_data(tc_results, test_groups)
 
-    for tg in test_groups.values():
-        tg.get_pass_rate()
+    total = common.TestGroup()
 
     header = "|  Suite  | Total | Pass | Fail | Pass Rate|"
     separator = "|---------|-------|------|------|----------|"
     rows = []
     for suite, stats in test_groups.items():
-        rows.append(
-            f"\n|{suite:<9}|{stats.total:<7}|{stats.passed:<6}|{stats.failed:<6}|{stats.pass_rate:>7.2f} % |")
+        total.total += stats.total
+        total.passed += stats.passed
+        total.failed += stats.failed
+
+        rows.append(f"\n|{suite:<9}|{stats.total:<7}|{stats.passed:<6}|{stats.failed:<6}|{stats.get_pass_rate():>7.2f} % |")
+
+    # Add final "Total" row that contains the overall result for the set of suites
+    rows.append(f"\n|{'Total':<9}|{total.total:<7}|{total.passed:<6}|{total.failed:<6}|{total.get_pass_rate():>7.2f} % |")
     table = f"\n{header}\n{separator}" + "".join(rows)
 
     return table


### PR DESCRIPTION
Add a new "Total" row in the automated reports.
This will help get a quicker overview of the overall state, and makes the results comparable with the emails that do contain the total and passrate.