### PR TITLE
Add "Total" row in email reports

### DIFF
--- a/autopts/bot/common_features/mail.py
+++ b/autopts/bot/common_features/mail.py
@@ -76,8 +76,14 @@ def html_profile_summary(tc_results):
     test_groups = {}
     common.get_tc_res_data(tc_results, test_groups)
 
+    total = common.TestGroup()
+
     table_rows = ""
     for suite, stats in test_groups.items():
+        total.total += stats.total
+        total.passed += stats.passed
+        total.failed += stats.failed
+
         table_rows += f"""
             <tr>
                 <td>{suite}</td>
@@ -88,6 +94,16 @@ def html_profile_summary(tc_results):
             </tr>
             """
 
+    # Add final "Total" row that contains the overall result for the set of suites
+    table_rows += f"""
+        <tr>
+            <td>Total</td>
+            <td>{total.total}</td>
+            <td>{total.passed}</td>
+            <td>{total.failed}</td>
+            <td>{total.get_pass_rate():.2f} %</td>
+        </tr>
+        """
     suite_summary = f"""
         <div>
             <h3>Test Group/Profile Summary</h3>


### PR DESCRIPTION
Add a new "Total" row in the automated email reports. This will help get a quicker overview of the overall state, and makes the results comparable with the emails that do contain the total and passrate.

This follows the same format as the .txt reports.