### PR TITLE
l2cap: increase frame count for test case L2CAP/COS/FLC/BV-03-C

### DIFF
--- a/autopts/bot/iut_config/zephyr.py
+++ b/autopts/bot/iut_config/zephyr.py
@@ -385,6 +385,7 @@ iut_config = {
             'CONFIG_BT_L2CAP_FCS': 'n',
             'CONFIG_BT_L2CAP_EXT_WIN_SIZE': 'n',
             'CONFIG_BT_L2CAP_MAX_WINDOW_SIZE': '5',
+            'CONFIG_BTTESTER_L2CAP_DATA_POOL_COUNT': '6',
         },
         "test_cases": [
             'L2CAP/COS/CFD/BV-10-C',

--- a/autopts/wid/l2cap.py
+++ b/autopts/wid/l2cap.py
@@ -856,12 +856,17 @@ def hdl_wid_1(params: WIDParams):
     return True
 
 
-def hdl_wid_134(_: WIDParams):
+def hdl_wid_134(params: WIDParams):
     '''
     Using the Implementation Under Test(IUT), send an I - Frame(data) to the PTS until TxWindow is full.
     '''
     l2cap = get_stack().l2cap
-    for _ in range(0, 5):
+
+    max_frame_count = 5
+    if params.test_case_name in ['L2CAP/COS/FLC/BV-03-C']:
+        max_frame_count += 1
+
+    for _ in range(max_frame_count):
         for channel in l2cap.channels:
             _l2cap_chann_send_safely(channel.id, '00', 1)
     return True


### PR DESCRIPTION
The L2CAP/COS/FLC/BV-03-C test case requires sending one additional I-Frame to fill the TxWindow compared to other flow control tests.

This change increases the max_frame_count from 5 to 6 specifically for this test case, while maintaining the default count of 5 for all other test cases using WID 134.