### PR TITLE
PACS: Add hdl_wid_35 and set Sink PAC update

### DIFF
--- a/autopts/wid/pacs.py
+++ b/autopts/wid/pacs.py
@@ -118,6 +118,17 @@ def hdl_wid_14(_: WIDParams):
     return True
 
 
+def hdl_wid_35(_: WIDParams):
+    """
+    Please update Sink PAC V2 characteristic value (Handle 0x0026),
+    and expect to receive a notification after reconnection.
+    """
+
+    global pacs_update_fun
+    pacs_update_fun = btp.pacs_update_sink_pac
+    return True
+
+
 def hdl_wid_20001(_: WIDParams):
     stack = get_stack()
     btp.gap_set_conn()


### PR DESCRIPTION
Added hdl_wid_35 handler and assigned pacs_update_fun to
btp.pacs_update_sink_pac to fix PACS/SR/PCU/BV-09-C test.

The following conformance tests now pass:
PACS/SR/PCU/BV-09-C

Testing
nRF5340 Audio DK
nRF54L15 DK