### PR TITLE
wid/sm: Fix passkey handling for KeyboardOnly in WID 106

### DIFF
--- a/autopts/wid/sm.py
+++ b/autopts/wid/sm.py
@@ -87,6 +87,12 @@ def hdl_wid_104(params: WIDParams):
 
 
 def hdl_wid_106(params: WIDParams):
+    stack = get_stack()
+    if stack.gap.io_cap == IOCap.keyboard_only:
+        bd_addr = btp.pts_addr_get()
+        bd_addr_type = btp.pts_addr_type_get()
+        passkey = stack.gap.get_passkey()
+        btp.gap_passkey_entry_rsp(bd_addr, bd_addr_type, passkey)
     return btp.var_store_get_wrong_passkey(params.description)
 
 


### PR DESCRIPTION
Fix Secure Connections pairing failure for KeyboardOnly IO capability observed in test cases:
	- SM/CEN/SCPK/BI-03-C
	- SM/PER/SCPK/BI-05-C

Previously, auto-pts only stored a generated passkey on gap_passkey_entry_req_ev_ but did not send it to the IUT, causing the IUT to wait for BTP_GAP_CMD_PASSKEY_ENTRY and eventually timeout. Update hdl_wid_106 to send the passkey to the IUT via btp.gap_passkey_entry_rsp() for KeyboardOnly, ensuring correct wrong-passkey flow. DisplayOnly behavior remains unchanged.