### PR TITLE
mynewt: gap: remove setting deprecated pixit

### DIFF
--- a/autopts/ptsprojects/mynewt/gap.py
+++ b/autopts/ptsprojects/mynewt/gap.py
@@ -147,9 +147,6 @@ def test_cases(ptses):
         TestFunc(lambda: pts.update_pixit_param(
             "GAP", "TSPX_bd_addr_iut",
             stack.gap.iut_addr_get_str())),
-        TestFunc(lambda: pts.update_pixit_param(
-            "GAP", "TSPX_bd_addr_PTS",
-            pts_bd_addr.replace(':', ''))),
         TestFunc(pts.update_pixit_param, "GAP",
                  "TSPX_iut_private_address_interval",
                  '30000'),


### PR DESCRIPTION
Setting deprecated TSPX_bd_addr_PTS Pixit in GAP precoditions causes XML-RPC error (bad pixit param). This is leftover after updating workspace to PTS 8.13

<img width="567" height="457" alt="image" src="https://github.com/user-attachments/assets/93bfc533-9ebf-48e0-8b42-f1c44129d729" />
