### PR TITLE
MCP: store discovered handles for WID validation

### DIFF
--- a/autopts/ptsprojects/stack/layers/mcp.py
+++ b/autopts/ptsprojects/stack/layers/mcp.py
@@ -18,6 +18,27 @@ from autopts.pybtp import defs
 
 
 class MCP:
+    """Media Control Profile (MCP) stack layer.
+
+    Manages event queues and state for MCP client operations.
+
+    Attributes:
+        event_queues (dict[int, list[tuple]]): Queues for each BTP MCP event type,
+            mapping event type constants to lists of event tuples.
+        error_opcodes (list[int]): List of error opcodes received from the server.
+        object_id (int | None): Object ID used in OTS-related MCP operations, or None
+            if not set.
+        discovered_handles (list[str]): Characteristic handles (as uppercase 4-digit hex
+            strings) parsed from the last successful BTP_MCP_EV_DISCOVERED event.
+            Updated only on discovery completion with status=0. Used by WID handlers
+            to validate that expected handles were reported by the IUT.
+    """
+
+    event_queues: dict[int, list[tuple]]
+    error_opcodes: list[int]
+    object_id: int | None
+    discovered_handles: list[str]
+
     def __init__(self):
         self.event_queues = {
             defs.BTP_MCP_EV_DISCOVERED: [],
@@ -43,8 +64,22 @@ class MCP:
         }
         self.error_opcodes = []
         self.object_id = None
+        self.discovered_handles = []
+
+    @staticmethod
+    def _extract_discovered_handles(event_data_tuple):
+        # Event tuple layout: (addr_type, addr, status, <characteristic handles...>)
+        chars = event_data_tuple[3:]
+        handles = [f'{chrc:04X}' for chrc in chars]
+        return [handle for handle in handles if handle != '0000']
 
     def event_received(self, event_type, event_data_tuple):
+        if event_type == defs.BTP_MCP_EV_DISCOVERED:
+            status = event_data_tuple[2]
+            if status == 0:
+                self.discovered_handles = self._extract_discovered_handles(event_data_tuple)
+            else:
+                self.discovered_handles = []
         self.event_queues[event_type].append(event_data_tuple)
 
     def wait_discovery_completed_ev(self, addr_type, addr, timeout=30, remove=True):

--- a/autopts/wid/mcp.py
+++ b/autopts/wid/mcp.py
@@ -17,7 +17,7 @@ import logging
 import re
 
 from autopts.ptsprojects.stack import get_stack
-from autopts.pybtp import btp, defs
+from autopts.pybtp import btp
 from autopts.pybtp.types import WIDParams
 
 log = logging.debug
@@ -489,17 +489,10 @@ def hdl_wid_20206(params: WIDParams):
      """
 
     stack = get_stack()
+    chrc_list = stack.mcp.discovered_handles
 
-    if params.test_case_name == "MCP/CL/CGGIT/SER/BV-02-C":
-        chars = stack.mcp.event_queues[defs.BTP_MCP_EV_DISCOVERED][0][3:25]
-        chrc_list = [f'{chrc:04X}' for chrc in chars]
-    elif params.test_case_name == "MCP/CL/CGGIT/SER/BV-03-C":
-        chars = stack.mcp.event_queues[defs.BTP_MCP_EV_DISCOVERED][0][25:]
-        chrc_list = [f'{chrc:04X}' for chrc in chars]
-        # Object First-Created and Object Last-Modified Characteristic are omitted
-        # because Server doest not have access to real time clock (data is set to 0)
-        while '0000' in chrc_list:
-            chrc_list.remove('0000')
+    if not chrc_list:
+        return False
 
     pattern = re.compile(r"0x([0-9a-fA-F]+)")
     desc_params = pattern.findall(params.description)
@@ -508,15 +501,13 @@ def hdl_wid_20206(params: WIDParams):
         return False
 
     desc_params_list = desc_params[2::4]
+    if not desc_params_list:
+        logging.error("parsing error")
+        return False
 
-    if params.test_case_name == "MCP/CL/CGGIT/SER/BV-03-C":
-        # Also Object List Filter characteristic isn't supported.
-        unsupported_chrc = ['012A', '012C', '0138', '013D', '013F', '013A']
-        for handle in unsupported_chrc:
-            while handle in desc_params_list:
-                desc_params_list.remove(handle)
+    discovered_set = set(chrc_list)
 
-    if desc_params_list == chrc_list:
+    if all(handle in discovered_set for handle in desc_params_list):
         return True
 
     return False


### PR DESCRIPTION
Store discovered handles in MCP stack state and validate
WID 20206 by checking expected handles exist in that stored
list. This removes test-specific filtering and avoids stale
queue/event coupling.

The following conformance tests now pass:
MCP/CL/CGGIT/SER/BV-02-C
MCP/CL/CGGIT/SER/BV-03-C

Testing
nRF5340 Audio DK
nRF54L15 DK