### PR TITLE
TMAP: confirm passkey on LT2 in WID 2004

### DIFF
--- a/autopts/wid/tmap.py
+++ b/autopts/wid/tmap.py
@@ -764,8 +764,12 @@ def hdl_wid_2004(params: WIDParams):
     pattern = r'[\d]{6}'
     passkey = re.search(pattern, params.description)[0]
     stack = get_stack()
-    bd_addr = btp.pts_addr_get()
-    bd_addr_type = btp.pts_addr_type_get()
+    if params.test_case_name.endswith('LT2'):
+        bd_addr = lt2_addr_get()
+        bd_addr_type = lt2_addr_type_get()
+    else:
+        bd_addr = pts_addr_get()
+        bd_addr_type = pts_addr_type_get()
 
     if stack.gap.get_passkey() is None:
         return False


### PR DESCRIPTION
Use LT2 address/type for WID 2004 in LT2
tests instead of always using LT1.

The following conformance tests now pass:

TMAP/UMS/VRC/BV-02-C
TMAP/UMS/VRC/BV-02-C_LT2

Testing
nRF5340 Audio DK
nRF54L15 DK