### PR TITLE
wid: gatt: adjust GATT/SR/GAN/BV-02-C

### DIFF
--- a/autopts/wid/gatt.py
+++ b/autopts/wid/gatt.py
@@ -1084,13 +1084,17 @@ def hdl_wid_93(params: WIDParams):
         addr_type, addr = (btp.pts_addr_type_get(), btp.pts_addr_get())
 
     db = gatt_server_fetch_db().db
-    handles = [
-        db[i].handle + 1
-        for i in range(1, len(db) + 1)
-        if isinstance(db[i], GattCharacteristic) and db[i].prop & Prop.notify
-    ]
+    handles = []
 
-    btp.gatts_notify_mult(addr_type, addr, len(handles), handles)
+    for i in range(1, len(db) + 1):
+        if isinstance(db[i], GattCharacteristic) and db[i].prop & Prop.notify:
+            handles.append(db[i].handle + 1)
+            # Limit to max 2 handles to ensure the ATT_MULTIPLE_HANDLE_VALUE_NTF PDU
+            # fits within ATT_MTU without truncating HLV tuples.
+            if len(handles) == 2:
+                break
+
+    btp.gatts_notify_mult(addr_type, addr, 2, handles)
     return True
 
 
@@ -2024,8 +2028,9 @@ def hdl_wid_304(params: WIDParams):
 
 
 def hdl_wid_308(params: WIDParams):
-    # description: Please do not send an ATT_Handle_value_Multiple_notification to Lower tester until timeout(30s).
-
+    """
+    Please do not send an ATT_Handle_value_Multiple_notification to Lower tester until timeout(30s).
+    """
     # PTS description is bit odd because in test spec UT is expected to request sending
     # ATT_Handle_value_Multiple_notification and IUT should ignore that.
 
@@ -2035,17 +2040,27 @@ def hdl_wid_308(params: WIDParams):
         addr_type, addr = (btp.pts_addr_type_get(), btp.pts_addr_get())
 
     db = gatt_server_fetch_db().db
-    handles = [
-        db[i].handle + 1
-        for i in range(1, len(db) + 1)
-        if isinstance(db[i], GattCharacteristic) and db[i].prop & Prop.notify
-    ]
+    handles = []
 
+    for i in range(1, len(db) + 1):
+        if isinstance(db[i], GattCharacteristic) and db[i].prop & Prop.notify:
+            handles.append(db[i].handle + 1)
+            # Limit to max 2 handles to ensure the ATT_MULTIPLE_HANDLE_VALUE_NTF PDU
+            # fits within ATT_MTU without truncating HLV tuples.
+            if len(handles) == 2:
+                break
     # IUT may fail here (or silently ignore and return success)
     try:
-        btp.gatts_notify_mult(addr_type, addr, len(handles), handles)
-    except BTPError:
-        pass
+        btp.gatts_notify_mult(addr_type, addr, 2, handles)
+    except BTPError as e:
+        if len(handles) < 2:
+            logging.error(
+                "gatts_notify_mult failed due to insufficient handles. The database contains %d"
+                " characteristic(s) with notify properties, but at least 2 are required. BTPError: %s", len(handles), e
+            )
+            return False
+
+        logging.error("BTPError occured but is safe to ignore with valid setup")
 
     return True
 


### PR DESCRIPTION
Per Bluetooth Core Specification 6.3 (Vol 3, Part F, Section 3.4.7.4), the ATT_MULTIPLE_HANDLE_VALUE_NTF PDU requires the Handle Length Value Tuple List to be 8 to (ATT_MTU - 1) octets. The server shall not truncate a Handle Length Value Tuple.

The amount of characteristics with notify properties is different for every IUT. If we pass too many handles to `gatts_notify_mult`, the resulting PDU will likely exceed the available ATT_MTU. Since we cannot truncate the final tuple, the implementation is forced to either omit tuples or reject the request entirely. The latter causes severe test failures.

Since we need only two handles to properly issue ATT_MULTIPLE_HANDLE_VALUE_NTF, we can limit the handle list to a
maximum of 2 elements.