### PR TITLE
gatt: fix timeout when running GATT/SR/GAN/BV-02-C

### DIFF
--- a/autopts/ptsprojects/mynewt/gatt.py
+++ b/autopts/ptsprojects/mynewt/gatt.py
@@ -221,6 +221,7 @@ def test_cases_server(ptses):
     pre_conditions_lt2 = [
                         TestFunc(lambda: pts2.update_pixit_param(
                                 "GATT", "TSPX_bd_addr_iut", iut_addr.get(timeout=90, clear=True))),
+                        TestFunc(btp.set_lt2_addr, pts2.q_bd_addr, Addr.le_public),
     ]
 
     test_cases_lt2 = [

--- a/autopts/ptsprojects/zephyr/gatt.py
+++ b/autopts/ptsprojects/zephyr/gatt.py
@@ -347,6 +347,7 @@ def test_cases_server(ptses):
     pre_conditions_lt2 = [
                         TestFunc(lambda: pts2.update_pixit_param(
                                 "GATT", "TSPX_bd_addr_iut", iut_addr.get(timeout=90, clear=True))),
+                        TestFunc(btp.set_lt2_addr, pts2.q_bd_addr, Addr.le_public),
     ]
 
     test_cases_lt2 = [

--- a/autopts/wid/gatt.py
+++ b/autopts/wid/gatt.py
@@ -100,14 +100,16 @@ COMPARED_VALUE = []
 def hdl_wid_1(params: WIDParams):
     if 'LT2' in params.test_case_name:
         addr = btp.lt2_addr_get()
+        conn_count = 2
     else:
         addr = btp.pts_addr_get()
+        conn_count = 1
 
     stack = get_stack()
     btp.gap_set_connectable()
     btp.gap_set_general_discoverable()
     btp.gap_start_advertising(ad=stack.gap.ad)
-    stack.gap.wait_for_connection(timeout=10, addr=addr)
+    stack.gap.wait_for_connection(timeout=10, conn_count=conn_count, addr=addr)
     return True
 
 


### PR DESCRIPTION
Timeout has occured in hdl_wid_1 when waiting for connection. Fix this by setting LT2 address in GATT preconditions and adjust conn_count parameter accordingly. This will save 10s in a single test case run.