### PR TITLE
l2cap: add WID 278 handler for repeated connection requests

### DIFF
--- a/autopts/ptsprojects/stack/layers/l2cap.py
+++ b/autopts/ptsprojects/stack/layers/l2cap.py
@@ -110,6 +110,8 @@ class L2cap:
         self.channels = []
         self.hold_credits = 0
         self.num_channels = 2
+        # Channel IDs that received a disconnect event before connect() was called.
+        self._early_disconnected = set()
 
     def chan_lookup_id(self, chan_id):
         """ lookup L2CAP channel with specified channel ID"""
@@ -151,6 +153,13 @@ class L2cap:
             if chan:
                 raise Exception(f'Channel already exists {chan}')
 
+            if chan_id in self._early_disconnected:
+                # A disconnect event arrived before connect() was called.
+                # Do not register the channel; wait_for_disconnection() will
+                # return True immediately because chan_lookup_id() returns None.
+                self._early_disconnected.discard(chan_id)
+                continue
+
             chan = L2capChan(chan_id, 0, 0, 0, 0, 0, None, None)
             self.channels.append(chan)
 
@@ -164,6 +173,10 @@ class L2cap:
                              bd_addr_type, bd_addr)
             self.channels.append(chan)
 
+        if chan_id in self._early_disconnected:
+            # Clear chan_id from early disconnected set if it exists
+            self._early_disconnected.discard(chan_id)
+
         if chan.is_connected():
             logging.error(f'Channel already connected {chan}')
             return
@@ -175,8 +188,15 @@ class L2cap:
         """ Called when specified channel is disconnected """
         chan = self.chan_lookup_id(chan_id)
         if chan is None:
-            logging.error("unknown channel")
+            # Channel not registered yet - record the early disconnect so that
+            # connect() can skip it and wait_for_disconnection() returns True.
+            logging.warning(f'Disconnect event for unregistered channel {chan_id}')
+            self._early_disconnected.add(chan_id)
             return
+
+        if chan_id in self._early_disconnected:
+            # Clear chan_id from early disconnected set if it exists
+            self._early_disconnected.discard(chan_id)
 
         if not chan.is_connected() and not chan.is_connecting():
             logging.error(f'Channel already disconnected {chan}')

--- a/autopts/wid/l2cap.py
+++ b/autopts/wid/l2cap.py
@@ -1201,3 +1201,20 @@ def hdl_wid_265(params: WIDParams):
         for cid in channel_ids:
             _safe_l2cap_disconnect(cid)
     return True
+
+
+def hdl_wid_278(_: WIDParams):
+    '''
+    Please send the L2CAP Connection Request 253 times.
+    '''
+    l2cap = get_stack().l2cap
+
+    for _i in range(253):
+        chans = btp.l2cap_conn(None, defs.BTP_BR_ADDRESS_TYPE, br_psm, br_initial_mtu)
+        l2cap.connect(chans)
+
+        # specification allows for maximum of 60 seconds timeout
+        if not l2cap.wait_for_disconnection(chans[0], 65):
+            return False
+
+    return True


### PR DESCRIPTION
* l2cap: handle early disconnect events before channel registration

Track disconnect events that arrive before connect() is called by maintaining a set of early disconnected channel IDs.

When a disconnect event arrives for an unregistered channel, store the channel ID in `_early_disconnected` set. During connect(), check if the channel ID is in this set and skip registration if found, allowing wait_for_disconnection() to return True immediately since chan_lookup_id() will return None.

This fixes race conditions where disconnect events arrive before the corresponding channel is registered, preventing errors and ensuring proper synchronization in L2CAP connection handling.

* l2cap: add WID 278 handler for repeated connection requests

Implement handler for WID 278 which sends 253 L2CAP Connection Requests sequentially. Each connection is established and then waits for disconnection with a 65-second timeout (allowing for the specification's maximum 60-second timeout).

The handler connects using BR/EDR address type with configured PSM and initial MTU values, returning False if any disconnection timeout occurs.
