### PR TITLE
gap: add WID 249 handler for dedicated bonding procedure

### DIFF
--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -2915,3 +2915,13 @@ def hdl_wid_357(_: WIDParams):
         return False
 
     return True
+
+
+def hdl_wid_249(_: WIDParams):
+    '''
+    Please initiate the bonding procedure in bondable mode with Dedicated Bonding specified in the
+    Authentication_Requirements.
+    '''
+    btp.gap_set_bondable_on()
+    btp.gap_pair_v2(bd_addr_type=defs.BTP_BR_ADDRESS_TYPE, level=defs.BTP_GAP_CMD_PAIR_V2_LEVEL_2)
+    return True


### PR DESCRIPTION
Implement handler for WID 249 which initiates bonding procedure in bondable mode with Dedicated Bonding specified in the Authentication Requirements.

The handler enables bondable mode and starts the bonding procedure using a BR/EDR address with pairing level 2, fulfilling the test case requirement for Dedicated Bonding in bondable mode.
