### PR TITLE
btp: gap: add min_level parameter to gap_wait_for_sec_lvl_change

### DIFF
--- a/autopts/ptsprojects/stack/layers/gap.py
+++ b/autopts/ptsprojects/stack/layers/gap.py
@@ -489,7 +489,7 @@ class Gap:
     def set_connection_sec_level(self, addr, level):
         self.connections[addr].sec_level = level
 
-    def gap_wait_for_sec_lvl_change(self, level, timeout=5, addr=None):
+    def gap_wait_for_sec_lvl_change(self, level=None, min_level=None, timeout=5, addr=None):
         if not self.is_connected(addr=addr):
             raise Exception("Not connected")
 
@@ -498,8 +498,16 @@ class Gap:
         else:
             addr, conn = list(self.connections.items())[0]
 
-        if conn.sec_level != level:
-            wait_for_event(timeout, lambda: conn.sec_level == level)
+        def is_met():
+            # min_level takes precedence if provided
+            if min_level is not None:
+                return conn.sec_level >= min_level
+            if level is not None:
+                return conn.sec_level == level
+            raise ValueError("Must specify either 'level' or 'min_level'")
+
+        if not is_met():
+            wait_for_event(timeout, is_met)
 
         return conn.sec_level
 

--- a/autopts/wid/gatt.py
+++ b/autopts/wid/gatt.py
@@ -2062,7 +2062,7 @@ def hdl_wid_400(params: WIDParams):
         addr = btp.pts_addr_get()
 
     stack = get_stack()
-    gap_ev = stack.gap.gap_wait_for_sec_lvl_change(level=2, timeout=30, addr=addr)
+    gap_ev = stack.gap.gap_wait_for_sec_lvl_change(min_level=1, timeout=30, addr=addr)
     if gap_ev is None:
         return False
 


### PR DESCRIPTION
Allow waiting for a minimum security level in
gap_wait_for_sec_lvl_change_ev rather than strictly requiring an exact level match.

Receiving an event with lower security level than required resulted in event timeout and extended test case execution time by 30 sec.

An established connection may have a lower security level than the waiter specified by default but is still sufficient to successfully copmlete the test case. This is applicable to most GATT/SR test cases.

Maintains  backward compatibility for all existing callers expecting exact level matching.