### PR TITLE
doc: Add bearer selection and identifier tracking to GATT client BTP

### DIFF
--- a/doc/btp_gatt_client.txt
+++ b/doc/btp_gatt_client.txt
@@ -38,12 +38,21 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
-                Response parameters:    <none>
+                                        Bearers (1 octet)
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used by a client to discover all primary
                 services on a server.
                 Services found during discovery are returned in the
                 Discover All Primary Services Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -52,14 +61,23 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         UUID_Length (1 octet)
                                         UUID (2 or 16 octets)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used by a client to discover primary services
                 with specific UUID on a server.
                 Services found during discovery are returned in the Discover
                 Primary Service by UUID Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -68,28 +86,48 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Service_Start_Handle (2 octets)
                                         Service_End_Handle (2 octets)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used by a client to discover service
                 relationships to other services.
-                Services found during discovery are returned in the rFind
+                Services found during discovery are returned in the Find
                 Included Services Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
+
+                In case of an error, the error response will be returned.
 
         Opcode 0x06 - Discover All Characteristics of a Service
 
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Service_Start_Handle (2 octets)
                                         Service_End_Handle (2 octets)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used by a client to discover all
                 characteristics within specified service range.
                 Characteristics found during discovery are returned in the
                 Discover All Characteristics of a Service Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -98,16 +136,25 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Start_Handle (2 octets)
                                         End_Handle (2 octets)
                                         UUID_Length (1 octet)
                                         UUID (2 or 16 octets)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used by a client to discover characteristic
                 declarations with given UUID on a server.
                 Characteristics found during discovery are returned in the
                 Discover Characteristics by UUID Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -116,14 +163,23 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Start_Handle (2 octets)
                                         End_Handle (2 octets)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used by a client to discover all the
                 characteristic descriptors contained within characteristic.
                 Descriptors found during discovery are returned in the
                 Discover All Characteristic Descriptors Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -132,13 +188,22 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Handle (2 octets)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used to read a Characteristic Value or
                 Characteristic Descriptor from a server.
                 Read results are returned in the Read Characteristic
                 Value/Descriptor Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -147,11 +212,12 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Start_Handle (2 octets)
                                         End_Handle (2 octets)
                                         UUID_Length (1 octet)
                                         UUID (2 or 16 octets)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 Valid UUID_Length parameter values:
                         0x02 = UUID16
@@ -162,6 +228,14 @@ Commands and responses:
                 Read results are returned in the Read Using Characteristic UUID
                 Resonse event.
 
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
+
                 In case of an error, the error response will be returned.
 
         Opcode 0x0b - Read Long Characteristic Value/Descriptor
@@ -169,14 +243,23 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Handle (2 octets)
                                         Offset (2 octets)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used to read Long Characteristic Value or
                 Long Characteristic Descriptor from a server.
                 Read results are returned in the Read Long Characteristic
                 Value/Descriptor Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -185,14 +268,23 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Handles_Count (1 octet)
                                         Handles (variable)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used to read multiple Characteristic Values
                 from a server.
                 Read results are returned in the Read Multiple Characteristic
                 Values Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -201,6 +293,7 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Handle (2 octets)
                                         Data_Length (2 octets)
                                         Data (variable)
@@ -210,6 +303,10 @@ Commands and responses:
                 server. There is no acknowledgment that the write was
                 successfully performed.
 
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
                 In case of an error, the error response will be returned.
 
         Opcode 0x0e - Signed Write Without Response
@@ -217,16 +314,25 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Handle (2 octets)
                                         Data_Length (2 octets)
                                         Data (variable)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used to write a Characteristic Value to a
                 server. There is no acknowledgment that the write was
                 successfully performed. This procedure is intended to be used
                 if client and server are bonded, and connected using
                 non-encrypted link.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -235,15 +341,24 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Handle (2 octets)
                                         Data_Length (2 octets)
                                         Data (variable)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used to write a Characteristic Value or
                 Characteristic Descriptor to a server.
                 Write status is returned in Write Characteristic
                 Value/Descriptor Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -252,16 +367,25 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Handle (2 octets)
                                         Offset (2 octets)
                                         Data_Length (2 octets)
                                         Data (variable)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used to write a Long Characteristic Value or
                 Long Characteristic Descriptor to a server.
                 Write status is returned in Write Long Characteristic
                 Value/Descriptor Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -270,16 +394,25 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Handle (2 octets)
                                         Offset (2 octets)
                                         Data_Length (2 octets)
                                         Data (variable)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used to write a Characteristic Value to
                 a server and assurance is required that the correct
                 Characteristic Value is going to be written.
                 Write status is returned in the Reliable Write Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -288,13 +421,22 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Enable (1 octet)
                                         CCC_Handle (2 octets)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used to configure server to notify
                 characteristic value to a client. Configuration status is
                 returned in Configure Notifications Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -303,13 +445,22 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Enable (1 octet)
                                         CCC_Handle (2 octets)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used to configure server to indicate
                 characteristic value to a client. Configuration status is
                 returned in Configure Indications Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -318,14 +469,23 @@ Commands and responses:
                 Controller Index:       <controller id>
                 Command parameters:     Address_Type (1 octet)
                                         Address (6 octets)
+                                        Bearers (1 octet)
                                         Handles_Count (1 octet)
                                         Handles (variable)
-                Response parameters:    <none>
+                Response parameters:    Identifier (4 octets)
 
                 This procedure is used to read multiple variable Characteristic
                 Values from a server. Handles Count shall be > 1.
                 Read results are returned in the Read Multiple Variable
                 Characteristic Values Response event.
+
+                Available Bearers:
+                bit 0 - ATT bearer
+                bit 1 - EATT bearer
+
+                The returned Identifier represents the specific BTP command. When the current BTP
+                command completes, the corresponding event will include this Identifier to indicate
+                which BTP command the event relates to.
 
                 In case of an error, the error response will be returned.
 
@@ -345,6 +505,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
                                         Services_Count (1 octet)
                                         [array] Service (variable)
@@ -366,6 +527,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
                                         Services_Count (1 octet)
                                         [array] Service (variable)
@@ -386,6 +548,7 @@ Events:
 
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
                                         Services_Count (1 octet)
                                         [array] Included_Service (variable)
@@ -416,6 +579,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
                                         Characteristics_Count (1 octet)
                                         [array] Characteristic (variable)
@@ -438,6 +602,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
                                         Characteristics_Count (1 octet)
                                         [array] Characteristic (variable)
@@ -460,6 +625,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
                                         Descriptors_Count (1 octet)
                                         [array] Descriptor (variable)
@@ -480,6 +646,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
                                         Data_Length (2 octets)
                                         Data (variable)
@@ -491,6 +658,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
                                         Data_Length (2 octets)
                                         Value_Len (1 octet)
@@ -507,6 +675,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
                                         Data_Length (2 octets)
                                         Data (variable)
@@ -518,6 +687,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
                                         Data_Length (2 octets)
                                         Data (variable)
@@ -529,6 +699,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
 
         Opcode 0x8c - Write Long Characteristic Value/Descriptor Response
@@ -536,6 +707,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
 
         Opcode 0x8d - Reliable Write Response
@@ -543,6 +715,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
 
         Opcode 0x8e - Configure Notifications Response
@@ -550,6 +723,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
 
         Opcode 0x8f - Configure Indications Response
@@ -557,6 +731,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
 
         Opcode 0x90 - Notification/Indication Received
@@ -564,6 +739,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Type (1 octet)
                                         Handle (2 octets)
                                         Data_Length (2 octets)
@@ -581,6 +757,7 @@ Events:
                 Controller Index:       <controller id>
                 Event parameters:       Address_Type (1 octet)
                                         Address (6 octets)
+                                        Identifier (4 octets)
                                         Status (1 octet)
                                         Data_Length (2 octets)
                                         Data (variable)


### PR DESCRIPTION
Update BTP GATT client documentation to support EATT bearer selection and command identifier tracking across all GATT client operations.

Add Bearers parameter (1 octet) to command parameters for all GATT client operations (opcodes 0x03-0x0c and 0x0e-0x14), allowing selection between ATT bearer (bit 0) and EATT bearer (bit 1).

Add Identifier (4 octets) to response parameters for all commands and corresponding events. The identifier links BTP commands to their completion events, enabling proper command-response correlation.

All corresponding response events (0x81-0x91) now include the Identifier parameter to match the initiating command.