### PR TITLE
zephyr: Fix HAS/SR/CP/BV-01-C regression after update to PTS 8.14

### DIFF
--- a/autopts/ptsprojects/zephyr/has.py
+++ b/autopts/ptsprojects/zephyr/has.py
@@ -65,6 +65,7 @@ def set_pixits(ptses):
     pts.set_pixit("HAS", "TSPX_security_enabled", "TRUE")
     pts.set_pixit("HAS", "TSPX_iut_ATT_transport", "ATT Bearer on LE Transport")
     pts.set_pixit("HAS", "TSPX_Connection_Interval", "120")
+    pts.set_pixit("HAS", "TSPX_largest_preset_index", str(max_index))
     pts.set_pixit("HAS", "TSPX_num_presets", str(num_presets))
     pts.set_pixit("HAS", "TSPX_available_preset_index", available_presets_str)
     pts.set_pixit("HAS", "TSPX_unavailable_preset_index", unavailable_presets_str)


### PR DESCRIPTION
TSPX_largest_preset_index IXIT was removed in HAP only and is stil present in HAS.