### PR TITLE
mynewt: errata: Update test case list

### DIFF
--- a/errata/mynewt.yaml
+++ b/errata/mynewt.yaml
@@ -2,9 +2,6 @@
 # GAP/CONN/NCON/BV-01-C: CASE00xxxxx
 # GAP/CONN/NCON/BV-02-C: CASE00xxxxx
 
-L2CAP/ECFC/BI-02-C: Request ID 103343
-L2CAP/COS/ECFC/BV-01-C: Request ID 145333
-GATT/SR/GAN/BV-03-C: Request ID 172623
 GAP/BROB/BCST/BV-04-C: https://github.com/apache/mynewt-nimble/issues/1029
 GATT/CL/GAR/BV-11-C: https://github.com/apache/mynewt-nimble/issues/2002
 GATT/SR/GAW/BV-12-C: https://github.com/apache/mynewt-nimble/issues/2002
@@ -13,3 +10,4 @@ GATT/SR/GAW/BV-14-C: https://github.com/apache/mynewt-nimble/issues/2002
 GATT/SR/GAR/BV-12-C: https://github.com/apache/mynewt-nimble/issues/2002
 GATT/SR/GAS/BV-04-C: https://github.com/apache/mynewt-nimble/issues/2262
 GATT/SR/GAW/BI-11-C: https://github.com/apache/mynewt-nimble/issues/2261
+GAP/SEC/SEM/BV-45-C: Request ID 190525


### PR DESCRIPTION
Remove GATT/SR/GAN/BV-03-C, L2CAP/ECFC/BI-02-C and L2CAP/COS/ECFC/BV-01-C from errata list.

Add GAP/SEC/SEM/BV-45-C to errata list. Brief description of the issue:

Expected behavior (Alternative 6A)
A negative response to MMI_267 should trigger alternative branch 6A.1 i.e. the IUT sends an event to the Upper Tester indicating that the connection procedure initiated in Step 2 failed, successfully ending the test case.

Actual Behavior (Alternative 6B):
PTS issues MMI_208, triggering alternative sequence 6B i.e. re-pair attempt