### PR TITLE
TMAP: add security fallback pairing in WID 20100

### DIFF
--- a/autopts/wid/tmap.py
+++ b/autopts/wid/tmap.py
@@ -827,7 +827,15 @@ def hdl_wid_20100(params: WIDParams):
 
     stack = get_stack()
     btp.gap_connect(addr, addr_type)
-    stack.gap.wait_for_connection(timeout=5, addr=addr)
+    stack.gap.wait_for_connection(timeout=10, addr=addr)
+    sec_lvl = stack.gap.gap_wait_for_sec_lvl_change(min_level=2, addr=addr)
+
+    # Workaround for issue described by PTS Request ID 190838
+    if sec_lvl < 2:
+        btp.gap_pair(addr, addr_type)
+        sec_lvl = stack.gap.gap_wait_for_sec_lvl_change(min_level=2, addr=addr)
+        if sec_lvl < 2:
+            return False
 
     # race condition: connect will cause pairing, which might trigger numeric comparison, but
     # PTS will show WID2004 to let us confirm, which we cannot if we're still in this function


### PR DESCRIPTION
Wait for security level 2 after connect in WID 20100.
If not reached, force paring and wait again.

The following conformance tests now pass:
TMAP/UMS/VRC/BV-02-C

Testing
nRF5340 Audio DK
nRF54L15 DK