### PR TITLE
mynewt: gatt: set pixit values for pts 2

### DIFF
--- a/autopts/ptsprojects/mynewt/gatt.py
+++ b/autopts/ptsprojects/mynewt/gatt.py
@@ -132,6 +132,27 @@ def set_pixits(ptses):
     pts.set_pixit("GATT", "TSPX_tester_appearance", "0000")
     pts.set_pixit("GATT", "TSPX_bearer_for_le", "EATT")
 
+    if len(ptses) < 2:
+        return
+
+    pts2 = ptses[1]
+
+    pts2.set_pixit("GATT", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
+    pts2.set_pixit("GATT", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
+    pts2.set_pixit("GATT", "TSPX_security_enabled", "FALSE")
+    pts2.set_pixit("GATT", "TSPX_delete_link_key", "TRUE")
+    pts2.set_pixit("GATT", "TSPX_time_guard", "180000")
+    pts2.set_pixit("GATT", "TSPX_use_implicit_send", "TRUE")
+    pts2.set_pixit("GATT", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
+    pts2.set_pixit("GATT", "TSPX_iut_is_client_periphral", "FALSE")
+    pts2.set_pixit("GATT", "TSPX_iut_is_server_central", "FALSE")
+    pts2.set_pixit("GATT", "TSPX_mtu_size", "23")
+    pts2.set_pixit("GATT", "TSPX_pin_code", "0000")
+    pts2.set_pixit("GATT", "TSPX_use_dynamic_pin", "FALSE")
+    pts2.set_pixit("GATT", "TSPX_delete_ltk", "TRUE")
+    pts2.set_pixit("GATT", "TSPX_tester_appearance", "0000")
+    pts2.set_pixit("GATT", "TSPX_bearer_for_le", "EATT")
+
 
 def test_cases_server(ptses):
     """Returns a list of GATT Server test cases"""


### PR DESCRIPTION
Set Pixit Values for PTS2 instance. This is needed when running tests with two lower testers.
e.g. when investigating failing GATT/SR/GAN/BV-02-C test case, on second iteration of test HCI Encryption Change with PIN Or Key Missing status have occured because TSPX_delete_ltk pixit was not set for Lower Tester 2